### PR TITLE
fix: fix bad cast exception

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -284,10 +284,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           blocks.add(
             refer("await $_dioVar.request")
                 .call([path], namedArguments)
-                .assignFinal(_resultVar, refer("Response<List<$innerReturnType>>"))
+                .assignFinal(_resultVar, refer("Response<List<dynamic>>"))
                 .statement,
           );
-          blocks.add(Code("final value = $_resultVar.data;"));
+          blocks.add(Code("final value = $_resultVar.data.cast<$innerReturnType>();"));
         } else {
           blocks.add(
             refer("await $_dioVar.request")

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -269,7 +269,7 @@ abstract class TestMapBody2 {
 
 @ShouldGenerate(
   r'''
-    final value = _result.data;
+    final value = _result.data.cast<String>();
     return Future.value(value);
 ''',
   contains: true,
@@ -282,7 +282,7 @@ abstract class TestBasicListString {
 
 @ShouldGenerate(
   r'''
-    final value = _result.data;
+    final value = _result.data.cast<bool>();
     return Future.value(value);
 ''',
   contains: true,
@@ -295,7 +295,7 @@ abstract class TestBasicListBool {
 
 @ShouldGenerate(
   r'''
-    final value = _result.data;
+    final value = _result.data.cast<int>();
     return Future.value(value);
 ''',
   contains: true,
@@ -308,7 +308,7 @@ abstract class TestBasicListInt {
 
 @ShouldGenerate(
   r'''
-    final value = _result.data;
+    final value = _result.data.cast<double>();
     return Future.value(value);
 ''',
   contains: true,


### PR DESCRIPTION
The previous version failed with a `List<dynamic> is not a subtype of
List<$innerReturnType>` exception.
This PR fixes the runtime issues as well as updates the tests accordingly.