### PR TITLE
fix: Add handling @MultiPart in codegen

### DIFF
--- a/annotation/lib/http.dart
+++ b/annotation/lib/http.dart
@@ -264,6 +264,14 @@ class Queries {
   const Queries({this.encoded = false});
 }
 
+/// An interface for annotation which has mime type.
+/// Such as [FormUrlEncoded] and [MultiPart].
+abstract class _MimeType {
+  abstract final String mime;
+
+  const _MimeType();
+}
+
 /// Denotes that the request body will use form URL encoding. Fields should be declared as
 /// parameters and annotated with [Field].
 ///
@@ -271,7 +279,8 @@ class Queries {
 /// type. Field names and values will be UTF-8 encoded before being URI-encoded in accordance to
 /// [RFC-3986](http://tools.ietf.org/html/rfc3986)
 @immutable
-class FormUrlEncoded {
+class FormUrlEncoded extends _MimeType {
+  @override
   final mime = 'application/x-www-form-urlencoded';
   const FormUrlEncoded();
 }
@@ -279,7 +288,11 @@ class FormUrlEncoded {
 /// Denotes that the request body is multi-part. Parts should be declared as parameters and
 /// annotated with [Part].
 @immutable
-class MultiPart {
+class MultiPart extends _MimeType {
+
+  @override
+  final mime = 'multipart/form-data';
+
   const MultiPart();
 }
 

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -226,7 +226,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     final formUrlEncoded = _getFormUrlEncodedAnnotation(method);
 
     if (multipart != null && formUrlEncoded != null) {
-      throw Exception('Two content-type annotation on one request ${method.name}');
+      throw InvalidGenerationSourceError('Two content-type annotation on one request ${method.name}');
     }
 
     return multipart ?? formUrlEncoded;
@@ -400,7 +400,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     }
 
     final contentType = _getContentTypeAnnotation(m);
-    print('DEVVV: $contentType');
     if (contentType != null) {
       extraOptions[_contentType] =
           literal(contentType.peek("mime")?.stringValue);

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -14,7 +14,8 @@ dependencies:
   built_collection: ^5.0.0
   code_builder: ^4.0.0
   tuple: ^2.0.0
-  retrofit: ^3.0.0
+  retrofit: 
+    path: ../annotation
   analyzer: ^2.0.0
   dart_style: ^2.0.1
   build: ^2.0.1

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -133,6 +133,17 @@ abstract class FormUrlEncodedTest {
 }
 
 @ShouldGenerate(
+  r"contentType: 'multipart/form-data'",
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class MultipartTest {
+  @POST("/get")
+  @MultiPart()
+  Future<String> ip();
+}
+
+@ShouldGenerate(
   r"/image/${id}_XL.png",
   contains: true,
 )

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -143,6 +143,15 @@ abstract class MultipartTest {
   Future<String> ip();
 }
 
+@ShouldThrow('Two content-type annotation on one request ip', element: false)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class TwoContentTypeAnnotationOnSameMethodTest {
+  @POST("/get")
+  @MultiPart()
+  @FormUrlEncoded()
+  Future<String> ip();
+}
+
 @ShouldGenerate(
   r"/image/${id}_XL.png",
   contains: true,


### PR DESCRIPTION
Codegen had ignored a @MultiPart annotation before this moment.

It is caused problems with multiparts requests.


This PR added a MimeType-interface to FormUrlEncoded and Multipart annotations
``` dart
// An interface for annotation which has mime type.
/// Such as [FormUrlEncoded] and [MultiPart].
abstract class _MimeType {
  abstract final String mime;

  const _MimeType();
}
```

and handling both annotations when generate code.
```dart
ConstantReader? _getContentTypeAnnotation(MethodElement method) {
    final multipart = _getMultipartAnnotation(method);
    final formUrlEncoded = _getFormUrlEncodedAnnotation(method);

    if (multipart != null && formUrlEncoded != null) {
      throw InvalidGenerationSourceError('Two content-type annotation on one request ${method.name}');
    }

    return multipart ?? formUrlEncoded;
  }
```