### PR TITLE
Extra constant fix

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -313,15 +313,12 @@ class RetrofitGenerator extends GeneratorForAnnotation<http.RestApi> {
       blocks.add(literalMap(
         c.peek('data')?.mapValue?.map((k, v) {
               return MapEntry(
-                k.toBoolValue() ??
-                    k.toDoubleValue() ??
-                    k.toIntValue() ??
-                    k.toStringValue() ??
-                    k.toListValue() ??
-                    k.toMapValue() ??
-                    k.toSetValue() ??
-                    k.toSymbolValue() ??
-                    k.toTypeValue(),
+                k.toStringValue() ??
+                    (throw InvalidGenerationSourceError(
+                      'Invalid key for extra Map, only `String` keys are supported',
+                      element: m,
+                      todo: 'Make sure all keys are of string type',
+                    )),
                 v.toBoolValue() ??
                     v.toDoubleValue() ??
                     v.toIntValue() ??
@@ -351,7 +348,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<http.RestApi> {
 Builder generatorFactoryBuilder({String header}) =>
     new SharedPartBuilder([new RetrofitGenerator()], "retrofit");
 
-// TODO(devkabiir): move this to a new package source_gen_utls
 /// Returns `$revived($args $kwargs)`, this won't have ending semi-colon (`;`).
 /// [object] must not be null.
 /// [object] is assumed to be a constant.

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -333,8 +333,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<http.RestApi> {
               );
             }) ??
             {},
-        refer('String'),
-        refer('dynamic'),
+        refer('Object'),
+        refer('Object'),
       ).assignConst(localExtraVar).statement);
     } else {
       blocks.add(literalMap(

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -335,8 +335,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<http.RestApi> {
               );
             }) ??
             {},
-        refer('Object'),
-        refer('Object'),
+        refer('String'),
+        refer('dynamic'),
       ).assignConst(localExtraVar).statement);
     } else {
       blocks.add(literalMap(

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1,5 +1,6 @@
 import 'package:source_gen_test/annotations.dart';
 import 'package:retrofit/http.dart';
+import 'package:retrofit/dio.dart' as dio;
 
 @ShouldGenerate(
   r'''
@@ -29,3 +30,46 @@ class _BaseUrl implements BaseUrl {
 )
 @RestApi(baseUrl: "http://httpbin.org/")
 abstract class BaseUrl {}
+
+@ShouldGenerate(
+  r'''
+    const _extra = <String, dynamic>{};
+''',
+  contains: true,
+)
+@RestApi()
+abstract class EmptyExtras {
+  @GET('/list/')
+  @dio.Extra({})
+  Future<void> list();
+}
+
+@ShouldGenerate(
+  r'''
+    const _extra = <String, dynamic>{'key': 'value'};
+''',
+  contains: true,
+)
+@RestApi()
+abstract class ExtrasWithPrimitiveValues {
+  @GET('/list/')
+  @dio.Extra({'key': 'value'})
+  Future<void> list();
+}
+
+@ShouldGenerate(
+  r'''
+    const _extra = <String, dynamic>{'key': CustomConstant()};
+''',
+  contains: true,
+)
+@RestApi()
+abstract class ExtrasWithCustomConstant {
+  @GET('/list/')
+  @dio.Extra({'key': CustomConstant()})
+  Future<void> list();
+}
+
+class CustomConstant {
+  const CustomConstant();
+}


### PR DESCRIPTION
This will fix the bug when
```dart
@GET('/list')
@dio.Extra({'my_key': CustomValue()}
Future<void> list();
```

Produces the `extra` variable with `null` values
```dart
const _extra = <String, dynamic>{'key':null};
```

This will fix it and produce correct output

```dart
const _extra = <String, dynamic>{'key': CustomValue()};
```

Also added test cases for this
