### PR TITLE
Fix documentation build workflow 

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build docs
         run: |
-          cd annotation
+          cd retrofit
           dartdoc
           mv doc/api ../public
       - name: GitHub Pages


### PR DESCRIPTION
Documentation directory has been moved by 3fcab1fadde64949f5fc10b4e2482248676acdde but hasn't been changed in workflow.

This PR just changes the documentation's directory path in the workflow.