### PR TITLE
移除query自定义输入对象，使得自身对象输入到dio中，用dio拦截器可以实现自己转换数据格式

### DIFF
--- a/example/bin/main.dart
+++ b/example/bin/main.dart
@@ -4,7 +4,8 @@ import 'package:logger/logger.dart';
 import 'package:dio/dio.dart';
 import 'package:retrofit_example/example.dart';
 import 'package:retrofit_example/json_mapper_example.dart' hide Task;
-import 'package:retrofit_example/json_mapper_example.reflectable.dart' show initializeReflectable;
+import 'package:retrofit_example/json_mapper_example.reflectable.dart'
+    show initializeReflectable;
 
 final logger = Logger();
 void main(List<String> args) {
@@ -58,5 +59,5 @@ void main(List<String> args) {
 
   initializeReflectable();
   final api = ApiService(dio);
-  api.getTasks().then((it) => logger.i(it.toString()));
+  api.getTasks(new DateTime.now()).then((it) => logger.i(it.toString()));
 }

--- a/example/lib/json_mapper_example.dart
+++ b/example/lib/json_mapper_example.dart
@@ -13,7 +13,7 @@ abstract class ApiService {
   factory ApiService(Dio dio, {String baseUrl}) = _ApiService;
 
   @GET("/tasks")
-  Future<List<Task>> getTasks();
+  Future<List<Task>> getTasks(@Query("dateTime") DateTime dateTime);
 }
 
 void main() {

--- a/example/lib/json_mapper_example.g.dart
+++ b/example/lib/json_mapper_example.g.dart
@@ -17,9 +17,10 @@ class _ApiService implements ApiService {
   String baseUrl;
 
   @override
-  getTasks() async {
+  getTasks(dateTime) async {
+    ArgumentError.checkNotNull(dateTime, 'dateTime');
     const _extra = <String, dynamic>{};
-    final queryParameters = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'dateTime': dateTime};
     final _data = <String, dynamic>{};
     final Response<List<dynamic>> _result = await _dio.request('/tasks',
         queryParameters: queryParameters,

--- a/example/test/example_test.dart
+++ b/example/test/example_test.dart
@@ -14,6 +14,7 @@ RestClient _client;
 ApiService _apiService;
 final _headers = {"Content-Type": "application/json"};
 final dispatcherMap = <String, MockResponse>{};
+
 void main() {
   setUp(() async {
     _server = MockWebServer();
@@ -27,6 +28,7 @@ void main() {
     await _server.start();
     final dio = Dio();
     dio.interceptors.add(LogInterceptor(responseBody: true));
+    dio.interceptors.add(DateTimeInterceptor());
     _client = RestClient(dio, baseUrl: _server.url);
 
     initializeReflectable();
@@ -130,7 +132,7 @@ void main() {
 
   test("test json mapper parse task", () async {
     _server.enqueue(body: demoTaskListJson, headers: _headers);
-    final tasks = await _apiService.getTasks();
+    final tasks = await _apiService.getTasks(new DateTime.now());
     expect(tasks, isNotNull);
     expect(tasks.length, 1);
   });
@@ -140,4 +142,19 @@ void main() {
     await _client.namedExample("apkKeyvalue", "hello", "ggggg");
     expect(true, true);
   });
+}
+
+class DateTimeInterceptor extends Interceptor {
+  @override
+  Future onRequest(RequestOptions options) async {
+    options.queryParameters = options.queryParameters.map((key, value) {
+      if (value is DateTime) {
+        //may be change to string from any you use object
+        return MapEntry(key, value.toString());
+      } else {
+        return MapEntry(key, value);
+      }
+    });
+    return options;
+  }
 }

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -628,7 +628,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               p.type.isDartCoreList ||
               p.type.isDartCoreMap)
           ? refer(p.displayName)
-          : refer(p.displayName).nullSafeProperty('toJson').call([]);
+          : clientAnnotation.parser == retrofit.Parser.DartJsonMapper
+              ? refer(p.displayName)
+              : refer(p.displayName).nullSafeProperty('toJson').call([]);
       return MapEntry(literalString(key, raw: true), value);
     });
 
@@ -642,7 +644,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       final value =
           (_isBasicType(type) || type.isDartCoreList || type.isDartCoreMap)
               ? refer(displayName)
-              : refer(displayName).nullSafeProperty('toJson').call([]);
+              : clientAnnotation.parser == retrofit.Parser.DartJsonMapper
+                  ? refer(displayName)
+                  : refer(displayName).nullSafeProperty('toJson').call([]);
 
       /// workaround until this is merged in code_builder
       /// https://github.com/dart-lang/code_builder/pull/269


### PR DESCRIPTION
添加使用dartjsonmapper之后，query参数添加tojson的方法，也不在适用，建议直接把对象存储到map中，通过dio拦截器去自定义转换输入内容，通过类型判断即可将对应的object转换成对应的string输入
也解决了我说的需要string convert的问题，通过拦截器就可以自己实现了。