### PR TITLE
Generator fix: Nullable result type

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -690,8 +690,11 @@ You should create a new class to encapsulate the response.
           );
           blocks.add(Code("final value = $_resultVar.data;"));
         } else {
+          final fetchType = returnType.isNullable
+              ? "Map<String,dynamic>?"
+              : "Map<String,dynamic>";
           blocks.add(
-            refer("await $_dioVar.fetch<Map<String,dynamic>>")
+            refer("await $_dioVar.fetch<$fetchType>")
                 .call([options])
                 .assignFinal(_resultVar)
                 .statement,

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1560,3 +1560,23 @@ mixin MethodInMixin {
 )
 @RestApi()
 abstract class NoMethods with MethodInMixin {}
+
+@ShouldGenerate(
+  r'''await _dio.fetch<Map<String, dynamic>?>''',
+  contains: true,
+)
+@RestApi()
+abstract class NullableGenericCastFetch {
+  @GET("/")
+  Future<User?> get();
+}
+
+@ShouldGenerate(
+  r'''await _dio.fetch<Map<String, dynamic>>''',
+  contains: true,
+)
+@RestApi()
+abstract class GenericCastFetch {
+  @GET("/")
+  Future<User> get();
+}


### PR DESCRIPTION
This pull request fixes an CastError that was happening when the resultType is an generic nullable

When sending fetch to dio, was forcing fetch result to be Map<String, dynamic>, causing an Error if the response was null.

Before:

    final _result = await _dio.fetch<Map<String, dynamic>>(
    
After:

    final _result = await _dio.fetch<Map<String, dynamic>?>(
    
I also added two tests to ensure fetch type correctly, if nullable or not.