### PR TITLE
Add @Query and @Queries examples to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ The HTTP methods in the below sample are supported.
 ```dart
   @GET("/tasks/{id}")
   Future<Task> getTask(@Path("id") String id);
+  
+  @GET('/demo')
+  Future<String> queries(@Queries() Map<String, dynamic> queries);
+
+  @GET("https://httpbin.org/get")
+  Future<String> namedExample(
+      @Query("apikey") String apiKey,
+      @Query("scope") String scope, 
+      @Query("type") String type,
+      @Query("from") int from}
+  );
 
   @PATCH("/tasks/{id}")
   Future<Task> updateTaskPart(


### PR DESCRIPTION
Examples for providing query parameters were missing from the README.