### PR TITLE
Always keep curly brackets for dynamic paths

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -339,7 +339,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     String? definePath = method.peek("path")?.stringValue;
     paths.forEach((k, v) {
       final value = v.peek("value")?.stringValue ?? k.displayName;
-      definePath = definePath?.replaceFirst("{$value}", "\$${k.displayName}");
+      definePath = definePath?.replaceFirst("{$value}", "\${${k.displayName}}");
     });
     return literal(definePath);
   }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -133,6 +133,16 @@ abstract class FormUrlEncodedTest {
 }
 
 @ShouldGenerate(
+  r"/image/${id}_XL.png",
+  contains: true,
+)
+@RestApi()
+abstract class PathTest {
+  @GET("/image/{id}_XL.png")
+  Future<HttpResponse> getImage(@Path('id') String id);
+}
+
+@ShouldGenerate(
   r'''
     final _data = FormData();
     _data.files.add(MapEntry(


### PR DESCRIPTION
Currently, when we declare dynamic path (with `@Path`), the generator do not include brackets for string interpolation which is fine in most cases but not always...

```dart
@GET('/images/{id}_XL.png')
Future<HttpResponse> getImage(@Path('id') String id)
```
this will generates this code :

```dart
Future<HttpResponse<dynamic>> getImage(uuid) async {
// ...
      .compose(_dio.options, '/api/images/products/$uuid_XL.png',
// ...
}
```
The string interpolation expects a variable named `uuid_XL` instead of `uuid`. The generator should always add brackets. This PR fixes that and now generates : 

```dart
Future<HttpResponse<dynamic>> getImage(uuid) async {
// ...
      .compose(_dio.options, '/api/images/products/${uuid}_XL.png',
// ...
}
```