### PR TITLE
feat: change `newRequestOptions` argument to Object.

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1011,7 +1011,7 @@ You should create a new class to encapsulate the response.
         /// required parameters
         ..requiredParameters.add(Parameter((p) {
           p.name = "options";
-          p.type = refer("Options?").type;
+          p.type = refer("Object?").type;
         }))
 
         /// add method body
@@ -1019,25 +1019,25 @@ You should create a new class to encapsulate the response.
          if (options is RequestOptions) {
             return options as RequestOptions;
           }
-          if (options == null) {
-            return RequestOptions(path: '');
+          if (options is Options) {
+            return RequestOptions(
+              method: options.method,
+              sendTimeout: options.sendTimeout,
+              receiveTimeout: options.receiveTimeout,
+              extra: options.extra,
+              headers: options.headers,
+              responseType: options.responseType,
+              contentType: options.contentType.toString(),
+              validateStatus: options.validateStatus,
+              receiveDataWhenStatusError: options.receiveDataWhenStatusError,
+              followRedirects: options.followRedirects,
+              maxRedirects: options.maxRedirects,
+              requestEncoder: options.requestEncoder,
+              responseDecoder: options.responseDecoder,
+              path: '',
+            );
           }
-          return RequestOptions(
-            method: options.method,
-            sendTimeout: options.sendTimeout,
-            receiveTimeout: options.receiveTimeout,
-            extra: options.extra,
-            headers: options.headers,
-            responseType: options.responseType,
-            contentType: options.contentType.toString(),
-            validateStatus: options.validateStatus,
-            receiveDataWhenStatusError: options.receiveDataWhenStatusError,
-            followRedirects: options.followRedirects,
-            maxRedirects: options.maxRedirects,
-            requestEncoder: options.requestEncoder,
-            responseDecoder: options.responseDecoder,
-            path: '',
-          );
+          return RequestOptions(path: '');
         ''');
     });
   }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -806,29 +806,29 @@ abstract class TestModelList {
 }
 
 @ShouldGenerate(r'''
-  RequestOptions newRequestOptions(Options? options) {
+  RequestOptions newRequestOptions(Object? options) {
     if (options is RequestOptions) {
       return options as RequestOptions;
     }
-    if (options == null) {
-      return RequestOptions(path: '');
+    if (options is Options) {
+      return RequestOptions(
+        method: options.method,
+        sendTimeout: options.sendTimeout,
+        receiveTimeout: options.receiveTimeout,
+        extra: options.extra,
+        headers: options.headers,
+        responseType: options.responseType,
+        contentType: options.contentType.toString(),
+        validateStatus: options.validateStatus,
+        receiveDataWhenStatusError: options.receiveDataWhenStatusError,
+        followRedirects: options.followRedirects,
+        maxRedirects: options.maxRedirects,
+        requestEncoder: options.requestEncoder,
+        responseDecoder: options.responseDecoder,
+        path: '',
+      );
     }
-    return RequestOptions(
-      method: options.method,
-      sendTimeout: options.sendTimeout,
-      receiveTimeout: options.receiveTimeout,
-      extra: options.extra,
-      headers: options.headers,
-      responseType: options.responseType,
-      contentType: options.contentType.toString(),
-      validateStatus: options.validateStatus,
-      receiveDataWhenStatusError: options.receiveDataWhenStatusError,
-      followRedirects: options.followRedirects,
-      maxRedirects: options.maxRedirects,
-      requestEncoder: options.requestEncoder,
-      responseDecoder: options.responseDecoder,
-      path: '',
-    );
+    return RequestOptions(path: '');
   }
 ''', contains: true)
 @ShouldGenerate(r'''


### PR DESCRIPTION
I see that there is 
```
    if (options is RequestOptions) {
      return options as RequestOptions;
    }
```

in `newRequestOptions`. However, when I do
```
  @POST('/url')
  Future<MyResponse> createSale(
    @Body() MyRequest body, [
    @DioOptions() RequestOptions? dioOption,
  ]);
``` 

I am getting 
```
Error: The argument type 'RequestOptions?' can't be assigned to the parameter type 'Options?'.
setel_services/…/setel_hub_gateway/api.g.dart:25
- 'RequestOptions' is from 'package:dio/src/options.dart' ('../../../.pub-cache/hosted/pub.dartlang.org/dio-4.0.4/lib/src/options.dart').
package:dio/src/options.dart:1
- 'Options' is from 'package:dio/src/options.dart' ('../../../.pub-cache/hosted/pub.dartlang.org/dio-4.0.4/lib/src/options.dart').
package:dio/src/options.dart:1
    final newOptions = newRequestOptions(dioOption);
```
when I run my flutter app. This is because `newRequestOptions` is expecting `Options` but `RequestOptions` does not inherit from `Options`

https://github.com/flutterchina/dio/blob/develop/dio/lib/src/options.dart#L418
```
class RequestOptions extends _RequestConfig with OptionsMixin {
...
}
```
```
class _RequestConfig {
...
}
```
and
```
mixin OptionsMixin {
...
}
```

My intention is to pass in `CancelToken` as stated in https://github.com/trevorwang/retrofit.dart/issues/450 but currently with `@DioOptions` is specified, the token is ignored. (Refer to issue)

Do let me know if there are better alternatives.
