### PR TITLE
feat: Generate code for Multipart mime-type

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -226,7 +226,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     final formUrlEncoded = _getFormUrlEncodedAnnotation(method);
 
     if (multipart != null && formUrlEncoded != null) {
-      throw Exception('Two content-type annotation on one request ${method.name}');
+      throw InvalidGenerationSourceError('Two content-type annotation on one request ${method.name}');
     }
 
     return multipart ?? formUrlEncoded;
@@ -400,7 +400,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     }
 
     final contentType = _getContentTypeAnnotation(m);
-    print('DEVVV: $contentType');
     if (contentType != null) {
       extraOptions[_contentType] =
           literal(contentType.peek("mime")?.stringValue);

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -14,7 +14,8 @@ dependencies:
   built_collection: ^5.0.0
   code_builder: ^4.0.0
   tuple: ^2.0.0
-  retrofit: ^3.0.0
+  retrofit: 
+    path: ../annotation
   analyzer: ^2.0.0
   dart_style: ^2.0.1
   build: ^2.0.1

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -14,8 +14,7 @@ dependencies:
   built_collection: ^5.0.0
   code_builder: ^4.0.0
   tuple: ^2.0.0
-  retrofit: 
-    path: ../annotation
+  retrofit: ^3.0.1
   analyzer: ^2.0.0
   dart_style: ^2.0.1
   build: ^2.0.1

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -133,6 +133,17 @@ abstract class FormUrlEncodedTest {
 }
 
 @ShouldGenerate(
+  r"contentType: 'multipart/form-data'",
+  contains: true,
+)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class MultipartTest {
+  @POST("/get")
+  @MultiPart()
+  Future<String> ip();
+}
+
+@ShouldGenerate(
   r"/image/${id}_XL.png",
   contains: true,
 )

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -143,6 +143,15 @@ abstract class MultipartTest {
   Future<String> ip();
 }
 
+@ShouldThrow('Two content-type annotation on one request ip', element: false)
+@RestApi(baseUrl: "https://httpbin.org/")
+abstract class TwoContentTypeAnnotationOnSameMethodTest {
+  @POST("/get")
+  @MultiPart()
+  @FormUrlEncoded()
+  Future<String> ip();
+}
+
 @ShouldGenerate(
   r"/image/${id}_XL.png",
   contains: true,


### PR DESCRIPTION
This last part of my PRs which fixes a work with multipart.

I added a logic about handling contents types while code generation based on annotations.
Also, added tests.