### PR TITLE
Add support for fileName attribute in List<List<int>>

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1137,8 +1137,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                   ${p.displayName}.map((i) => MapEntry(
                 '${fieldName}',
                 MultipartFile.fromBytes(i,
-
-                filename:${literal(fileName ?? null)},
+                    filename:${literal(fileName ?? null)},
                     ${conType}
                     )))
                   ''')

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1127,6 +1127,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           var innerType = _genericOf(p.type);
 
           if (_displayString(innerType) == "List<int>") {
+            final fileName = r.peek("fileName")?.stringValue;
             final conType = contentType == null
                 ? ""
                 : 'contentType: MediaType.parse(${literal(contentType)}),';
@@ -1136,6 +1137,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                   ${p.displayName}.map((i) => MapEntry(
                 '${fieldName}',
                 MultipartFile.fromBytes(i,
+
+                filename:${literal(fileName ?? null)},
                     ${conType}
                     )))
                   ''')


### PR DESCRIPTION
At the moment the List<List<int>> files is not actually send as file.

The filename is required at least in a PHP environment (I didn't test in other environments).

This patch add support for the fileName attribute that fix the issue.