### PR TITLE
Upload multiple files with unique names

### DIFF
--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1560,3 +1560,22 @@ mixin MethodInMixin {
 )
 @RestApi()
 abstract class NoMethods with MethodInMixin {}
+
+@ShouldGenerate(
+  r'''
+    final _data = FormData();
+    final _files = <MapEntry<String, MultipartFile>>[];
+    images.forEach((name, image) {
+      _files.add(
+          MapEntry('images[]', MultipartFile.fromBytes(image, filename: name)));
+    });
+
+    _data.files.addAll(_files);
+''',
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class UploadFileMapTest {
+  @POST("/profile")
+  Future<String> setProfile(@Part(name: 'images[]') Map<String, List<int>> images);
+}

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1577,5 +1577,6 @@ abstract class NoMethods with MethodInMixin {}
 @RestApi(baseUrl: "https://httpbin.org/")
 abstract class UploadFileMapTest {
   @POST("/profile")
+  @MultiPart()
   Future<String> setProfile(@Part(name: 'images[]') Map<String, List<int>> images);
 }


### PR DESCRIPTION
This PR is regarding to this https://github.com/trevorwang/retrofit.dart/issues/430.
You can now use this syntax:
```
@Part(name: 'files[]') required Map<String, List<int>> files
```
to upload files which gives you the ability to provide a name for each file

**example**
```
Map<String, List<int>> filesToUpload = {
    "sample1.pdf": file1 as List<int> ,
    "sample2.pdf": file2,
};
```
