### PR TITLE
support mixin to avoid a large class

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -112,13 +112,18 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         c.body = Block.of(block);
       });
 
-  Iterable<Method> _parseMethods(ClassElement element) =>
-      element.methods.where((MethodElement m) {
-        final methodAnnot = _getMethodAnnotation(m);
-        return methodAnnot != null &&
-            m.isAbstract &&
-            m.returnType.isDartAsyncFuture;
-      }).map((m) => _generateMethod(m));
+  Iterable<Method> _parseMethods(ClassElement element) {
+    List<MethodElement> methods = element.methods;
+    for (var mixin in element.mixins) {
+      methods.addAll(mixin.element.methods);
+    }
+    return methods.where((MethodElement m) {
+      final methodAnnot = _getMethodAnnotation(m);
+      return methodAnnot != null &&
+          m.isAbstract &&
+          m.returnType.isDartAsyncFuture;
+    }).map((m) => _generateMethod(m));
+  }
 
   final _methodsAnnotations = const [
     retrofit.GET,


### PR DESCRIPTION
support mixin so we can divide a large class to many small class.It's easy to manage when API amount is very big