### PR TITLE
[generator] Fix DioOptions to include the baseUrl and headers

### DIFF
--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -652,10 +652,10 @@ class _RestClient implements RestClient {
     final _data = <String, dynamic>{};
     final newOptions = newRequestOptions(options);
     newOptions.extra.addAll(_extra);
-    newOptions.headers.addAll(<String, dynamic>{});
+    newOptions.headers.addAll(<String, dynamic>{} + _dio.options.headers);
     final _result = await _dio.fetch<String>(newOptions.copyWith(
         method: 'GET',
-        baseUrl: baseUrl,
+        baseUrl: baseUrl ?? _dio.options.baseUrl,
         queryParameters: queryParameters,
         path: '')
       ..data = _data);

--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -652,7 +652,8 @@ class _RestClient implements RestClient {
     final _data = <String, dynamic>{};
     final newOptions = newRequestOptions(options);
     newOptions.extra.addAll(_extra);
-    newOptions.headers.addAll(<String, dynamic>{} + _dio.options.headers);
+    newOptions.headers.addAll(_dio.options.headers);
+    newOptions.headers.addAll(<String, dynamic>{});
     final _result = await _dio.fetch<String>(newOptions.copyWith(
         method: 'GET',
         baseUrl: baseUrl ?? _dio.options.baseUrl,

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -801,8 +801,12 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       blocks.add(newOptions
           .property('headers')
           .property('addAll')
-          .call([extraOptions.remove('headers')!
-          .operatorAdd(refer(_dioVar).property('options').property('headers'))])
+          .call([refer(_dioVar).property('options').property('headers')])
+        .statement);
+      blocks.add(newOptions
+          .property('headers')
+          .property('addAll')
+          .call([extraOptions.remove('headers')!])
           .statement);
       return newOptions.property('copyWith').call([], Map.from(extraOptions)
         ..[_queryParamsVar] = namedArguments[_queryParamsVar]!

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -801,10 +801,16 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       blocks.add(newOptions
           .property('headers')
           .property('addAll')
-          .call([extraOptions.remove('headers')!]).statement);
+          .call([extraOptions.remove('headers')!
+          .operatorAdd(refer(_dioVar).property('options').property('headers'))])
+          .statement);
       return newOptions.property('copyWith').call([], Map.from(extraOptions)
         ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
-        ..[_path] = namedArguments[_path]!).cascade('data').assign(namedArguments[_dataVar]!);
+        ..[_path] = namedArguments[_path]!
+        ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
+            refer(_dioVar).property('options').property('baseUrl'))
+        ).cascade('data').assign(namedArguments[_dataVar]!
+      );
     }
   }
 

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -748,7 +748,8 @@ abstract class TestModelList {
 @ShouldGenerate(r'''
     final newOptions = newRequestOptions(options);
     newOptions.extra.addAll(_extra);
-    newOptions.headers.addAll(<String, dynamic>{} + _dio.options.headers);
+    newOptions.headers.addAll(_dio.options.headers);
+    newOptions.headers.addAll(<String, dynamic>{});
     await _dio.fetch<void>(newOptions.copyWith(
         method: 'GET',
         baseUrl: baseUrl ?? _dio.options.baseUrl,

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -748,10 +748,10 @@ abstract class TestModelList {
 @ShouldGenerate(r'''
     final newOptions = newRequestOptions(options);
     newOptions.extra.addAll(_extra);
-    newOptions.headers.addAll(<String, dynamic>{});
+    newOptions.headers.addAll(<String, dynamic>{} + _dio.options.headers);
     await _dio.fetch<void>(newOptions.copyWith(
         method: 'GET',
-        baseUrl: baseUrl,
+        baseUrl: baseUrl ?? _dio.options.baseUrl,
         queryParameters: queryParameters,
         path: '')
       ..data = _data);


### PR DESCRIPTION
I'm not sure if I've implemented it correctly, but this fixes my project, which otherwise didn't include the base URL or headers if `DioOptions` were included.