### PR TITLE
Fix bug deserialize List

### DIFF
--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -22,39 +22,13 @@ Map<String, dynamic> _$TaskToJson(Task instance) => <String, dynamic>{
 
 TaskQuery _$TaskQueryFromJson(Map<String, dynamic> json) => TaskQuery(
       (json['statuses'] as List<dynamic>)
-          .map((e) => _$enumDecode(_$StatusEnumMap, e))
+          .map((e) => $enumDecode(_$StatusEnumMap, e))
           .toList(),
     );
 
 Map<String, dynamic> _$TaskQueryToJson(TaskQuery instance) => <String, dynamic>{
       'statuses': instance.statuses.map((e) => _$StatusEnumMap[e]).toList(),
     };
-
-K _$enumDecode<K, V>(
-  Map<K, V> enumValues,
-  Object? source, {
-  K? unknownValue,
-}) {
-  if (source == null) {
-    throw ArgumentError(
-      'A value must be provided. Supported values: '
-      '${enumValues.values.join(', ')}',
-    );
-  }
-
-  return enumValues.entries.singleWhere(
-    (e) => e.value == source,
-    orElse: () {
-      if (unknownValue == null) {
-        throw ArgumentError(
-          '`$source` is not one of the supported values: '
-          '${enumValues.values.join(', ')}',
-        );
-      }
-      return MapEntry(unknownValue, enumValues.values.first);
-    },
-  ).key;
-}
 
 const _$StatusEnumMap = {
   Status.New: 'new',
@@ -101,6 +75,8 @@ Map<String, dynamic> _$ValueWrapperToJson<T>(
 // **************************************************************************
 // RetrofitGenerator
 // **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps
 
 class _RestClient implements RestClient {
   _RestClient(this._dio, {this.baseUrl}) {
@@ -185,7 +161,7 @@ class _RestClient implements RestClient {
     final _data = <String, dynamic>{};
     final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<Task>(
         Options(method: 'GET', headers: _headers, extra: _extra)
-            .compose(_dio.options, '/tasks/$id',
+            .compose(_dio.options, '/tasks/${id}',
                 queryParameters: queryParameters, data: _data)
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
     final value = Task.fromJson(_result.data!);
@@ -201,7 +177,7 @@ class _RestClient implements RestClient {
     _data.addAll(map);
     final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<Task>(
         Options(method: 'PATCH', headers: _headers, extra: _extra)
-            .compose(_dio.options, '/tasks/$id',
+            .compose(_dio.options, '/tasks/${id}',
                 queryParameters: queryParameters, data: _data)
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
     final value = Task.fromJson(_result.data!);
@@ -217,7 +193,7 @@ class _RestClient implements RestClient {
     _data.addAll(task.toJson());
     final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<Task>(
         Options(method: 'PUT', headers: _headers, extra: _extra)
-            .compose(_dio.options, '/tasks/$id',
+            .compose(_dio.options, '/tasks/${id}',
                 queryParameters: queryParameters, data: _data)
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
     final value = Task.fromJson(_result.data!);
@@ -232,7 +208,7 @@ class _RestClient implements RestClient {
     final _data = <String, dynamic>{};
     await _dio.fetch<void>(_setStreamType<void>(
         Options(method: 'DELETE', headers: _headers, extra: _extra)
-            .compose(_dio.options, '/tasks/$id',
+            .compose(_dio.options, '/tasks/${id}',
                 queryParameters: queryParameters, data: _data)
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
     return null;
@@ -468,7 +444,7 @@ class _RestClient implements RestClient {
     final _data = <String, dynamic>{};
     final _result = await _dio.fetch<void>(_setStreamType<HttpResponse<void>>(
         Options(method: 'DELETE', headers: _headers, extra: _extra)
-            .compose(_dio.options, '/tasks/$id',
+            .compose(_dio.options, '/tasks/${id}',
                 queryParameters: queryParameters, data: _data)
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
     final httpResponse = HttpResponse(null, _result);

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -815,7 +815,7 @@ You should create a new class to encapsulate the response.
             .map<${genericTypeString}>((i) => ${genericTypeString}.fromJson(
                   i as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(genericType)}
                 ))
-            .toList()
+            .toList(),
     """;
         } else {
           if (_isBasicType(genericType)) {
@@ -824,7 +824,7 @@ You should create a new class to encapsulate the response.
             .map<${genericTypeString}>((i) => 
                   i as ${genericTypeString}
                 )
-            .toList()
+            .toList(),
     """;
           } else {
             mapperVal = """
@@ -832,7 +832,7 @@ You should create a new class to encapsulate the response.
             .map<${genericTypeString}>((i) =>
             ${genericTypeString == 'dynamic' ? ' i as Map<String, dynamic>' : genericTypeString + '.fromJson(  i as Map<String, dynamic> )  '}
     )
-            .toList()
+            .toList(),
     """;
           }
         }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1407,7 +1407,8 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsDynamic {
         _result.data!,
         (json) => (json as List<dynamic>)
             .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
-            .toList());
+            .toList(),
+    );
     return value;
   ''',
   contains: true,
@@ -1426,7 +1427,8 @@ abstract class DynamicInnerListGenericTypeShouldBeCastedRecursively {
             _result.data!,
             (json) => (json as List<dynamic>)
                 .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
-                .toList());
+                .toList(),
+          );
     return value;
   ''',
   contains: true,

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1404,10 +1404,10 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsDynamic {
 @ShouldGenerate(
   r'''
     final value = GenericUser<List<User>>.fromJson(
-        _result.data!,
-        (json) => (json as List<dynamic>)
-            .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
-            .toList(),
+      _result.data!,
+      (json) => (json as List<dynamic>)
+          .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
+          .toList(),
     );
     return value;
   ''',
@@ -1495,9 +1495,9 @@ abstract class NullableDynamicInnerGenericTypeShouldBeCastedAsMap {
 @ShouldGenerate(
   r'''
     final value = GenericUser<List<double>>.fromJson(
-        _result.data!,
-        (json) =>
-            (json as List<dynamic>).map<double>((i) => i as double).toList(),
+      _result.data!,
+      (json) =>
+          (json as List<dynamic>).map<double>((i) => i as double).toList(),
     );
     return value;
   ''',

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1495,7 +1495,8 @@ abstract class NullableDynamicInnerGenericTypeShouldBeCastedAsMap {
     final value = GenericUser<List<double>>.fromJson(
         _result.data!,
         (json) =>
-            (json as List<dynamic>).map<double>((i) => i as double).toList());
+            (json as List<dynamic>).map<double>((i) => i as double).toList(),
+    );
     return value;
   ''',
   contains: true,
@@ -1514,7 +1515,8 @@ abstract class DynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursively {
             _result.data!,
             (json) => (json as List<dynamic>)
                 .map<double>((i) => i as double)
-                .toList());
+                .toList(),
+          );
     return value;
   ''',
   contains: true,


### PR DESCRIPTION
I encounter a problem when trying to deserialize a generic List. My sample codes:

**Generic model:**
```dart
@JsonSerializable(genericArgumentFactories: true)
class ApiResponse<Data, Meta>{
   final Data? _data;
   final Meta? _meta;
   final bool _success;
   
   const ApiResponse({
      Data? data,
      Meta? meta,
      bool success = false,
    })  : _data = data,
        _meta = meta,
        _success = success;

    Data? get data => _data;
    Meta? get meta => _meta;
    ApiError? get error => _error;
    bool get success => _success;

    factory ApiResponse.fromJson(
       Map<String, dynamic> json,
       Data Function(Object? json) dataFromJson,
       Meta Function(Object? json) metaFromJson,
    ) =>  _$ApiResponseFromJson(json, dataFromJson, metaFromJson);
}
```

**Retrofit class1:**
```dart
@RestApi()
abstract class SearchApi1 {
  factory SearchApi1(Dio dio, {String baseUrl}) = _SearchApi;

  @GET('/destination-search')
  Future<ApiResponse<List<MyData>, MyMeta>> fetchSomething();
}

```

**Retrofit class2:**
```dart
@RestApi()
abstract class SearchApi2 {
  factory SearchApi1(Dio dio, {String baseUrl}) = _SearchApi;

  @GET('/destination-search')
  Future<ApiResponse<MyData, MyMeta>> fetchSomething();
}

```

When I try to run generator, the first implementation `SearchApi1` get failed, but the second one `SearchApi2` get success. I try to look at generated codes and it turns out that the codes are used to generate generic List missing a comma at the end, it causes this codes cannot chain with following parameters in `.fromJson()` method.