### PR TITLE
Multiple @Extra and @Headers

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -197,9 +197,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   ConstantReader? _getMethodAnnotation(MethodElement method) {
     for (final type in _methodsAnnotations) {
-      final annot = _typeChecker(type)
-          .firstAnnotationOf(method, throwOnUnresolved: false);
-      if (annot != null) return ConstantReader(annot);
+      final annot = _getMethodAnnotationByType(method, type);
+      if (annot != null) return annot;
     }
     return null;
   }
@@ -212,17 +211,11 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   ConstantReader? _getHeadersAnnotation(MethodElement method) {
-    final annotation = _typeChecker(retrofit.Headers)
-        .firstAnnotationOf(method, throwOnUnresolved: false);
-    if (annotation != null) return ConstantReader(annotation);
-    return null;
+    return _getMethodAnnotationByType(method, retrofit.Headers);
   }
 
   ConstantReader? _getCacheAnnotation(MethodElement method) {
-    final annotation = _typeChecker(retrofit.CacheControl)
-        .firstAnnotationOf(method, throwOnUnresolved: false);
-    if (annotation != null) return ConstantReader(annotation);
-    return null;
+    return _getMethodAnnotationByType(method, retrofit.CacheControl);
   }
 
   ConstantReader? _getContentTypeAnnotation(MethodElement method) {
@@ -238,24 +231,15 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   ConstantReader? _getMultipartAnnotation(MethodElement method) {
-    final annotation = _typeChecker(retrofit.MultiPart)
-        .firstAnnotationOf(method, throwOnUnresolved: false);
-    if (annotation != null) return ConstantReader(annotation);
-    return null;
+    return _getMethodAnnotationByType(method, retrofit.MultiPart);
   }
 
   ConstantReader? _getFormUrlEncodedAnnotation(MethodElement method) {
-    final annotation = _typeChecker(retrofit.FormUrlEncoded)
-        .firstAnnotationOf(method, throwOnUnresolved: false);
-    if (annotation != null) return ConstantReader(annotation);
-    return null;
+    return _getMethodAnnotationByType(method, retrofit.FormUrlEncoded);
   }
 
   ConstantReader? _getResponseTypeAnnotation(MethodElement method) {
-    final annotation = _typeChecker(retrofit.DioResponseType)
-        .firstAnnotationOf(method, throwOnUnresolved: false);
-    if (annotation != null) return ConstantReader(annotation);
-    return null;
+    return _getMethodAnnotationByType(method, retrofit.DioResponseType);
   }
 
   Map<ParameterElement, ConstantReader> _getAnnotations(

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1645,13 +1645,13 @@ You should create a new class to encapsulate the response.
 
   void _generateExtra(
       MethodElement m, List<Code> blocks, String localExtraVar) {
-    final extra = _typeChecker(retrofit.Extra)
-        .firstAnnotationOf(m, throwOnUnresolved: false);
+    final extras =
+        _typeChecker(retrofit.Extra).annotationsOf(m, throwOnUnresolved: false);
 
-    if (extra != null) {
-      final c = ConstantReader(extra);
       blocks.add(literalMap(
-        c.peek('data')?.mapValue.map((k, v) {
+      extras
+          .map((e) => ConstantReader(e).peek('data'))
+          .map((data) => data?.mapValue.map((k, v) {
               return MapEntry(
                 k?.toStringValue() ??
                     (throw InvalidGenerationSourceError(
@@ -1670,18 +1670,11 @@ You should create a new class to encapsulate the response.
                     (v?.toTypeValue() ??
                         (v != null ? Code(revivedLiteral(v)) : Code('null'))),
               );
-            }) ??
-            {},
+              }))
+          .fold<Map<String, Object>>({}, (p, e) => p..addAll(e ?? {})),
         refer('String'),
         refer('dynamic'),
       ).assignConst(localExtraVar).statement);
-    } else {
-      blocks.add(literalMap(
-        {},
-        refer('String'),
-        refer('dynamic'),
-      ).assignConst(localExtraVar).statement);
-    }
   }
 
   bool _missingToJson(ClassElement ele) {

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -58,6 +58,20 @@ abstract class ExtrasWithPrimitiveValues {
 
 @ShouldGenerate(
   r'''
+    const _extra = <String, dynamic>{'key': 'value', 'key2': 'value2'};
+''',
+  contains: true,
+)
+@RestApi()
+abstract class MultipleExtrasWithPrimitiveValues {
+  @GET('/list/')
+  @Extra({'key': 'value'})
+  @Extra({'key2': 'value2'})
+  Future<void> list();
+}
+
+@ShouldGenerate(
+  r'''
     const _extra = <String, dynamic>{'key': CustomConstant()};
 ''',
   contains: true,

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:dio/dio.dart';
+import 'package:dio/dio.dart' hide Headers;
 import 'package:retrofit/retrofit.dart';
 import 'package:source_gen_test/annotations.dart';
 
@@ -85,6 +85,46 @@ abstract class ExtrasWithCustomConstant {
 
 class CustomConstant {
   const CustomConstant();
+}
+
+@ShouldGenerate(
+  r'''
+    final _headers = <String, dynamic>{};
+''',
+  contains: true,
+)
+@RestApi()
+abstract class EmptyHeaders {
+  @GET('/list/')
+  @Headers(<String, dynamic>{})
+  Future<void> list();
+}
+
+@ShouldGenerate(
+  r'''
+    final _headers = <String, dynamic>{r'key': 'value'};
+''',
+  contains: true,
+)
+@RestApi()
+abstract class HeadersWithPrimitiveValues {
+  @GET('/list/')
+  @Headers({'key': 'value'})
+  Future<void> list();
+}
+
+@ShouldGenerate(
+  r'''
+    final _headers = <String, dynamic>{r'key': 'value', r'key2': 'value2'};
+''',
+  contains: true,
+)
+@RestApi()
+abstract class MultipleHeadersWithPrimitiveValues {
+  @GET('/list/')
+  @Headers({'key': 'value'})
+  @Headers({'key2': 'value2'})
+  Future<void> list();
 }
 
 @ShouldGenerate(


### PR DESCRIPTION
We have a massive project with hundreds of packages, and each package has 5-20 API calls. Efficient development at such a scale would not be possible without heavy usage of code generation. And retrofit package plays a crucial role in our project. Thanks for such a fantastic tool!
To push code minimization even further, we developed an approach with the usage of `@Exra` request annotations and `Dio` interceptors. We declare a `const` value based on `Extra`:
```dart
const authenticatedRequest = Extra({'append-token': true});
```
And a `Dio` interceptor that awaits for `append-token` key:
```dart
class AppendTokenInterceptor extends Interceptor {
  AppendTokenInterceptor(this._authService);

  final AuthService _authService;

  static const _appendTokenExtraKey = 'append-token';

  @override
  Future<void> onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
    final appendToken = options.extra[_appendTokenExtraKey] ?? false;
    if (appendToken) {
      final token = await _authService.getToken();
      options.headers['Authorization'] = token;
    }
    options.extra.remove(_appendTokenExtraKey);

    return super.onRequest(options, handler);
  }
}
```
Then we are able to use the new `@authenticatedRequest` annotation above the request instead of `@Extra`:
```dart
@RestApi()
abstract class ExampleApi {
  factory ExampleApi(Dio dio) = _ExampleApi;

  @GET('/users/{id}')
  @authenticatedRequest
  Future<UserResponse> getUser(
    @Path('id') String id,
  );
}
```
However, the scale of the project and sophisticated requirements forces us to have multiple such annotations dedicated to different information we need to send with specific requests. This leads to the desire to be able to append multiple Extra-based annotations above each request. This is currently not possible. Only the information from the first `Extra` makes it to the generated file.

With this PR, I add a possibility to add multiple `@Extra` and `@Headers` annotations.
Additionally, I slightly refactored `_get*Annotation` functions to reduce code duplication and added tests for the `@Headers` annotation.