### PR TITLE
support analyzer 4.0.0

### DIFF
--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   code_builder: ^4.0.0
   tuple: ^2.0.0
   retrofit: ^3.0.1
-  analyzer: ^3.0.0
+  analyzer: '>=3.0.0 <5.0.0'
   dart_style: ^2.0.1
   build: ^2.0.1
 


### PR DESCRIPTION
Packages are slowly starting to use the latest analyzer version and it would soon (again) become an incompatibility problem.
I have widened the version range to include both 3 and 4 - but if you want to allow only 4, I can change that.