### PR TITLE
support inherited tojson

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.3.7
 
-- Add support for abstract class with mixin/interface approach
-used in [freezed](https://pub.dev/packages/freezed) package 
+- Add support for abstract classes with `toJson` defined in mixin/interface/superclass.
+This approach is used in [freezed](https://pub.dev/packages/freezed) package 
 
 ## 1.3.6
 

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.7
+
+- Add support for abstract class with mixin/interface approach
+used in [freezed](https://pub.dev/packages/freezed) package 
+
 ## 1.3.6
 
 - Add support of Stream return type.

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -683,8 +683,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             .statement);
       } else if (_bodyName.type.element is ClassElement) {
         final ele = _bodyName.type.element as ClassElement;
-        final toJson = ele.methods
-            .firstWhere((i) => i.displayName == "toJson", orElse: () => null);
+        final toJson = ele.lookUpMethod('toJson', ele.library);
         if (toJson == null) {
           log.warning(
               "${_bodyName.type} must provide a `toJson()` method which return a Map.\n"
@@ -797,9 +796,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             ]).statement);
           } else if (innnerType.element is ClassElement) {
             final ele = innnerType.element as ClassElement;
-            final toJson = ele.methods.firstWhere(
-                (i) => i.displayName == "toJson",
-                orElse: () => null);
+            final toJson = ele.lookUpMethod('toJson', ele.library);
             if (toJson == null) {
               throw Exception("toJson() method have to add to ${p.type}");
             } else {
@@ -832,8 +829,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           ]).statement);
         } else if (p.type.element is ClassElement) {
           final ele = p.type.element as ClassElement;
-          final toJson = ele.methods
-              .firstWhere((i) => i.displayName == "toJson", orElse: () => null);
+          final toJson = ele.lookUpMethod('toJson', ele.library);
           if (toJson == null) {
             throw Exception("toJson() method have to add to ${p.type}");
           } else {

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: retrofit_generator
 description: retrofit generator is an dio client generator using source_gen and inspired by Chopper and Retrofit.
-version: 1.3.6
+version: 1.3.7
 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -239,14 +239,27 @@ abstract class StreamReturnModifier {
   Stream<User> getUser();
 }
 
-class User {
+class User implements AbstractUser {
   User();
+
   factory User.fromJson(Map<String, dynamic> json) {
     return User();
   }
+
   Map<String, dynamic> toJson() {
     return {};
   }
+}
+
+mixin AbstractUserMixin {
+  Map<String, dynamic> toJson();
+}
+
+abstract class AbstractUser with AbstractUserMixin {
+  factory AbstractUser() = User;
+
+  factory AbstractUser.fromJson(Map<String, dynamic> json) =>
+      User.fromJson(json);
 }
 
 @ShouldGenerate(
@@ -277,6 +290,19 @@ abstract class TestObjectBody {
 
 @ShouldGenerate(
   r'''
+    final _data = <String, dynamic>{};
+    _data.addAll(user?.toJson() ?? <String, dynamic>{});
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class TestAbstractObjectBody {
+  @POST("/users")
+  Future<String> createUser(@Body() AbstractUser user);
+}
+
+@ShouldGenerate(
+  r'''
     final queryParameters = <String, dynamic>{r'u': u?.toJson()};
     queryParameters.addAll(user1?.toJson() ?? <String, dynamic>{});
     queryParameters.addAll(user2?.toJson() ?? <String, dynamic>{});
@@ -286,11 +312,13 @@ abstract class TestObjectBody {
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class TestObjectQueries {
   @POST("/users")
-  Future<String> createUser(@Query('u') User u, @Queries() User user1, @Queries() User user2);
+  Future<String> createUser(
+      @Query('u') User u, @Queries() User user1, @Queries() User user2);
 }
 
 class CustomObject {
   final String id;
+
   CustomObject(this.id);
 }
 


### PR DESCRIPTION
Add support for abstract classes with `toJson` defined in mixin/interface/superclass.
This approach is used in [freezed](https://pub.dev/packages/freezed) package.

Before: `toJson` defined indirectly wasn't found and the following warning appeared in console:
```
[WARNING] retrofit_generator:retrofit on lib/src/components/appointment/client.dart:
MySerializableAbstractClass must provide a `toJson()` method which return a Map.
It is programmer's responsibility to make sure the CancellationAppointment is properly serialized
```