### PR TITLE
added Parser.MapSrializable with toMap and fromMap functions

### DIFF
--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -18,6 +18,9 @@ enum Parser {
   /// For more detail, please visit 'https://github.com/trevorwang/retrofit.dart#type-conversion'
   JsonSerializable,
 
+  /// same as [JsonSerializable] but with toMap and fromMap functions.
+  MapSerializable,
+
   /// Each model class must add annotation '@jsonSerializable'
   /// For more detail, please visit 'https://github.com/k-paxian/dart-json-mapper'
   DartJsonMapper

--- a/flutter_example/pubspec.yaml
+++ b/flutter_example/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  retrofit:
+  retrofit: any
   json_annotation:
   dart_json_mapper:
   reflectable: ^2.2.4

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -418,6 +418,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                 .statement,
           );
           switch (clientAnnotation.parser) {
+            case retrofit.Parser.MapSerializable:
+              blocks.add(Code(
+                  "var value = $_resultVar.data.map((dynamic i) => $innerReturnType.fromMap(i as Map<String,dynamic>)).toList();"));
+              break;
             case retrofit.Parser.JsonSerializable:
               blocks.add(Code(
                   "var value = $_resultVar.data.map((dynamic i) => $innerReturnType.fromJson(i as Map<String,dynamic>)).toList();"));
@@ -445,6 +449,18 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               _typeChecker(BuiltList).isExactlyType(secondType)) {
             final type = _getResponseType(secondType);
             switch (clientAnnotation.parser) {
+              case retrofit.Parser.MapSerializable:
+                blocks.add(Code("""
+            var value = $_resultVar.data
+              .map((k, dynamic v) =>
+                MapEntry(
+                  k, (v as List)
+                    .map((i) => $type.fromMap(i as Map<String,dynamic>))
+                    .toList()
+                )
+              );
+            """));
+                break;
               case retrofit.Parser.JsonSerializable:
                 blocks.add(Code("""
             var value = $_resultVar.data
@@ -472,6 +488,14 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             }
           } else if (!_isBasicType(secondType)) {
             switch (clientAnnotation.parser) {
+              case retrofit.Parser.MapSerializable:
+                blocks.add(Code("""
+            var value = $_resultVar.data
+              .map((k, dynamic v) =>
+                MapEntry(k, $secondType.fromMap(v as Map<String, dynamic>))
+              );
+            """));
+                break;
               case retrofit.Parser.JsonSerializable:
                 blocks.add(Code("""
             var value = $_resultVar.data
@@ -518,6 +542,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                 .statement,
           );
           switch (clientAnnotation.parser) {
+            case retrofit.Parser.MapSerializable:
+              blocks.add(
+                  Code("final value = $returnType.fromMap($_resultVar.data);"));
+              break;
             case retrofit.Parser.JsonSerializable:
               blocks.add(Code(
                   "final value = $returnType.fromJson($_resultVar.data);"));
@@ -630,7 +658,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           ? refer(p.displayName)
           : clientAnnotation.parser == retrofit.Parser.DartJsonMapper
               ? refer(p.displayName)
-              : refer(p.displayName).nullSafeProperty('toJson').call([]);
+              : clientAnnotation.parser == retrofit.Parser.JsonSerializable
+                  ? refer(p.displayName).nullSafeProperty('toJson').call([])
+                  : refer(p.displayName).nullSafeProperty('toMap').call([]);
       return MapEntry(literalString(key, raw: true), value);
     });
 
@@ -646,7 +676,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               ? refer(displayName)
               : clientAnnotation.parser == retrofit.Parser.DartJsonMapper
                   ? refer(displayName)
-                  : refer(displayName).nullSafeProperty('toJson').call([]);
+                  : clientAnnotation.parser == retrofit.Parser.JsonSerializable
+                      ? refer(displayName).nullSafeProperty('toJson').call([])
+                      : refer(displayName).nullSafeProperty('toMap').call([]);
 
       /// workaround until this is merged in code_builder
       /// https://github.com/dart-lang/code_builder/pull/269
@@ -688,20 +720,38 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             .statement);
       } else if (_bodyName.type.element is ClassElement) {
         final ele = _bodyName.type.element as ClassElement;
-        final toJson = ele.lookUpMethod('toJson', ele.library);
-        if (toJson == null) {
-          log.warning(
-              "${_bodyName.type} must provide a `toJson()` method which return a Map.\n"
-              "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
-          blocks.add(
-              refer(_bodyName.displayName).assignFinal(_dataVar).statement);
+        if (clientAnnotation.parser == retrofit.Parser.MapSerializable) {
+          final toMap = ele.lookUpMethod('toMap', ele.library);
+          if (toMap == null) {
+            log.warning(
+                "${_bodyName.type} must provide a `toMap()` method which return a Map.\n"
+                "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
+            blocks.add(
+                refer(_bodyName.displayName).assignFinal(_dataVar).statement);
+          } else {
+            blocks.add(literalMap({}, refer("String"), refer("dynamic"))
+                .assignFinal(_dataVar)
+                .statement);
+            blocks.add(refer("$_dataVar.addAll").call([
+              refer("${_bodyName.displayName}?.toMap() ?? <String,dynamic>{}")
+            ]).statement);
+          }
         } else {
-          blocks.add(literalMap({}, refer("String"), refer("dynamic"))
-              .assignFinal(_dataVar)
-              .statement);
-          blocks.add(refer("$_dataVar.addAll").call([
-            refer("${_bodyName.displayName}?.toJson() ?? <String,dynamic>{}")
-          ]).statement);
+          final toJson = ele.lookUpMethod('toJson', ele.library);
+          if (toJson == null) {
+            log.warning(
+                "${_bodyName.type} must provide a `toJson()` method which return a Map.\n"
+                "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
+            blocks.add(
+                refer(_bodyName.displayName).assignFinal(_dataVar).statement);
+          } else {
+            blocks.add(literalMap({}, refer("String"), refer("dynamic"))
+                .assignFinal(_dataVar)
+                .statement);
+            blocks.add(refer("$_dataVar.addAll").call([
+              refer("${_bodyName.displayName}?.toJson() ?? <String,dynamic>{}")
+            ]).statement);
+          }
         }
       } else {
         /// @Body annotations with no type are assinged as is

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   built_collection: ^4.2.0
   code_builder: ^3.2.0
   tuple: ^1.0.2
-  retrofit: ^1.3.4
+  retrofit: any
   analyzer: '<=0.39.17'
   dart_style: '<=1.3.6'
   build: ^1.2.2

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -688,3 +688,72 @@ abstract class JsonMapperTestMapBody2 {
   @GET("/xx")
   Future<Map<String, User>> getResult();
 }
+
+@ShouldGenerate(
+  r'''
+    final value = User.fromMap(_result.data);
+    return value;
+''',
+  contains: true,
+)
+@RestApi(
+  baseUrl: "https://httpbin.org/",
+  parser: Parser.MapSerializable,
+)
+abstract class MapSerializableGenericCast {
+  @POST("/xx")
+  Future<User> getUser();
+}
+
+@ShouldGenerate(
+  r'''
+    var value = _result.data
+        .map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
+        .toList();
+''',
+  contains: true,
+)
+@RestApi(
+  baseUrl: "https://httpbin.org/",
+  parser: Parser.MapSerializable,
+)
+abstract class MapSerializableTestListBody {
+  @GET("/xx")
+  Future<List<User>> getResult();
+}
+
+@ShouldGenerate(
+  r'''
+    var value = _result.data.map((k, dynamic v) => MapEntry(
+        k,
+        (v as List)
+            .map((i) => User.fromMap(i as Map<String, dynamic>))
+            .toList()));
+
+''',
+  contains: true,
+)
+@RestApi(
+  baseUrl: "https://httpbin.org/",
+  parser: Parser.MapSerializable,
+)
+abstract class MapSerializableTestMapBody {
+  @GET("/xx")
+  Future<Map<String, List<User>>> getResult();
+}
+
+@ShouldGenerate(
+  r'''
+    var value = _result.data.map(
+        (k, dynamic v) => MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
+''',
+  contains: true,
+)
+@RestApi(
+  baseUrl: "https://httpbin.org/",
+  parser: Parser.MapSerializable,
+)
+abstract class MapSerializableTestMapBody2 {
+  @GET("/xx")
+  Future<Map<String, User>> getResult();
+}


### PR DESCRIPTION
this pull request solves issue #253 , I added a MapSerializable Parser. It works just like the JsonSerializable parser, but uses toMap and fromMap instead of toJson and fromJson functions. 

From experience, both ways are quite popular, and it should be important to know how to handle both of them, if we want to get to all costumers.