### PR TITLE
Fix inner type parsing

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -280,11 +280,11 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       final innerReturnType = _getResponseInnerType(returnType);
       if (_typeChecker(List).isExactlyType(returnType) ||
           _typeChecker(BuiltList).isExactlyType(returnType)) {
-        if (_isBasicType(returnType)) {
+        if (_isBasicType(innerReturnType)) {
           blocks.add(
             refer("await $_dioVar.request")
                 .call([path], namedArguments)
-                .assignFinal(_resultVar, refer("Response<List<$returnType>>"))
+                .assignFinal(_resultVar, refer("Response<List<$innerReturnType>>"))
                 .statement,
           );
           blocks.add(Code("final value = $_resultVar.data;"));
@@ -322,14 +322,14 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                     .map((i) => $type.fromJson(i as Map<String,dynamic>))
                     .toList()
                 )
-              );  
+              );
             """));
           } else if (!_isBasicType(secondType)) {
             blocks.add(Code("""
             var value = $_resultVar.data
               .map((k, dynamic v) =>
                 MapEntry(k, $secondType.fromJson(v as Map<String, dynamic>))
-              );  
+              );
             """));
           }
         } else {
@@ -365,6 +365,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return _typeChecker(String).isExactlyType(returnType) ||
         _typeChecker(bool).isExactlyType(returnType) ||
         _typeChecker(int).isExactlyType(returnType) ||
+        _typeChecker(double).isExactlyType(returnType) ||
         _typeChecker(Double).isExactlyType(returnType) ||
         _typeChecker(Float).isExactlyType(returnType);
   }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -266,3 +266,55 @@ abstract class TestMapBody2 {
   @GET("/xx")
   Future<Map<String, User>> getResult();
 }
+
+@ShouldGenerate(
+  r'''
+    final value = _result.data;
+    return Future.value(value);
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class TestBasicListString {
+  @GET("/xx")
+  Future<List<String>> getResult();
+}
+
+@ShouldGenerate(
+  r'''
+    final value = _result.data;
+    return Future.value(value);
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class TestBasicListBool {
+  @GET("/xx")
+  Future<List<bool>> getResult();
+}
+
+@ShouldGenerate(
+  r'''
+    final value = _result.data;
+    return Future.value(value);
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class TestBasicListInt {
+  @GET("/xx")
+  Future<List<int>> getResult();
+}
+
+@ShouldGenerate(
+  r'''
+    final value = _result.data;
+    return Future.value(value);
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class TestBasicListDouble {
+  @GET("/xx")
+  Future<List<double>> getResult();
+}


### PR DESCRIPTION
This PR should fix #44 and every situation where a service method contains basic types such as:
```dart

  @GET("...")
  Future<List<String>> getListOfString();

  @GET("...")
  Future<List<bool>> getListOfBool();

  @GET("...")
  Future<List<int>> getListOfInt();

  @GET("...")
  Future<List<double>> getListOfDouble();
```

Adding regression tests to verify those may be necessary too.

EDIT: Added regression tests.