### PR TITLE
Allow passing a MultipartFile objects directly for custom content types

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -941,6 +941,15 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                     )))
                   ''')
             ]).statement);
+          } else if (_typeChecker(MultipartFile).isExactlyType(innnerType)) {
+            blocks
+                .add(refer(_dataVar).property('files').property("addAll").call([
+              refer(''' 
+                  ${p.displayName}?.map((i) => MapEntry(
+                '${fieldName}',
+                i))
+                  ''')
+            ]).statement);
           } else if (innnerType.element is ClassElement) {
             final ele = innnerType.element as ClassElement;
             final toJson = ele.lookUpMethod('toJson', ele.library);


### PR DESCRIPTION
Simple change to fix #270. 
It does not exactly meet the general logic of the generator but still provides a nice way to customize settings.
Usage remains the same:
```
@POST("publish/")
Future<void> publishContent(
    @Part(name: "files") List<MultipartFile> files);
```

Calling `publishContent` is also easy:

```
void callPublishContent(File file){
  return restApi.publishContent(
    MultipartFile.fromFileSync(file.path, filename: file.path.split(Platform.pathSeparator).last, contentType: MediaType.parse(_getContentType(file))
  )
}
```
