### PR TITLE
Do not remove null fields from body

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -837,7 +837,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         blocks.add(refer("$_dataVar.addAll").call([
           refer("${_bodyName.displayName} ?? <String,dynamic>{}")
         ]).statement);
-        blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
       } else if ((_typeChecker(List).isExactly(_bodyName.type.element) ||
               _typeChecker(BuiltList).isExactly(_bodyName.type.element)) &&
           !_isBasicInnerType(_bodyName.type)) {
@@ -885,7 +884,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             blocks.add(refer("$_dataVar.addAll").call([
               refer("${_bodyName.displayName}?.toJson() ?? <String,dynamic>{}")
             ]).statement);
-            blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
           }
         }
       } else {

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -771,26 +771,6 @@ abstract class MapSerializableTestMapBody2 {
 }
 
 @ShouldGenerate(
-  '_data.removeWhere((k, v) => v == null);',
-  contains: true,
-)
-@RestApi()
-abstract class MapBodyShouldBeCleanTest {
-  @PUT("/")
-  Future<void> update(@Body() Map<String, dynamic> data);
-}
-
-@ShouldGenerate(
-  '_data.removeWhere((k, v) => v == null);',
-  contains: true,
-)
-@RestApi()
-abstract class JsonSerializableBodyShouldBeCleanTest {
-  @PUT("/")
-  Future<void> update(@Body() User obj);
-}
-
-@ShouldGenerate(
     r'''
     final _data = str;
     await _dio.request<void>('/',


### PR DESCRIPTION
We should be able to send a body with `null` as field's value since it can be interpreted differently by remote service than the absence of the field (e.g absent  = no change, present with null = reset value) .
`JsonSerializable` already offers the possibility to include or not null values. And it's much more flexible to let programmer remove them himself if he doesn't use `JsonSerializable`
As we can see here https://github.com/trevorwang/retrofit.dart/issues/283 it can be completely blocking