### PR TITLE
support Stream return type

### DIFF
--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -15,6 +15,9 @@ abstract class RestClient {
   @GET("/tags")
   Future<List<String>> getTags();
 
+  @GET("/tags")
+  Stream<List<String>> getTagsAsStream();
+
   @GET("/tasks")
   Future<List<Task>> getTasks();
 

--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -125,7 +125,24 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data.cast<String>();
-    return Future.value(value);
+    return value;
+  }
+
+  @override
+  getTagsAsStream() async* {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final Response<List<dynamic>> _result = await _dio.request('/tags',
+        queryParameters: queryParameters,
+        options: RequestOptions(
+            method: 'GET',
+            headers: <String, dynamic>{},
+            extra: _extra,
+            baseUrl: baseUrl),
+        data: _data);
+    final value = _result.data.cast<String>();
+    yield value;
   }
 
   @override
@@ -144,7 +161,7 @@ class _RestClient implements RestClient {
     var value = _result.data
         .map((dynamic i) => Task.fromJson(i as Map<String, dynamic>))
         .toList();
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -163,7 +180,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = Task.fromJson(_result.data);
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -184,7 +201,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = Task.fromJson(_result.data);
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -205,7 +222,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = Task.fromJson(_result.data);
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -222,7 +239,7 @@ class _RestClient implements RestClient {
             extra: _extra,
             baseUrl: baseUrl),
         data: _data);
-    return Future.value(null);
+    return null;
   }
 
   @override
@@ -241,7 +258,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = Task.fromJson(_result.data);
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -262,7 +279,7 @@ class _RestClient implements RestClient {
             extra: _extra,
             baseUrl: baseUrl),
         data: _data);
-    return Future.value(null);
+    return null;
   }
 
   @override
@@ -281,7 +298,7 @@ class _RestClient implements RestClient {
             responseType: ResponseType.bytes),
         data: _data);
     final value = _result.data.cast<int>();
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -301,7 +318,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -318,7 +335,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -335,7 +352,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -353,7 +370,7 @@ class _RestClient implements RestClient {
         data: _data);
     final value = _result.data;
     final httpResponse = HttpResponse(value, _result);
-    return Future.value(httpResponse);
+    return httpResponse;
   }
 
   @override
@@ -372,7 +389,7 @@ class _RestClient implements RestClient {
     var value = _result.data
         .map((dynamic i) => TaskGroup.fromJson(i as Map<String, dynamic>))
         .toList();
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -392,7 +409,7 @@ class _RestClient implements RestClient {
         .map((dynamic i) => Task.fromJson(i as Map<String, dynamic>))
         .toList();
     final httpResponse = HttpResponse(value, _result);
-    return Future.value(httpResponse);
+    return httpResponse;
   }
 
   @override
@@ -410,7 +427,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final httpResponse = HttpResponse(null, _result);
-    return Future.value(httpResponse);
+    return httpResponse;
   }
 
   @override
@@ -436,7 +453,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -461,7 +478,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -492,7 +509,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -516,7 +533,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -551,7 +568,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -570,7 +587,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -588,7 +605,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -614,7 +631,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -635,7 +652,7 @@ class _RestClient implements RestClient {
             baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   @override
@@ -652,7 +669,7 @@ class _RestClient implements RestClient {
         options: newOptions.merge(method: 'GET', baseUrl: baseUrl),
         data: _data);
     final value = _result.data;
-    return Future.value(value);
+    return value;
   }
 
   RequestOptions newRequestOptions(Options options) {

--- a/example/lib/json_mapper_example.g.dart
+++ b/example/lib/json_mapper_example.g.dart
@@ -33,7 +33,7 @@ class _ApiService implements ApiService {
         .map((dynamic i) =>
             JsonMapper.deserialize<Task>(i as Map<String, dynamic>))
         .toList();
-    return Future.value(value);
+    return value;
   }
 
   RequestOptions newRequestOptions(Options options) {

--- a/example/test/example_test.dart
+++ b/example/test/example_test.dart
@@ -47,6 +47,17 @@ void main() {
     expect(tasks.length, 2);
   });
 
+  test("test stream tag list", () async {
+    print(jsonEncode(["tag1", "tag2"]));
+    _server.enqueue(
+        body: jsonEncode(["tag1", "tag2"]),
+        headers: {"Content-Type": "application/json"});
+    final tasksStream = await _client.getTagsAsStream();
+    final tasks = await tasksStream.first;
+    expect(tasks, isNotNull);
+    expect(tasks.length, 2);
+  });
+
   test("test empy task list", () async {
     _server.enqueue(
         body: demoEmptyListJson, headers: {"Content-Type": "application/json"});

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.5
+
+- Add support of Stream return type.
+
 ## 1.3.4
 
 - Add dart json mapper deserialize support

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -125,7 +125,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         final methodAnnot = _getMethodAnnotation(m);
         return methodAnnot != null &&
             m.isAbstract &&
-            m.returnType.isDartAsyncFuture;
+            (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
       }).map((m) => _generateMethod(m));
 
   final _methodsAnnotations = const [
@@ -236,7 +236,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return Method((mm) {
       mm
         ..name = m.displayName
-        ..modifier = MethodModifier.async
+        ..modifier = m.returnType.isDartAsyncFuture ? MethodModifier.async : MethodModifier.asyncStar
         ..annotations = ListBuilder([CodeExpression(Code('override'))]);
 
       /// required parameters
@@ -269,6 +269,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   Code _generateRequest(MethodElement m, ConstantReader httpMehod) {
+    final returnAsyncWrapper = m.returnType.isDartAsyncFuture ? 'return' : 'yield';
     final path = _generatePath(m, httpMehod);
     final blocks = <Code>[];
 
@@ -365,7 +366,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             .call([path], namedArguments, [refer("void")])
             .statement,
       );
-      blocks.add(Code("return Future.value(null);"));
+      blocks.add(Code("$returnAsyncWrapper null;"));
       return Block.of(blocks);
     }
 
@@ -383,7 +384,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         );
         blocks.add(Code("""
       final httpResponse = HttpResponse(null, $_resultVar);
-      return Future.value(httpResponse);
+      $returnAsyncWrapper httpResponse;
       """));
       } else {
         blocks.add(
@@ -391,7 +392,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               .call([path], namedArguments, [refer("void")])
               .statement,
         );
-        blocks.add(Code("return Future.value(null);"));
+        blocks.add(Code("$returnAsyncWrapper null;"));
       }
     } else {
       final innerReturnType = _getResponseInnerType(returnType);
@@ -528,10 +529,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       if (isWrappered) {
         blocks.add(Code("""
       final httpResponse = HttpResponse(value, $_resultVar);
-      return Future.value(httpResponse);
+      $returnAsyncWrapper httpResponse;
       """));
       } else {
-        blocks.add(Code("return Future.value(value);"));
+        blocks.add(Code("$returnAsyncWrapper value;"));
       }
     }
 
@@ -1018,4 +1019,14 @@ String revivedLiteral(
   }
 
   return '$instantiation($args $kwargs)';
+}
+
+extension DartTypeStreamAnnotation on DartType {
+  bool get isDartAsyncStream {
+    ClassElement element = this.element;
+    if (element == null) {
+      return false;
+    }
+    return element.name == "Stream" && element.library.isDartAsync;
+  }
 }

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -236,7 +236,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return Method((mm) {
       mm
         ..name = m.displayName
-        ..modifier = m.returnType.isDartAsyncFuture ? MethodModifier.async : MethodModifier.asyncStar
+        ..modifier = m.returnType.isDartAsyncFuture
+            ? MethodModifier.async
+            : MethodModifier.asyncStar
         ..annotations = ListBuilder([CodeExpression(Code('override'))]);
 
       /// required parameters
@@ -269,7 +271,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   Code _generateRequest(MethodElement m, ConstantReader httpMehod) {
-    final returnAsyncWrapper = m.returnType.isDartAsyncFuture ? 'return' : 'yield';
+    final returnAsyncWrapper =
+        m.returnType.isDartAsyncFuture ? 'return' : 'yield';
     final path = _generatePath(m, httpMehod);
     final blocks = <Code>[];
 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: retrofit_generator
 description: retrofit generator is an dio client generator using source_gen and inspired by Chopper and Retrofit.
-version: 1.3.4+2
+version: 1.3.5
 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -215,6 +215,18 @@ abstract class GenericCast {
   Future<User> getUser();
 }
 
+@ShouldGenerate(
+  r'''
+    yield value;
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class StreamReturnType {
+  @POST("/users/1")
+  Stream<User> getUser();
+}
+
 class User {
   User();
   factory User.fromJson(Map<String, dynamic> json) {

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -227,6 +227,18 @@ abstract class StreamReturnType {
   Stream<User> getUser();
 }
 
+@ShouldGenerate(
+  r'''
+  getUser() async* {
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class StreamReturnModifier {
+  @POST("/users/1")
+  Stream<User> getUser();
+}
+
 class User {
   User();
   factory User.fromJson(Map<String, dynamic> json) {

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -205,7 +205,7 @@ abstract class UploadFileInfoPartTest {
 @ShouldGenerate(
   r'''
     final value = User.fromJson(_result.data);
-    return Future.value(value);
+    return value;
 ''',
   contains: true,
 )
@@ -228,7 +228,7 @@ class User {
 @ShouldGenerate(
   r'''
     final value = _result.data;
-    return Future.value(value);
+    return value;
 ''',
   contains: true,
 )
@@ -304,7 +304,7 @@ abstract class TestMapBody2 {
 @ShouldGenerate(
   r'''
     final value = _result.data.cast<String>();
-    return Future.value(value);
+    return value;
 ''',
   contains: true,
 )
@@ -317,7 +317,7 @@ abstract class TestBasicListString {
 @ShouldGenerate(
   r'''
     final value = _result.data.cast<bool>();
-    return Future.value(value);
+    return value;
 ''',
   contains: true,
 )
@@ -330,7 +330,7 @@ abstract class TestBasicListBool {
 @ShouldGenerate(
   r'''
     final value = _result.data.cast<int>();
-    return Future.value(value);
+    return value;
 ''',
   contains: true,
 )
@@ -343,7 +343,7 @@ abstract class TestBasicListInt {
 @ShouldGenerate(
   r'''
     final value = _result.data.cast<double>();
-    return Future.value(value);
+    return value;
 ''',
   contains: true,
 )
@@ -555,7 +555,7 @@ abstract class CustonOptions {
 @ShouldGenerate(
   r'''
     final value = JsonMapper.deserialize<User>(_result.data);
-    return Future.value(value);
+    return value;
 ''',
   contains: true,
 )


### PR DESCRIPTION
support `Stream` return type

closes #149 (`Observable`s are replaced by `Stream` extensions since 0.23.x rxdart)

adjust `return` and `MethodModifier` generation 
return type | before | after
|- | - | -|
`Future` | `return Future.value(abc)` | `return abc` 
`Stream`| | `yield abc` 
