### PR TITLE
[wip] run decoding on a background isolate

### DIFF
--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:isolate/isolate_runner.dart';
 import 'package:meta/meta.dart';
 
 /// A holder that includs all http methods which are supported by retrofit.
@@ -195,4 +198,15 @@ class Queries {
 class FormUrlEncoded {
   final mime = 'application/x-www-form-urlencoded';
   const FormUrlEncoded();
+}
+
+/// Runs the given function with the passed argument in a new isolate and returns
+/// its result. The isolate will be stopped afterwards.
+Future<R> run_background<R, P> (FutureOr<R> function(P argument), P argument) async {
+  IsolateRunner iso = await IsolateRunner.spawn();
+  try {
+    return await iso.run(function, argument);
+  } finally {
+    await iso.close();
+  }
 }

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -14,3 +14,4 @@ environment:
 dependencies:
   meta: ^1.1.6
   dio: ^3.0.1
+  isolate: ^2.0.2

--- a/example/lib/demo.g.dart
+++ b/example/lib/demo.g.dart
@@ -64,7 +64,11 @@ class _DemoClient implements DemoClient {
             extra: _extra,
             baseUrl: baseUrl),
         data: _data);
-    final value = Result.fromJson(_result.data);
+    final value = await run_background(_$getData_converter, _result.data);
     return Future.value(value);
+  }
+
+  static Result _$getData_converter(Map<String, dynamic> response) {
+    return Result.fromJson(response);
   }
 }

--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -70,8 +70,12 @@ class _RestClient implements RestClient {
             extra: _extra,
             baseUrl: baseUrl),
         data: _data);
-    final value = Task.fromJson(_result.data);
+    final value = await run_background(_$getTask_converter, _result.data);
     return Future.value(value);
+  }
+
+  static Task _$getTask_converter(Map<String, dynamic> response) {
+    return Task.fromJson(response);
   }
 
   @override
@@ -91,8 +95,13 @@ class _RestClient implements RestClient {
             extra: _extra,
             baseUrl: baseUrl),
         data: _data);
-    final value = Task.fromJson(_result.data);
+    final value =
+        await run_background(_$updateTaskPart_converter, _result.data);
     return Future.value(value);
+  }
+
+  static Task _$updateTaskPart_converter(Map<String, dynamic> response) {
+    return Task.fromJson(response);
   }
 
   @override
@@ -112,8 +121,12 @@ class _RestClient implements RestClient {
             extra: _extra,
             baseUrl: baseUrl),
         data: _data);
-    final value = Task.fromJson(_result.data);
+    final value = await run_background(_$updateTask_converter, _result.data);
     return Future.value(value);
+  }
+
+  static Task _$updateTask_converter(Map<String, dynamic> response) {
+    return Task.fromJson(response);
   }
 
   @override
@@ -148,8 +161,12 @@ class _RestClient implements RestClient {
             extra: _extra,
             baseUrl: baseUrl),
         data: _data);
-    final value = Task.fromJson(_result.data);
+    final value = await run_background(_$createTask_converter, _result.data);
     return Future.value(value);
+  }
+
+  static Task _$createTask_converter(Map<String, dynamic> response) {
+    return Task.fromJson(response);
   }
 
   @override

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -204,8 +204,16 @@ abstract class UploadFileInfoFieldTest {
 
 @ShouldGenerate(
   r'''
-    final value = User.fromJson(_result.data);
+    final value = await run_background(_$getUser_converter, _result.data);
     return Future.value(value);
+''',
+  contains: true,
+)
+@ShouldGenerate(
+  r'''
+  static _$getUser_converter(response) {
+    return User.fromJson(response);
+  }
 ''',
   contains: true,
 )
@@ -273,12 +281,20 @@ abstract class TestCustomObjectBody {
 
 @ShouldGenerate(
   r'''
-    var value = _result.data.map((k, dynamic v) => MapEntry(
+    final value = await run_background(_$getResult_converter, _result.data);
+    return Future.value(value);
+''',
+  contains: true,
+)
+@ShouldGenerate(
+  r'''
+  static _$getResult_converter(response) {
+    return response.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => User.fromJson(i as Map<String, dynamic>))
             .toList()));
-
+  }
 ''',
   contains: true,
 )
@@ -290,8 +306,17 @@ abstract class TestMapBody {
 
 @ShouldGenerate(
   r'''
-    var value = _result.data.map((k, dynamic v) =>
+    final value = await run_background(_$getResult_converter, _result.data);
+    return Future.value(value);
+''',
+  contains: true,
+)
+@ShouldGenerate(
+  r'''
+  static _$getResult_converter(response) {
+    return response.map((k, dynamic v) =>
         MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
+  }
 ''',
   contains: true,
 )


### PR DESCRIPTION
This eliminates jank on the ui thread when parsing big responses.

Fixes #60.

I updated the existing test cases for the changes.
What I have not changed, yet, is to move decoding of the raw `String` from the response into a dart object to the background, i.e. we still rely on the default dio decoding, which in itself might be slow for big responses.

Also, there are two places in the generator code that don't use the new decoding, because there were no test cases for them previously and I didn't bother to check what they are actually supposed to return. 

TODO:
- [x] convert most types in background isolate
- [ ] decode raw response String to dart object in background isolate
- [ ] add annotation to decide per class and per method whether the decoding should happen in the background. What should be the default? Decoding in the background might be a bit slower, but it is always safe and leaves the UI jank free, so I guess this should be the new default, because it is generally hard to decide for users which of their requests should be performed in the background to avoid jank.
- [ ] add more test cases for the missing code paths and convert those types in the background as well

You can test these changes in your code with the following dependencies in your `pubspec.yaml`:
```yaml
dependencies:
  retrofit:
    git:
      url: git://github.com/nioncode/retrofit.dart
      path: annotation
      ref: isolate

dev_dependencies:
  retrofit_generator:
    git:
      url: git://github.com/nioncode/retrofit.dart
      path: generator
      ref: isolate

dependency_overrides:
  retrofit:
    git:
      url: git://github.com/nioncode/retrofit.dart
      path: annotation
      ref: isolate
```