### PR TITLE
handing of enum API method parameters annotated with @Path

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -362,7 +362,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     String? definePath = method.peek("path")?.stringValue;
     paths.forEach((k, v) {
       final value = v.peek("value")?.stringValue ?? k.displayName;
-      definePath = definePath?.replaceFirst("{$value}", "\${${k.displayName}}");
+      definePath = definePath?.replaceFirst("{$value}", "\${${k.displayName}${k.type.element?.kind == ElementKind.ENUM ? '.name' : ''}}");
     });
     return literal(definePath);
   }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -155,13 +155,17 @@ abstract class TwoContentTypeAnnotationOnSameMethodTest {
 }
 
 @ShouldGenerate(
-  r"/image/${id}_XL.png",
+  r"/image/${imageType.name}/${id}_XL.png",
   contains: true,
 )
 @RestApi()
 abstract class PathTest {
-  @GET("/image/{id}_XL.png")
-  Future<HttpResponse> getImage(@Path('id') String id);
+  @GET("/image/{imageType}/{id}_XL.png")
+  Future<HttpResponse> getImage(@Path('imageType') ImageType imageType, @Path('id') String id);
+}
+
+enum ImageType {
+  icon, large  
 }
 
 @ShouldGenerate(


### PR DESCRIPTION
Here is a proposed patch to address https://github.com/trevorwang/retrofit.dart/issues/465
Improve handling of enum method parameter types annotated with `@Path`