### PR TITLE
Generate also mixin methods

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -162,7 +162,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       });
 
   Iterable<Method> _parseMethods(ClassElement element) =>
-      element.methods.where((MethodElement m) {
+      (element.methods..addAll(element.mixins.expand((i) => i.methods)))
+          .where((MethodElement m) {
         final methodAnnot = _getMethodAnnotation(m);
         return methodAnnot != null &&
             m.isAbstract &&

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -926,3 +926,18 @@ abstract class NoBodyGeneratesNullBody {
   @NoBody()
   Future<GenericUser<dynamic>> puy();
 }
+
+mixin MethodInMixin {
+  @GET("https://httpbin.org/")
+  Future<void> someGet();
+}
+
+@ShouldGenerate(
+  r'''
+  @override
+  Future<void> someGet() async {
+  ''',
+  contains: true,
+)
+@RestApi()
+abstract class NoMethods with MethodInMixin {}


### PR DESCRIPTION
We wanted to split api endpoints into multiple files reflecting multiple services and use mixins for that. With class marked with `@RestApi()` implementing those mixins. In this PR I made necessary changes to also generate methods from mixins.