### PR TITLE
add cache control header support

### DIFF
--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -271,3 +271,26 @@ class Part {
   final String? contentType;
   const Part({this.value, this.name, this.fileName, this.contentType});
 }
+
+@immutable
+class Cache {
+  final int? maxAge;
+  final int? maxStale;
+  final int? minFresh;
+  final bool noCache;
+  final bool noStore;
+  final bool noTransform;
+  final bool onlyIfCached;
+  final List<String> other;
+
+  const Cache({
+    this.maxAge,
+    this.maxStale,
+    this.minFresh,
+    this.noCache = false,
+    this.noStore = false,
+    this.noTransform = false,
+    this.onlyIfCached = false,
+    this.other = const [],
+  });
+}

--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -273,7 +273,7 @@ class Part {
 }
 
 @immutable
-class Cache {
+class CacheControl {
   final int? maxAge;
   final int? maxStale;
   final int? minFresh;
@@ -283,7 +283,7 @@ class Cache {
   final bool onlyIfCached;
   final List<String> other;
 
-  const Cache({
+  const CacheControl({
     this.maxAge,
     this.maxStale,
     this.minFresh,

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -162,8 +162,8 @@ abstract class RestClient {
   Future<ValueWrapper<ValueWrapper<String>>> nestGeneric();
 
   @GET('cache')
-  @Cache(maxAge: 180,maxStale: 300,minFresh: 60,noCache: true,noStore: true,noTransform: true,onlyIfCached: true,other: ['public','proxy-revalidate'])
-  @Headers({'test':'test'})
+  @CacheControl(maxAge: 180,maxStale: 300,minFresh: 60,noCache: true,noStore: true,noTransform: true,onlyIfCached: true,other: ['public','proxy-revalidate'])
+  @Headers({'test':'tes t'})
   Future<String> cache();
 }
 

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -160,6 +160,11 @@ abstract class RestClient {
 
   @GET('/nestGeneric')
   Future<ValueWrapper<ValueWrapper<String>>> nestGeneric();
+
+  @GET('cache')
+  @Cache(maxAge: 180,maxStale: 300,minFresh: 60,noCache: true,noStore: true,noTransform: true,onlyIfCached: true,other: ['public','proxy-revalidate'])
+  @Headers({'test':'test'})
+  Future<String> cache();
 }
 
 @JsonSerializable()

--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -777,7 +777,7 @@ class _RestClient implements RestClient {
     final _result = await _dio.fetch<String>(_setStreamType<String>(Options(
             method: 'GET',
             headers: <String, dynamic>{
-              r'test': 'test',
+              r'test': 'tes t',
               r'cache-control':
                   'max-age=180, max-stale=300, max-fresh=60, no-cache, no-store, no-transform, only-if-cached, public, proxy-revalidate'
             },

--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -769,6 +769,26 @@ class _RestClient implements RestClient {
     return value;
   }
 
+  @override
+  Future<String> cache() async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final _result = await _dio.fetch<String>(_setStreamType<String>(Options(
+            method: 'GET',
+            headers: <String, dynamic>{
+              r'test': 'test',
+              r'cache-control':
+                  'max-age=180, max-stale=300, max-fresh=60, no-cache, no-store, no-transform, only-if-cached, public, proxy-revalidate'
+            },
+            extra: _extra)
+        .compose(_dio.options, 'cache',
+            queryParameters: queryParameters, data: _data)
+        .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = _result.data!;
+    return value;
+  }
+
   RequestOptions newRequestOptions(Options? options) {
     if (options is RequestOptions) {
       return options as RequestOptions;

--- a/flutter_example/lib/example.g.dart
+++ b/flutter_example/lib/example.g.dart
@@ -23,10 +23,11 @@ class _RestClient implements RestClient {
     final _data = <String, dynamic>{};
     final newOptions = newRequestOptions(options);
     newOptions.extra.addAll(_extra);
+    newOptions.headers.addAll(_dio.options.headers);
     newOptions.headers.addAll(<String, dynamic>{});
     final _result = await _dio.fetch<List<dynamic>>(newOptions.copyWith(
         method: 'GET',
-        baseUrl: baseUrl,
+        baseUrl: baseUrl ?? _dio.options.baseUrl,
         queryParameters: queryParameters,
         path: '/tags')
       ..data = _data);

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -205,16 +205,16 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   ConstantReader? _getHeadersAnnotation(MethodElement method) {
-    final annot = _typeChecker(retrofit.Headers)
+    final annotation = _typeChecker(retrofit.Headers)
         .firstAnnotationOf(method, throwOnUnresolved: false);
-    if (annot != null) return ConstantReader(annot);
+    if (annotation != null) return ConstantReader(annotation);
     return null;
   }
 
   ConstantReader? _getCacheAnnotation(MethodElement method) {
-    final annot = _typeChecker(retrofit.Cache)
+    final annotation = _typeChecker(retrofit.CacheControl)
         .firstAnnotationOf(method, throwOnUnresolved: false);
-    if (annot != null) return ConstantReader(annot);
+    if (annotation != null) return ConstantReader(annotation);
     return null;
   }
 
@@ -1269,7 +1269,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     final anno = _getHeadersAnnotation(m);
     final headersMap = anno?.peek("value")?.mapValue ?? {};
     final headers = headersMap.map((k, v) {
-      return MapEntry(k?.toStringValue() ?? 'null', literal(v?.toStringValue()));
+      return MapEntry(
+          k?.toStringValue() ?? 'null', literal(v?.toStringValue()));
     });
 
     final annosInParam = _getAnnotations(m, retrofit.Header);
@@ -1287,20 +1288,21 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   Map<String, Expression> _generateCache(MethodElement m) {
     final cache = _getCacheAnnotation(m);
-    var result=<String,Expression>{};
+    final result = <String, Expression>{};
     if (cache != null && cache.toString() != '') {
-      var maxAge = cache.peek('maxAge')?.intValue;
-      var maxStale = cache.peek('maxStale')?.intValue;
-      var minFresh = cache.peek('minFresh')?.intValue;
-      var noCache = cache.peek('noCache')?.boolValue;
-      var noStore = cache.peek('noStore')?.boolValue;
-      var noTransform = cache.peek('noTransform')?.boolValue;
-      var onlyIfCached = cache.peek('onlyIfCached')?.boolValue;
-      var other = (cache.peek('other')?.listValue ?? const []).map((e) => e.toStringValue());
-      var otherResult = <String>[];
+      final maxAge = cache.peek('maxAge')?.intValue;
+      final maxStale = cache.peek('maxStale')?.intValue;
+      final minFresh = cache.peek('minFresh')?.intValue;
+      final noCache = cache.peek('noCache')?.boolValue;
+      final noStore = cache.peek('noStore')?.boolValue;
+      final noTransform = cache.peek('noTransform')?.boolValue;
+      final onlyIfCached = cache.peek('onlyIfCached')?.boolValue;
+      final other = (cache.peek('other')?.listValue ?? const [])
+          .map((e) => e.toStringValue());
+      final otherResult = <String>[];
 
       other.forEach((element) {
-        if(element!=null){
+        if (element != null) {
           otherResult.add(element);
         }
       });
@@ -1316,7 +1318,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         ...otherResult
       ];
 
-      var value=values.where((element) => element != '').join(', ');
+      final value = values.where((element) => element != '').join(', ');
 
       result.putIfAbsent(HttpHeaders.cacheControlHeader, () => literal(value));
     }

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -22,3 +22,8 @@ dependencies:
 dev_dependencies:
   test: 1.17.4
   source_gen_test: ^1.0.0
+
+dependency_overrides:
+  retrofit:
+    path: ../annotation
+

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -22,8 +22,3 @@ dependencies:
 dev_dependencies:
   test: 1.17.4
   source_gen_test: ^1.0.0
-
-dependency_overrides:
-  retrofit:
-    path: ../annotation
-


### PR DESCRIPTION
添加一个cache注解，专门用来添加header的cache control属性
根据
https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Cache-Control
把所有支持的客户端属性添加上，并使用other来扩展用户认为可以使用的自定义属性。