### PR TITLE
fix null handling of MultipartFile

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1466,14 +1466,20 @@ You should create a new class to encapsulate the response.
             ]).statement);
           } else if (innerType != null &&
               _typeChecker(MultipartFile).isExactlyType(innerType)) {
+            if (p.type.isNullable) {
+              blocks.add(Code("if (${p.displayName} != null) {"));
+            }
             blocks
                 .add(refer(_dataVar).property('files').property("addAll").call([
               refer(''' 
-                  ${p.displayName}?.map((i) => MapEntry(
+                  ${p.displayName}.map((i) => MapEntry(
                 '${fieldName}',
                 i))
                   ''')
             ]).statement);
+            if (p.type.isNullable) {
+              blocks.add(Code("}"));
+            }
           } else if (innerType?.element is ClassElement) {
             final ele = innerType!.element as ClassElement;
             if (_missingToJson(ele)) {

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -178,6 +178,34 @@ abstract class FilePartWithCustomNameTest {
 @ShouldGenerate(
   r'''
     final _data = FormData();
+    _data.files.addAll(images.map((i) => MapEntry('images', i)));
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class FilePartWithMultipartListTest {
+  @POST("/profile")
+  Future<String> setProfile(@Part() List<MultipartFile> images);
+}
+
+@ShouldGenerate(
+  r'''
+    final _data = FormData();
+    if (images != null) {
+      _data.files.addAll(images.map((i) => MapEntry('images', i)));
+    }
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class FilePartWithNullableMultipartListTest {
+  @POST("/profile")
+  Future<String> setProfile(@Part() List<MultipartFile>? images);
+}
+
+@ShouldGenerate(
+  r'''
+    final _data = FormData();
     _data.files.add(MapEntry(
         'image',
         MultipartFile.fromFileSync(image.path,


### PR DESCRIPTION
This PR contains following changes:
- fix null handling of MultipartFile code generation
- add some tests

Before this PR, the generated code won't be compiled by following error:
```
Error: The argument type 'Iterable<MapEntry<String, MultipartFile>>?' can't be assigned to the parameter type
 'Iterable<MapEntry<String, MultipartFile>>' because 'Iterable<MapEntry<String, MultipartFile>>?' is nullable and 'Iterable<MapEntry<String, Mu
ltipartFile>>' isn't

    _data.files.addAll(images?.map((i) => MapEntry('images', i)));
                       ^
```

related: https://github.com/trevorwang/retrofit.dart/pull/272