### PR TITLE
🐛fix (generator) Support intercepted custom object serializers

### DIFF
--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.6.3
+
+- Added `autoCastResponse` option to `RestApi` and all `Method` annotations (default : `true`)
+- Added `auto_cast_response` to builder options.
+  - Users can specify this in `build.yaml` as global default
+
+    ```yaml
+    targets:
+      $default:
+        sources: ['lib/**']
+        builders:
+          retrofit_generator|retrofit:
+            enabled: true
+            options:
+              auto_cast_response: true
+
+    ```
+
 ## 0.6.2
 
 - fix: fix bad cast exception (#47)

--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -45,7 +45,17 @@ class Method {
   /// See [RestApi.baseUrl] for details of how this is resolved against a base URL
   /// to create the full endpoint URL.
   final String path;
-  const Method(this.method, this.path);
+  const Method(
+    this.method,
+    this.path, {
+    this.autoCastResponse: false,
+  });
+
+  /// Automatically cast response to proper type
+  ///
+  /// This is experimental, Currently there's no perfect solution for this.
+  @experimental
+  final bool autoCastResponse;
 }
 
 /// Make a `GET` request
@@ -56,31 +66,36 @@ class Method {
 /// ```
 @immutable
 class GET extends Method {
-  const GET(String path) : super(HttpMethod.GET, path);
+  const GET(String path, {bool autoCastResponse})
+      : super(HttpMethod.GET, path, autoCastResponse: autoCastResponse);
 }
 
 /// Make a `POST` request
 @immutable
 class POST extends Method {
-  const POST(String path) : super(HttpMethod.POST, path);
+  const POST(String path, {bool autoCastResponse})
+      : super(HttpMethod.POST, path, autoCastResponse: autoCastResponse);
 }
 
 /// Make a `PATCH` request
 @immutable
 class PATCH extends Method {
-  const PATCH(final String path) : super(HttpMethod.PATCH, path);
+  const PATCH(final String path, {bool autoCastResponse})
+      : super(HttpMethod.PATCH, path, autoCastResponse: autoCastResponse);
 }
 
 /// Make a `PUT` request
 @immutable
 class PUT extends Method {
-  const PUT(final String path) : super(HttpMethod.PUT, path);
+  const PUT(final String path, {bool autoCastResponse})
+      : super(HttpMethod.PUT, path, autoCastResponse: autoCastResponse);
 }
 
 /// Make a `DELETE` request
 @immutable
 class DELETE extends Method {
-  const DELETE(final String path) : super(HttpMethod.DELETE, path);
+  const DELETE(final String path, {bool autoCastResponse})
+      : super(HttpMethod.DELETE, path, autoCastResponse: autoCastResponse);
 }
 
 /// Adds headers specified in the [value] map.

--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -32,7 +32,13 @@ class RestApi {
   /// Otherwise the `path` field of any [HttpMethod]  like [@POST()] should have the full URL.
 
   final String baseUrl;
-  const RestApi({this.baseUrl});
+  const RestApi({this.baseUrl, this.autoCastResponse = true});
+
+  /// Automatically cast response to proper type for all methods in this client
+  ///
+  /// This is experimental, Currently there's no perfect solution for this.
+  @experimental
+  final bool autoCastResponse;
 }
 
 @immutable
@@ -48,10 +54,10 @@ class Method {
   const Method(
     this.method,
     this.path, {
-    this.autoCastResponse: false,
+    this.autoCastResponse: true,
   });
 
-  /// Automatically cast response to proper type
+  /// Automatically cast response to proper type for this method only
   ///
   /// This is experimental, Currently there's no perfect solution for this.
   @experimental
@@ -66,35 +72,35 @@ class Method {
 /// ```
 @immutable
 class GET extends Method {
-  const GET(String path, {bool autoCastResponse})
+  const GET(String path, {bool autoCastResponse: true})
       : super(HttpMethod.GET, path, autoCastResponse: autoCastResponse);
 }
 
 /// Make a `POST` request
 @immutable
 class POST extends Method {
-  const POST(String path, {bool autoCastResponse})
+  const POST(String path, {bool autoCastResponse: true})
       : super(HttpMethod.POST, path, autoCastResponse: autoCastResponse);
 }
 
 /// Make a `PATCH` request
 @immutable
 class PATCH extends Method {
-  const PATCH(final String path, {bool autoCastResponse})
+  const PATCH(final String path, {bool autoCastResponse: true})
       : super(HttpMethod.PATCH, path, autoCastResponse: autoCastResponse);
 }
 
 /// Make a `PUT` request
 @immutable
 class PUT extends Method {
-  const PUT(final String path, {bool autoCastResponse})
+  const PUT(final String path, {bool autoCastResponse: true})
       : super(HttpMethod.PUT, path, autoCastResponse: autoCastResponse);
 }
 
 /// Make a `DELETE` request
 @immutable
 class DELETE extends Method {
-  const DELETE(final String path, {bool autoCastResponse})
+  const DELETE(final String path, {bool autoCastResponse: true})
       : super(HttpMethod.DELETE, path, autoCastResponse: autoCastResponse);
 }
 

--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -32,7 +32,7 @@ class RestApi {
   /// Otherwise the `path` field of any [HttpMethod]  like [@POST()] should have the full URL.
 
   final String baseUrl;
-  const RestApi({this.baseUrl, this.autoCastResponse = true});
+  const RestApi({this.baseUrl, this.autoCastResponse});
 
   /// Automatically cast response to proper type for all methods in this client
   ///

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: retrofit
-version: 0.6.2+1
+version: 0.6.3
 
 authors:
   - Trevor Wang <trevor.wang@qq.com>
@@ -9,7 +9,7 @@ homepage: https://github.com/trevorwang/retrofit.dart/
 description: retrofit.dart is an dio client generator using source_gen and inspired by Chopper and Retrofit.
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   meta: ^1.1.6

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -8,23 +8,23 @@ part 'example.g.dart';
 abstract class RestClient {
   factory RestClient(Dio dio) = _RestClient;
 
-  @GET("/tasks", autoCastResponse: true)
+  @GET("/tasks")
   Future<List<Task>> getTasks();
 
-  @GET("/tasks/{id}", autoCastResponse: true)
+  @GET("/tasks/{id}")
   Future<Task> getTask(@Path("id") String id);
 
-  @PATCH("/tasks/{id}", autoCastResponse: true)
+  @PATCH("/tasks/{id}")
   Future<Task> updateTaskPart(
       @Path() String id, @Body() Map<String, dynamic> map);
 
-  @PUT("/tasks/{id}", autoCastResponse: true)
+  @PUT("/tasks/{id}")
   Future<Task> updateTask(@Path() String id, @Body() Task task);
 
-  @DELETE("/tasks/{id}", autoCastResponse: true)
+  @DELETE("/tasks/{id}")
   Future<void> deleteTask(@Path() String id);
 
-  @POST("/tasks", autoCastResponse: true)
+  @POST("/tasks")
   Future<Task> createTask(@Body() Task task);
 }
 

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -8,23 +8,23 @@ part 'example.g.dart';
 abstract class RestClient {
   factory RestClient(Dio dio) = _RestClient;
 
-  @GET("/tasks")
+  @GET("/tasks", autoCastResponse: true)
   Future<List<Task>> getTasks();
 
-  @GET("/tasks/{id}")
+  @GET("/tasks/{id}", autoCastResponse: true)
   Future<Task> getTask(@Path("id") String id);
 
-  @PATCH("/tasks/{id}")
+  @PATCH("/tasks/{id}", autoCastResponse: true)
   Future<Task> updateTaskPart(
       @Path() String id, @Body() Map<String, dynamic> map);
 
-  @PUT("/tasks/{id}")
+  @PUT("/tasks/{id}", autoCastResponse: true)
   Future<Task> updateTask(@Path() String id, @Body() Task task);
 
-  @DELETE("/tasks/{id}")
+  @DELETE("/tasks/{id}", autoCastResponse: true)
   Future<void> deleteTask(@Path() String id);
 
-  @POST("/tasks")
+  @POST("/tasks", autoCastResponse: true)
   Future<Task> createTask(@Body() Task task);
 }
 

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.3
+
+- [BREAKING CHANGE] Requires `retrofit: ^0.6.3`
+- Respect user option `autoCastResponse` (this will skip `.fromJson`)
+- Allow custom classes without `.toJson` method (generator will throw warning)
+
 ## 0.6.2
 
 - fix: fix bad cast exception (#47)
@@ -49,7 +55,7 @@ Here's the example.
 
 ## 0.3.0
 
-Added support for generic serilization.
+Added support for generic serialization.
 
 > Please note:
 >

--- a/generator/lib/builder.dart
+++ b/generator/lib/builder.dart
@@ -2,4 +2,4 @@ import 'package:build/build.dart';
 import 'src/generator.dart';
 
 Builder retrofitBuilder(BuilderOptions options) =>
-    generatorFactoryBuilder(header: options.config["header"] as String);
+    generatorFactoryBuilder(options);

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -286,6 +286,18 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           refer(receiveProgress.item1.displayName);
 
     final returnType = _getResponseType(m.returnType);
+
+    /// If autoCastResponse is false, return the response as it is
+    if (!(httpMehod.peek('autoCastResponse')?.boolValue ?? false)) {
+      blocks.add(
+        refer("$_dioVar.request")
+            .call([path], namedArguments)
+            .returned
+            .statement,
+      );
+      return Block.of(blocks);
+    }
+
     if (returnType == null || "void" == returnType.toString()) {
       blocks.add(
         refer("await $_dioVar.request")
@@ -426,9 +438,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         final toJson = ele.methods
             .firstWhere((i) => i.displayName == "toJson", orElse: () => null);
         if (toJson == null) {
-          log.severe(
+          log.warning(
               "${_bodyName.type} must provide a `toJson()` method which return a Map.");
-          log.severe(
+          log.warning(
               "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
           blocks.add(
               refer(_bodyName.displayName).assignFinal(_dataVar).statement);

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -21,7 +21,7 @@ class RetrofitOptions {
 
   RetrofitOptions.fromOptions([BuilderOptions options])
       : autoCastResponse =
-            (options?.config['auto_cast_response']?.toString() ?? 'false') ==
+            (options?.config['auto_cast_response']?.toString() ?? 'true') ==
                 'true';
 }
 
@@ -310,8 +310,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final returnType = _getResponseType(m.returnType);
 
-    final autoCastResponse = ((globalOptions.autoCastResponse ?? false) ||
-        (clientAnnotation.autoCastResponse ?? false) ||
+    final autoCastResponse = (globalOptions.autoCastResponse ??
+        (clientAnnotation.autoCastResponse ?? true) ??
         (httpMehod.peek('autoCastResponse')?.boolValue ?? true));
 
     /// If autoCastResponse is false, return the response as it is

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -236,6 +236,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     for (var parameter in m.parameters.where((p) =>
         p.isRequiredNamed ||
         p.isRequiredPositional ||
+        // TODO: remove this after requried syntax is available https://github.com/dart-lang/language/issues/15
+        // ignore: deprecated_member_use
+        p.isRequired ||
         p.metadata.firstWhere((meta) => meta.isRequired, orElse: () => null) !=
             null)) {
       blocks.add(Code(

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -439,8 +439,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             .firstWhere((i) => i.displayName == "toJson", orElse: () => null);
         if (toJson == null) {
           log.warning(
-              "${_bodyName.type} must provide a `toJson()` method which return a Map.");
-          log.warning(
+              "${_bodyName.type} must provide a `toJson()` method which return a Map.\n"
               "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
           blocks.add(
               refer(_bodyName.displayName).assignFinal(_dataVar).statement);

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -21,7 +21,7 @@ class RetrofitOptions {
 
   RetrofitOptions.fromOptions([BuilderOptions options])
       : autoCastResponse =
-            (options?.config['auto_cast_response']?.toString() ?? 'true') ==
+            (options?.config['auto_cast_response']?.toString() ?? 'false') ==
                 'true';
 }
 

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -67,8 +67,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     final className = element.name;
     final name = '_$className';
     clientAnnotation = retrofit.RestApi(
-      autoCastResponse:
-          (annotation?.peek('autoCastResponse')?.boolValue ?? true),
+      autoCastResponse: (annotation?.peek('autoCastResponse')?.boolValue),
       baseUrl: (annotation?.peek(_baseUrlVar)?.stringValue ?? ''),
     );
     final baseUrl = clientAnnotation.baseUrl;
@@ -311,10 +310,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final returnType = _getResponseType(m.returnType);
 
-    final autoCastResponse =
-        (httpMehod.peek('autoCastResponse')?.boolValue ?? true) ||
-            clientAnnotation.autoCastResponse ||
-            globalOptions.autoCastResponse;
+    final autoCastResponse = ((globalOptions.autoCastResponse ?? false) ||
+        (clientAnnotation.autoCastResponse ?? false) ||
+        (httpMehod.peek('autoCastResponse')?.boolValue ?? true));
 
     /// If autoCastResponse is false, return the response as it is
     if (!autoCastResponse) {

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: retrofit_generator
 description: retrofit generator is an dio client generator using source_gen and inspired by Chopper and Retrofit.
-version: 0.6.2+1
+version: 0.6.3
 
 authors:
   - Trevor Wang <trevor.wang@qq.com>
@@ -9,7 +9,7 @@ authors:
 homepage: https://github.com/trevorwang/retrofit.dart/
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   dio: ^2.1.0
@@ -17,11 +17,10 @@ dependencies:
   built_collection: ^4.2.0
   code_builder: ^3.2.0
   tuple: ^1.0.2
-  retrofit: ^0.6.0
+  retrofit: ^0.6.3
 dev_dependencies:
   test:
   source_gen_test: any
-  retrofit: ^0.6.0
 
 dependency_overrides:
   retrofit:

--- a/generator/test/generator_test.dart
+++ b/generator/test/generator_test.dart
@@ -10,5 +10,6 @@ Future<void> main() async {
   final reader = await initializeLibraryReaderForDirectory(
       'test/src', 'generator_test_src.dart');
   initializeBuildLogTracking();
-  testAnnotatedElements<http.RestApi>(reader, RetrofitGenerator());
+  testAnnotatedElements<http.RestApi>(
+      reader, RetrofitGenerator(RetrofitOptions()));
 }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -248,8 +248,8 @@ class CustomObject {
 ''',
     contains: true,
     expectedLogItems: [
-      "CustomObject must provide a `toJson()` method which return a Map.",
-      "It is programmer's responsibility to make sure the CustomObject is properly serialized",
+      "CustomObject must provide a `toJson()` method which return a Map.\n"
+          "It is programmer's responsibility to make sure the CustomObject is properly serialized",
     ])
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestCustomObjectBody {

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -197,7 +197,7 @@ abstract class UploadFileInfoFieldTest {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class GenericCast {
-  @POST("/users/1", autoCastResponse: true)
+  @POST("/users/1")
   Future<User> getUser();
 }
 
@@ -220,7 +220,7 @@ class User {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class GenericCastBasicType {
-  @POST("/users/1", autoCastResponse: true)
+  @POST("/users/1")
   Future<String> getUser();
 }
 
@@ -270,7 +270,7 @@ abstract class TestCustomObjectBody {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestMapBody {
-  @GET("/xx", autoCastResponse: true)
+  @GET("/xx")
   Future<Map<String, List<User>>> getResult();
 }
 
@@ -283,7 +283,7 @@ abstract class TestMapBody {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestMapBody2 {
-  @GET("/xx", autoCastResponse: true)
+  @GET("/xx")
   Future<Map<String, User>> getResult();
 }
 
@@ -296,7 +296,7 @@ abstract class TestMapBody2 {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestBasicListString {
-  @GET("/xx", autoCastResponse: true)
+  @GET("/xx")
   Future<List<String>> getResult();
 }
 
@@ -309,7 +309,7 @@ abstract class TestBasicListString {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestBasicListBool {
-  @GET("/xx", autoCastResponse: true)
+  @GET("/xx")
   Future<List<bool>> getResult();
 }
 
@@ -322,7 +322,7 @@ abstract class TestBasicListBool {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestBasicListInt {
-  @GET("/xx", autoCastResponse: true)
+  @GET("/xx")
   Future<List<int>> getResult();
 }
 
@@ -335,7 +335,7 @@ abstract class TestBasicListInt {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestBasicListDouble {
-  @GET("/xx", autoCastResponse: true)
+  @GET("/xx")
   Future<List<double>> getResult();
 }
 

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -237,6 +237,26 @@ abstract class TestObjectBody {
   Future<String> createUser(@Body() User user);
 }
 
+class CustomObject {
+  final String id;
+  CustomObject(this.id);
+}
+
+@ShouldGenerate(
+    r'''
+    final _data = customObject;
+''',
+    contains: true,
+    expectedLogItems: [
+      "CustomObject must provide a `toJson()` method which return a Map.",
+      "It is programmer's responsibility to make sure the CustomObject is properly serialized",
+    ])
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class TestCustomObjectBody {
+  @POST("/custom-object")
+  Future<String> createCustomObject(@Body() CustomObject customObject);
+}
+
 @ShouldGenerate(
   r'''
     var value = _result.data.map((k, dynamic v) => MapEntry(
@@ -326,7 +346,8 @@ abstract class TestBasicListDouble {
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestCancelToken {
   @POST("/users")
-  Future<String> createUser(@Body() User user, @dio.CancelRequest() CancelToken cancelToken );
+  Future<String> createUser(
+      @Body() User user, @dio.CancelRequest() CancelToken cancelToken);
 }
 
 @ShouldGenerate(
@@ -336,7 +357,8 @@ abstract class TestCancelToken {
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestSendProgress {
   @POST("/users")
-  Future<String> createUser(@Body() User user, @dio.SendProgress() ProgressCallback onSendProgress );
+  Future<String> createUser(
+      @Body() User user, @dio.SendProgress() ProgressCallback onSendProgress);
 }
 
 @ShouldGenerate(
@@ -346,5 +368,6 @@ abstract class TestSendProgress {
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestReceiveProgress {
   @POST("/users")
-  Future<String> createUser(@Body() User user, @dio.ReceiveProgress() ProgressCallback onReceiveProgress );
+  Future<String> createUser(@Body() User user,
+      @dio.ReceiveProgress() ProgressCallback onReceiveProgress);
 }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -197,7 +197,7 @@ abstract class UploadFileInfoFieldTest {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class GenericCast {
-  @POST("/users/1")
+  @POST("/users/1", autoCastResponse: true)
   Future<User> getUser();
 }
 
@@ -220,7 +220,7 @@ class User {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class GenericCastBasicType {
-  @POST("/users/1")
+  @POST("/users/1", autoCastResponse: true)
   Future<String> getUser();
 }
 
@@ -270,7 +270,7 @@ abstract class TestCustomObjectBody {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestMapBody {
-  @GET("/xx")
+  @GET("/xx", autoCastResponse: true)
   Future<Map<String, List<User>>> getResult();
 }
 
@@ -283,7 +283,7 @@ abstract class TestMapBody {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestMapBody2 {
-  @GET("/xx")
+  @GET("/xx", autoCastResponse: true)
   Future<Map<String, User>> getResult();
 }
 
@@ -296,7 +296,7 @@ abstract class TestMapBody2 {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestBasicListString {
-  @GET("/xx")
+  @GET("/xx", autoCastResponse: true)
   Future<List<String>> getResult();
 }
 
@@ -309,7 +309,7 @@ abstract class TestBasicListString {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestBasicListBool {
-  @GET("/xx")
+  @GET("/xx", autoCastResponse: true)
   Future<List<bool>> getResult();
 }
 
@@ -322,7 +322,7 @@ abstract class TestBasicListBool {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestBasicListInt {
-  @GET("/xx")
+  @GET("/xx", autoCastResponse: true)
   Future<List<int>> getResult();
 }
 
@@ -335,7 +335,7 @@ abstract class TestBasicListInt {
 )
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestBasicListDouble {
-  @GET("/xx")
+  @GET("/xx", autoCastResponse: true)
   Future<List<double>> getResult();
 }
 


### PR DESCRIPTION
I use a custom dio interceptor to automatically convert objects to maps. My custom objects do not have `.toJson()` methods. This requires me to add custom `.toJson()` method to make retrofit work again. But my objects do not require json conversion.

Simple fix is to warn the programmer that they do not have `.toJson()` method and continue the generator.

I use [`built_value`](https://github.com/google/built_value.dart) instead of `json_serializable`. `built_value` creates serializers automatically, so I don't have `.toJson` on my custom objects

Example using automatic json conversion using dio interceptors:

```dart
class AutomaticConverterInterceptor extends Interceptor {
  onRequest(options) {
    if (options.data is CustomObject) {
      options.data = {'id': options.data.id };
    }

    if (options.data is User) {
      options.data = {'id': options.data.id, 'email': options.data.email };
    }

    return options;
  }

  onResponse(response) {
    if (response.request.responseType == ResponseType.json &&
        (response.data is Map || response.data is List)) {
      response.data = User(id: response.data.id, email: response.data.email);
    }

    return response;
  }
```

When you want to automatically convert, use the interceptor
```dart
final dio = Dio()..interceptors.add(AutomaticConverterInterceptor())
```


Also formats code with standard dart formatting using `dartfmt -w .`