### PR TITLE
⚡ Added Path param handling when dealing with FormData

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1067,22 +1067,13 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final parts = _getAnnotations(m, retrofit.Part);
     if (parts.isNotEmpty) {
-      if (m.parameters.length == 1 && m.parameters.first.type.isDartCoreMap) {
-        blocks.add(refer('FormData')
-            .newInstanceNamed('fromMap',
-                [CodeExpression(Code(m.parameters.first.displayName))])
-            .assignFinal(_dataVar)
-            .statement);
-        return;
-      }
-      else if (m.parameters.length == 2) {
-        blocks.add(refer('FormData')
-            .newInstanceNamed('fromMap',
-                [CodeExpression(Code(m.parameters[1].displayName))])
-            .assignFinal(_dataVar)
-            .statement);
-        return;
-      }
+      blocks.add(refer('FormData')
+          .newInstanceNamed('fromMap',
+              [CodeExpression(Code(m.parameters[1].displayName))])
+          .assignFinal(_dataVar)
+          .statement);
+      return;
+      
       blocks.add(
           refer('FormData').newInstance([]).assignFinal(_dataVar).statement);
 

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1075,7 +1075,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             .statement);
         return;
       }
-      else if (m.parameters.length == 2 && m.parameters[1].type.isDartCoreMap) {
+      else if (m.parameters.length == 2) {
         blocks.add(refer('FormData')
             .newInstanceNamed('fromMap',
                 [CodeExpression(Code(m.parameters[1].displayName))])

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1075,6 +1075,14 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             .statement);
         return;
       }
+      else if (m.parameters.length == 2 && m.parameters[1].type.isDartCoreMap) {
+        blocks.add(refer('FormData')
+            .newInstanceNamed('fromMap',
+                [CodeExpression(Code(m.parameters[1].displayName))])
+            .assignFinal(_dataVar)
+            .statement);
+        return;
+      }
       blocks.add(
           refer('FormData').newInstance([]).assignFinal(_dataVar).statement);
 

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1067,13 +1067,22 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final parts = _getAnnotations(m, retrofit.Part);
     if (parts.isNotEmpty) {
-      blocks.add(refer('FormData')
-          .newInstanceNamed('fromMap',
-              [CodeExpression(Code(m.parameters[1].displayName))])
-          .assignFinal(_dataVar)
-          .statement);
-      return;
-      
+      if (m.parameters.length == 1 && m.parameters.first.type.isDartCoreMap) {
+        blocks.add(refer('FormData')
+            .newInstanceNamed('fromMap',
+                [CodeExpression(Code(m.parameters.first.displayName))])
+            .assignFinal(_dataVar)
+            .statement);
+        return;
+      }
+      else if (m.parameters.length == 2 && m.parameters[1].type.isDartCoreMap) {
+        blocks.add(refer('FormData')
+            .newInstanceNamed('fromMap',
+                [CodeExpression(Code(m.parameters[1].displayName))])
+            .assignFinal(_dataVar)
+            .statement);
+        return;
+      }
       blocks.add(
           refer('FormData').newInstance([]).assignFinal(_dataVar).statement);
 


### PR DESCRIPTION
``` dart
// previous working one's
@POST("/order")
Future<ApiResponse> createOrder(@Part() Map<String, dynamic> map);

// added support for path
@POST("/order/{id}?_method=PATCH")
Future<ApiResponse> editOrder(@Path() String id, @Part() Map<String, dynamic> map);
```