### PR TITLE
[generator] Adds a `ignore_for_file` rule to suppress the analyzer warnings for the generated files.

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -14,6 +14,8 @@ import 'package:retrofit/retrofit.dart' as retrofit;
 import 'package:source_gen/source_gen.dart';
 import 'package:tuple/tuple.dart';
 
+const _analyzerIgnores = '// ignore_for_file: unnecessary_brace_in_string_interps';
+
 class RetrofitOptions {
   final bool? autoCastResponse;
 
@@ -101,7 +103,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     });
 
     final emitter = DartEmitter();
-    return DartFormatter().format('${classBuilder.accept(emitter)}');
+    return DartFormatter().format([_analyzerIgnores, classBuilder.accept(emitter)].join('\n\n'));
   }
 
   Field _buildDioFiled() => Field((m) => m

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -5,6 +5,8 @@ import 'package:retrofit/retrofit.dart';
 import 'package:source_gen_test/annotations.dart';
 
 @ShouldGenerate(r'''
+// ignore_for_file: unnecessary_brace_in_string_interps
+
 class _RestClient implements RestClient {
   _RestClient(this._dio, {this.baseUrl});
 


### PR DESCRIPTION
Due to this commit 74bae83474aa421a665ea721f60463fc717ac7c3, the dart analyzer is now showing warnings about using curly braces in string interpolation when not needed.
```
info: Avoid using braces in interpolation when not needed.
```

This PR adds an `ignore_for_file` rule to suppress these warnings.