### PR TITLE
File form fields update

### DIFF
--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## 0.2.3
+
+* Added optional parameter `fileName` in `@Field` annotation for custom file name
+
 ## 0.2.2
 
 * add example

--- a/annotation/README.md
+++ b/annotation/README.md
@@ -67,23 +67,18 @@ abstract class RestClient {
       @Field() int field,
       @Field("field-g") String ffff});
 
-  /// Do not forget to add the appropriate headers
-  @Headers({'Content-Type': 'multipart/form-data'})
   @POST("/profile")
   Future<Response<String>> setProfile(
       @Field('image', 'my_profile_image.jpg') File image);
 
-  /// Do not forget to add the appropriate headers
-  @Headers({'Content-Type': 'multipart/form-data'})
-  @POST("/profile")
   /// This will add the image name from `image.path.split(Platform.pathSeperator).last`
+  @POST("/profile")
   Future<Response<String>> setProfileImage(@Field() File image);
 
-  /// Do not forget to add the appropriate headers
-  @Headers({'Content-Type': 'multipart/form-data'})
-  @POST("/profile")
   /// This will automatically work too.
-  Future<Response<String>> setProfileImageWithInfo(@Field() UploadFileInfo image);
+  @POST("/profile")
+  Future<Response<String>> setProfileImageWithInfo(
+      @Field() UploadFileInfo image);
 }
 ```
 

--- a/annotation/README.md
+++ b/annotation/README.md
@@ -68,19 +68,19 @@ abstract class RestClient {
       @Field("field-g") String ffff});
 
   /// Do not forget to add the appropriate headers
-  @Header('Content-Type: multipart/form-data')
+  @Headers({'Content-Type': 'multipart/form-data'})
   @POST("/profile")
   Future<Response<String>> setProfile(
       @Field('image', 'my_profile_image.jpg') File image);
 
   /// Do not forget to add the appropriate headers
-  @Header('Content-Type: multipart/form-data')
+  @Headers({'Content-Type': 'multipart/form-data'})
   @POST("/profile")
   /// This will add the image name from `image.path.split(Platform.pathSeperator).last`
   Future<Response<String>> setProfileImage(@Field() File image);
 
   /// Do not forget to add the appropriate headers
-  @Header('Content-Type: multipart/form-data')
+  @Headers({'Content-Type': 'multipart/form-data'})
   @POST("/profile")
   /// This will automatically work too.
   Future<Response<String>> setProfileImageWithInfo(@Field() UploadFileInfo image);

--- a/annotation/README.md
+++ b/annotation/README.md
@@ -66,6 +66,24 @@ abstract class RestClient {
       {@QueryMap() Map<String, dynamic> queryies,
       @Field() int field,
       @Field("field-g") String ffff});
+
+  /// Do not forget to add the appropriate headers
+  @Header('Content-Type: multipart/form-data')
+  @POST("/profile")
+  Future<Response<String>> setProfile(
+      @Field('image', 'my_profile_image.jpg') File image);
+
+  /// Do not forget to add the appropriate headers
+  @Header('Content-Type: multipart/form-data')
+  @POST("/profile")
+  /// This will add the image name from `image.path.split(Platform.pathSeperator).last`
+  Future<Response<String>> setProfileImage(@Field() File image);
+
+  /// Do not forget to add the appropriate headers
+  @Header('Content-Type: multipart/form-data')
+  @POST("/profile")
+  /// This will automatically work too.
+  Future<Response<String>> setProfileImageWithInfo(@Field() UploadFileInfo image);
 }
 ```
 
@@ -93,3 +111,7 @@ main(List<String> args) {
 }
 
 ```
+
+### *NOTE*
+
+> `retrofit.dart` will not automatically add `Content-Type` headers. Please use the `@Header` annotation for any required headers.

--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -123,7 +123,11 @@ class Body {
 @immutable
 class Field {
   final String value;
-  const Field([this.value]);
+
+  /// If this field is a file, optionally specify it's name. otherwise the name
+  /// will be derived from the actual file.
+  final String fileName;
+  const Field([this.value, this.fileName]);
 }
 
 /// Named replacement in a URL path segment.

--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -159,3 +159,15 @@ class Queries {
   final bool encoded;
   const Queries({this.encoded = false});
 }
+
+/// Denotes that the request body will use form URL encoding. Fields should be declared as
+/// parameters and annotated with [Field].
+///
+/// Requests made with this annotation will have `application/x-www-form-urlencoded` MIME
+/// type. Field names and values will be UTF-8 encoded before being URI-encoded in accordance to
+/// [RFC-3986](http://tools.ietf.org/html/rfc3986)
+@immutable
+class FormUrlEncoded {
+  final mime = 'application/x-www-form-urlencoded';
+  const FormUrlEncoded();
+}

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:retrofit/http.dart';
 import 'package:dio/dio.dart';
 
@@ -44,4 +46,25 @@ abstract class RestClient {
       {@Queries() Map<String, dynamic> queryies,
       @Field() int field,
       @Field("field-g") String ffff});
+
+  /// Do not forget to add the appropriate headers
+  @Headers({'Content-Type': 'multipart/form-data'})
+  @POST("/profile")
+  Future<Response<String>> setProfile(
+      @Field('image', 'my_profile_image.jpg') File image);
+
+  /// Do not forget to add the appropriate headers
+  @Headers({'Content-Type': 'multipart/form-data'})
+  @POST("/profile")
+
+  /// This will add the image name from `image.path.split(Platform.pathSeperator).last`
+  Future<Response<String>> setProfileImage(@Field() File image);
+
+  /// Do not forget to add the appropriate headers
+  @Headers({'Content-Type': 'multipart/form-data'})
+  @POST("/profile")
+
+  /// This will automatically work too.
+  Future<Response<String>> setProfileImageWithInfo(
+      @Field() UploadFileInfo image);
 }

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -47,24 +47,16 @@ abstract class RestClient {
       @Field() int field,
       @Field("field-g") String ffff});
 
-  /// Do not forget to add the appropriate headers
-  @Headers({'Content-Type': 'multipart/form-data'})
   @POST("/profile")
   Future<Response<String>> setProfile(
       @Field('image', 'my_profile_image.jpg') File image);
 
-  /// Do not forget to add the appropriate headers
-  @Headers({'Content-Type': 'multipart/form-data'})
-  @POST("/profile")
-
   /// This will add the image name from `image.path.split(Platform.pathSeperator).last`
+  @POST("/profile")
   Future<Response<String>> setProfileImage(@Field() File image);
 
-  /// Do not forget to add the appropriate headers
-  @Headers({'Content-Type': 'multipart/form-data'})
-  @POST("/profile")
-
   /// This will automatically work too.
+  @POST("/profile")
   Future<Response<String>> setProfileImageWithInfo(
       @Field() UploadFileInfo image);
 }

--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -97,10 +97,7 @@ class _RestClient implements RestClient {
         FormData.from({'image': UploadFileInfo(image, 'my_profile_image.jpg')});
     return _dio.request('/profile',
         queryParameters: queryParameters,
-        options: RequestOptions(
-            method: 'POST',
-            headers: {'Content-Type': 'multipart/form-data'},
-            extra: _extra),
+        options: RequestOptions(method: 'POST', headers: {}, extra: _extra),
         data: _data);
   }
 
@@ -115,10 +112,7 @@ class _RestClient implements RestClient {
     });
     return _dio.request('/profile',
         queryParameters: queryParameters,
-        options: RequestOptions(
-            method: 'POST',
-            headers: {'Content-Type': 'multipart/form-data'},
-            extra: _extra),
+        options: RequestOptions(method: 'POST', headers: {}, extra: _extra),
         data: _data);
   }
 
@@ -130,10 +124,7 @@ class _RestClient implements RestClient {
     final _data = FormData.from({'image': image});
     return _dio.request('/profile',
         queryParameters: queryParameters,
-        options: RequestOptions(
-            method: 'POST',
-            headers: {'Content-Type': 'multipart/form-data'},
-            extra: _extra),
+        options: RequestOptions(method: 'POST', headers: {}, extra: _extra),
         data: _data);
   }
 }

--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -87,4 +87,53 @@ class _RestClient implements RestClient {
         options: RequestOptions(method: 'PATCH', headers: {}, extra: _extra),
         data: _data);
   }
+
+  @override
+  setProfile(image) async {
+    ArgumentError.checkNotNull(image, 'image');
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _data =
+        FormData.from({'image': UploadFileInfo(image, 'my_profile_image.jpg')});
+    return _dio.request('/profile',
+        queryParameters: queryParameters,
+        options: RequestOptions(
+            method: 'POST',
+            headers: {'Content-Type': 'multipart/form-data'},
+            extra: _extra),
+        data: _data);
+  }
+
+  @override
+  setProfileImage(image) async {
+    ArgumentError.checkNotNull(image, 'image');
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _data = FormData.from({
+      'image':
+          UploadFileInfo(image, image.path.split(Platform.pathSeparator).last)
+    });
+    return _dio.request('/profile',
+        queryParameters: queryParameters,
+        options: RequestOptions(
+            method: 'POST',
+            headers: {'Content-Type': 'multipart/form-data'},
+            extra: _extra),
+        data: _data);
+  }
+
+  @override
+  setProfileImageWithInfo(image) async {
+    ArgumentError.checkNotNull(image, 'image');
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _data = FormData.from({'image': image});
+    return _dio.request('/profile',
+        queryParameters: queryParameters,
+        options: RequestOptions(
+            method: 'POST',
+            headers: {'Content-Type': 'multipart/form-data'},
+            extra: _extra),
+        data: _data);
+  }
 }

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## 0.2.3
+
+* Added support for `File` form fields. See example in `retrofit.dart` readme.
+
 ## 0.2.2
+
 * bump to 0.2.2
 
 ## 0.2.1
+
 * Fixed pub upload issue
 
 ## 0.2.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -17,8 +17,12 @@ dependencies:
   built_collection: ^4.2.0
   code_builder: ^3.2.0
   tuple: ^1.0.2
-  retrofit: ^0.2.2
 
 dev_dependencies:
   test:
   source_gen_test: any
+  retrofit: ^0.2.2
+
+dependency_overrides:
+  retrofit:
+    path: ../annotation

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -209,3 +209,36 @@ abstract class HttpPatchTest {
   @PATCH("/delete")
   Future<Response<String>> ip();
 }
+
+@ShouldGenerate(r'''
+class _FormUrlEncodedTest implements FormUrlEncodedTest {
+  _FormUrlEncodedTest(this._dio) {
+    ArgumentError.checkNotNull(_dio, '_dio');
+    _dio.options.baseUrl = 'https://httpbin.org/';
+  }
+
+  final Dio _dio;
+
+  @override
+  ip() async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    const _data = null;
+    return _dio.request('/get',
+        queryParameters: queryParameters,
+        options: RequestOptions(
+            method: 'POST',
+            headers: {},
+            extra: _extra,
+            contentType:
+                ContentType.parse('application/x-www-form-urlencoded')),
+        data: _data);
+  }
+}
+''')
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class FormUrlEncodedTest {
+  @POST("/get")
+  @FormUrlEncoded()
+  Future<Response<String>> ip();
+}

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -273,3 +273,15 @@ abstract class FileFieldWithCustomNameTest {
   Future<Response<String>> setProfile(
       @Field('image', 'my_profile_image.jpg') File image);
 }
+
+@ShouldGenerate(
+  r'''
+    final _data = FormData.from({'image': image});
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class UploadFileInfoFieldTest {
+  @POST("/profile")
+  Future<Response<String>> setProfile(@Field() UploadFileInfo image);
+}

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:source_gen_test/annotations.dart';
 import 'package:retrofit/http.dart';
 import 'package:retrofit/dio.dart' as dio;
@@ -241,4 +243,33 @@ abstract class FormUrlEncodedTest {
   @POST("/get")
   @FormUrlEncoded()
   Future<Response<String>> ip();
+}
+
+@ShouldGenerate(
+  r'''
+    final _data = FormData.from({
+      'image':
+          UploadFileInfo(image, image.path.split(Platform.pathSeparator).last)
+    });
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class FileFieldTest {
+  @POST("/profile")
+  Future<Response<String>> setProfile(@Field() File image);
+}
+
+@ShouldGenerate(
+  r'''
+    final _data =
+        FormData.from({'image': UploadFileInfo(image, 'my_profile_image.jpg')});
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class FileFieldWithCustomNameTest {
+  @POST("/profile")
+  Future<Response<String>> setProfile(
+      @Field('image', 'my_profile_image.jpg') File image);
 }


### PR DESCRIPTION
This will allow users to have `File` from fields, example:

```dart
  /// Do not forget to add the appropriate headers
  @Headers({'Content-Type': 'multipart/form-data'})
  @POST("/profile")

  /// This will add the image name from `image.path.split(Platform.pathSeperator).last`
  Future<Response<String>> setProfileImage(@Field() File image);
```