### PR TITLE
support serializable queries

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.5
+
+- Add multiple `@Queries` decorators support
+- Add serializable objects with `@Queries` decorator support
+
 ## 1.3.4
 
 - Add dart json mapper deserialize support

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -631,9 +631,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     blocks.add(literalMap(queryParameters, refer("String"), refer("dynamic"))
         .assignFinal(_queryParamsVar)
         .statement);
-    if (queryMap.isNotEmpty) {
-      final type = queryMap.keys.first.type;
-      final displayName = queryMap.keys.first.displayName;
+    for (final p in queryMap.keys) {
+      final type = p.type;
+      final displayName = p.displayName;
       final value =
           (_isBasicType(type) || type.isDartCoreList || type.isDartCoreMap)
               ? refer(displayName)

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -632,9 +632,22 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         .assignFinal(_queryParamsVar)
         .statement);
     if (queryMap.isNotEmpty) {
-      blocks.add(refer('$_queryParamsVar.addAll').call(
-        [refer("${queryMap.keys.first.displayName} ?? <String,dynamic>{}")],
-      ).statement);
+      final type = queryMap.keys.first.type;
+      final displayName = queryMap.keys.first.displayName;
+      final value =
+          (_isBasicType(type) || type.isDartCoreList || type.isDartCoreMap)
+              ? refer(displayName)
+              : refer(displayName).nullSafeProperty('toJson').call([]);
+
+      /// workaround until this is merged in code_builder
+      /// https://github.com/dart-lang/code_builder/pull/269
+      final emitter = DartEmitter();
+      final buffer = StringBuffer();
+      value.accept(emitter, buffer);
+      refer('?? <String,dynamic>{}').accept(emitter, buffer);
+      final expression = refer(buffer.toString());
+
+      blocks.add(refer('$_queryParamsVar.addAll').call([expression]).statement);
     }
 
     if (m.parameters

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: retrofit_generator
 description: retrofit generator is an dio client generator using source_gen and inspired by Chopper and Retrofit.
-version: 1.3.4+2
+version: 1.3.5
 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -251,6 +251,20 @@ abstract class TestObjectBody {
   Future<String> createUser(@Body() User user);
 }
 
+@ShouldGenerate(
+  r'''
+    final queryParameters = <String, dynamic>{r'u': u?.toJson()};
+    queryParameters.addAll(user1?.toJson() ?? <String, dynamic>{});
+    queryParameters.addAll(user2?.toJson() ?? <String, dynamic>{});
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class TestObjectQueries {
+  @POST("/users")
+  Future<String> createUser(@Query('u') User u, @Queries() User user1, @Queries() User user2);
+}
+
 class CustomObject {
   final String id;
   CustomObject(this.id);


### PR DESCRIPTION
add support for serializable args decorated with `@Queries`
support multiple `@Queries` decorators (might be useful for multiple subsets of query parameters)

closes #192