### PR TITLE
Update analyzer and Dart version to 2.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        sdk: [stable, 2.17.6, 2.18.1]
+        sdk: [stable, 2.17.6]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        sdk: [stable, 2.14.4, 2.15.1, 2.16.2]
+        sdk: [stable, 2.17.6, 2.18.1]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -24,8 +24,8 @@ class RetrofitOptions {
 
   RetrofitOptions.fromOptions([BuilderOptions? options])
       : autoCastResponse =
-      (options?.config['auto_cast_response']?.toString() ?? 'true') ==
-          'true';
+            (options?.config['auto_cast_response']?.toString() ?? 'true') ==
+                'true';
 }
 
 class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
@@ -56,7 +56,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   @override
   String generateForAnnotatedElement(
-      Element element, ConstantReader annotation, BuildStep buildStep) {
+    Element element,
+    ConstantReader annotation,
+    BuildStep buildStep,
+  ) {
     if (element is! ClassElement) {
       final name = element.displayName;
       throw InvalidGenerationSourceError(
@@ -87,7 +90,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         ..fields.addAll([_buildDioFiled(), _buildBaseUrlFiled(baseUrl)])
         ..constructors.addAll(
           annotClassConsts.map(
-                (e) => _generateConstructor(baseUrl, superClassConst: e),
+            (e) => _generateConstructor(baseUrl, superClassConst: e),
           ),
         )
         ..methods.addAll(_parseMethods(element));
@@ -108,30 +111,40 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         .format([_analyzerIgnores, classBuilder.accept(emitter)].join('\n\n'));
   }
 
-  Field _buildDioFiled() => Field((m) => m
-    ..name = _dioVar
-    ..type = refer("Dio")
-    ..modifier = FieldModifier.final$);
+  Field _buildDioFiled() => Field(
+        (m) => m
+          ..name = _dioVar
+          ..type = refer("Dio")
+          ..modifier = FieldModifier.final$,
+      );
 
   Field _buildBaseUrlFiled(String? url) => Field((m) {
-    m
-      ..name = _baseUrlVar
-      ..type = refer("String?")
-      ..modifier = FieldModifier.var$;
-  });
+        m
+          ..name = _baseUrlVar
+          ..type = refer("String?")
+          ..modifier = FieldModifier.var$;
+      });
 
   Constructor _generateConstructor(
-      String? url, {
-        ConstructorElement? superClassConst,
-      }) =>
+    String? url, {
+    ConstructorElement? superClassConst,
+  }) =>
       Constructor((c) {
-        c.requiredParameters.add(Parameter((p) => p
-          ..name = _dioVar
-          ..toThis = true));
-        c.optionalParameters.add(Parameter((p) => p
-          ..named = true
-          ..name = _baseUrlVar
-          ..toThis = true));
+        c.requiredParameters.add(
+          Parameter(
+            (p) => p
+              ..name = _dioVar
+              ..toThis = true,
+          ),
+        );
+        c.optionalParameters.add(
+          Parameter(
+            (p) => p
+              ..named = true
+              ..name = _baseUrlVar
+              ..toThis = true,
+          ),
+        );
         if (superClassConst != null) {
           var superConstName = 'super';
           if (superClassConst.name.isNotEmpty) {
@@ -141,14 +154,22 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           final constParams = superClassConst.parameters;
           constParams.forEach((element) {
             if (!element.isOptional || element.isPrivate) {
-              c.requiredParameters.add(Parameter((p) => p
-                ..type = refer(_displayString(element.type))
-                ..name = element.name));
+              c.requiredParameters.add(
+                Parameter(
+                  (p) => p
+                    ..type = refer(_displayString(element.type))
+                    ..name = element.name,
+                ),
+              );
             } else {
-              c.optionalParameters.add(Parameter((p) => p
-                ..named = element.isNamed
-                ..type = refer(_displayString(element.type))
-                ..name = element.name));
+              c.optionalParameters.add(
+                Parameter(
+                  (p) => p
+                    ..named = element.isNamed
+                    ..type = refer(_displayString(element.type))
+                    ..name = element.name,
+                ),
+              );
             }
           });
           final paramList = constParams
@@ -167,20 +188,20 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       });
 
   Iterable<Method> _parseMethods(ClassElement element) => (<MethodElement>[]
-    ..addAll(element.methods)
-    ..addAll(element.mixins.expand((i) => i.methods)))
-      .where((MethodElement m) {
-    final methodAnnot = _getMethodAnnotation(m);
-    return methodAnnot != null &&
-        m.isAbstract &&
-        (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
-  }).map((m) => _generateMethod(m)!);
+            ..addAll(element.methods)
+            ..addAll(element.mixins.expand((i) => i.methods)))
+          .where((MethodElement m) {
+        final methodAnnot = _getMethodAnnotation(m);
+        return methodAnnot != null &&
+            m.isAbstract &&
+            (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
+      }).map((m) => _generateMethod(m)!);
 
   String _generateTypeParameterizedName(TypeParameterizedElement element) =>
       element.displayName +
-          (element.typeParameters.isNotEmpty
-              ? '<${element.typeParameters.join(',')}>'
-              : '');
+      (element.typeParameters.isNotEmpty
+          ? '<${element.typeParameters.join(',')}>'
+          : '');
 
   final _methodsAnnotations = const [
     retrofit.GET,
@@ -205,7 +226,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   ConstantReader? _getMethodAnnotationByType(MethodElement method, Type type) {
     final annot =
-    _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
+        _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
     if (annot != null) return ConstantReader(annot);
     return null;
   }
@@ -220,7 +241,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     if (multipart != null && formUrlEncoded != null) {
       throw InvalidGenerationSourceError(
-          'Two content-type annotation on one request ${method.name}');
+        'Two content-type annotation on one request ${method.name}',
+      );
     }
 
     return multipart ?? formUrlEncoded;
@@ -239,14 +261,18 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   Iterable<ConstantReader> _getMethodAnnotations(
-      MethodElement method, Type type) {
+    MethodElement method,
+    Type type,
+  ) {
     return _typeChecker(type)
         .annotationsOf(method, throwOnUnresolved: false)
         .map((e) => ConstantReader(e));
   }
 
   Map<ParameterElement, ConstantReader> _getAnnotations(
-      MethodElement m, Type type) {
+    MethodElement m,
+    Type type,
+  ) {
     var annot = <ParameterElement, ConstantReader>{};
     for (final p in m.parameters) {
       final a = _typeChecker(type).firstAnnotationOf(p);
@@ -258,7 +284,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   Tuple2<ParameterElement, ConstantReader>? _getAnnotation(
-      MethodElement m, Type type) {
+    MethodElement m,
+    Type type,
+  ) {
     for (final p in m.parameters) {
       final a = _typeChecker(type).firstAnnotationOf(p);
       if (a != null) {
@@ -313,7 +341,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return Method((mm) {
       mm
         ..returns =
-        refer(_displayString(m.type.returnType, withNullability: true))
+            refer(_displayString(m.type.returnType, withNullability: true))
         ..name = m.displayName
         ..types.addAll(m.typeParameters.map((e) => refer(e.name)))
         ..modifier = m.returnType.isDartAsyncFuture
@@ -322,24 +350,32 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         ..annotations.add(CodeExpression(Code('override')));
 
       /// required parameters
-      mm.requiredParameters.addAll(m.parameters
-          .where((it) => it.isRequiredPositional)
-          .map((it) => Parameter((p) => p
-        ..name = it.name
-        ..named = it.isNamed)));
+      mm.requiredParameters.addAll(
+        m.parameters.where((it) => it.isRequiredPositional).map(
+              (it) => Parameter(
+                (p) => p
+                  ..name = it.name
+                  ..named = it.isNamed,
+              ),
+            ),
+      );
 
       /// optional positional or named parameters
-      mm.optionalParameters.addAll(m.parameters
-          .where((i) => i.isOptional || i.isRequiredNamed)
-          .map((it) => Parameter((p) => p
-        ..required = (it.isNamed &&
-            it.type.nullabilitySuffix == NullabilitySuffix.none &&
-            !it.hasDefaultValue)
-        ..name = it.name
-        ..named = it.isNamed
-        ..defaultTo = it.defaultValueCode == null
-            ? null
-            : Code(it.defaultValueCode!))));
+      mm.optionalParameters.addAll(
+        m.parameters.where((i) => i.isOptional || i.isRequiredNamed).map(
+              (it) => Parameter(
+                (p) => p
+                  ..required = (it.isNamed &&
+                      it.type.nullabilitySuffix == NullabilitySuffix.none &&
+                      !it.hasDefaultValue)
+                  ..name = it.name
+                  ..named = it.isNamed
+                  ..defaultTo = it.defaultValueCode == null
+                      ? null
+                      : Code(it.defaultValueCode!),
+              ),
+            ),
+      );
       mm.body = _generateRequest(m, httpMehod);
     });
   }
@@ -349,15 +385,17 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     String? definePath = method.peek("path")?.stringValue;
     paths.forEach((k, v) {
       final value = v.peek("value")?.stringValue ?? k.displayName;
-      definePath = definePath?.replaceFirst("{$value}",
-          "\${${k.displayName}${k.type.element2?.kind == ElementKind.ENUM ? '.name' : ''}}");
+      definePath = definePath?.replaceFirst(
+        "{$value}",
+        "\${${k.displayName}${k.type.element2?.kind == ElementKind.ENUM ? '.name' : ''}}",
+      );
     });
     return literal(definePath);
   }
 
   Code _generateRequest(MethodElement m, ConstantReader httpMethod) {
     final returnAsyncWrapper =
-    m.returnType.isDartAsyncFuture ? 'return' : 'yield';
+        m.returnType.isDartAsyncFuture ? 'return' : 'yield';
     final path = _generatePath(m, httpMethod);
     final blocks = <Code>[];
 
@@ -365,12 +403,17 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     _generateQueries(m, blocks, _queryParamsVar);
     Map<String, Expression> headers = _generateHeaders(m);
-    blocks.add(declareFinal(_localHeadersVar)
-        .assign(literalMap(
-        headers.map((k, v) => MapEntry(literalString(k, raw: true), v)),
-        refer("String"),
-        refer("dynamic")))
-        .statement);
+    blocks.add(
+      declareFinal(_localHeadersVar)
+          .assign(
+            literalMap(
+              headers.map((k, v) => MapEntry(literalString(k, raw: true), v)),
+              refer("String"),
+              refer("dynamic"),
+            ),
+          )
+          .statement,
+    );
 
     if (headers.isNotEmpty) {
       blocks.add(Code("${_localHeadersVar}.removeWhere((k, v) => v == null);"));
@@ -386,7 +429,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final contentTypeInHeader = headers.entries
         .firstWhereOrNull(
-            (i) => "Content-Type".toLowerCase() == i.key.toLowerCase())
+          (i) => "Content-Type".toLowerCase() == i.key.toLowerCase(),
+        )
         ?.value;
     if (contentTypeInHeader != null) {
       extraOptions[_contentType] = contentTypeInHeader;
@@ -404,17 +448,20 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     if (responseType != null) {
       final v = responseType.peek("responseType")?.objectValue;
       log.info("ResponseType  :  ${v?.getField("index")?.toIntValue()}");
-      final rsType = ResponseType.values.firstWhere((it) {
-        return responseType
-            .peek("responseType")
-            ?.objectValue
-            .getField('index')
-            ?.toIntValue() ==
-            it.index;
-      }, orElse: () {
-        log.warning("responseType cast error!!!!");
-        return ResponseType.json;
-      });
+      final rsType = ResponseType.values.firstWhere(
+        (it) {
+          return responseType
+                  .peek("responseType")
+                  ?.objectValue
+                  .getField('index')
+                  ?.toIntValue() ==
+              it.index;
+        },
+        orElse: () {
+          log.warning("responseType cast error!!!!");
+          return ResponseType.json;
+        },
+      );
 
       extraOptions["responseType"] = refer(rsType.toString());
     }
@@ -461,7 +508,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     }
 
     final bool isWrappered =
-    _typeChecker(retrofit.HttpResponse).isExactlyType(wrapperedReturnType);
+        _typeChecker(retrofit.HttpResponse).isExactlyType(wrapperedReturnType);
     final returnType = isWrappered
         ? _getResponseType(wrapperedReturnType)
         : wrapperedReturnType;
@@ -471,10 +518,12 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           refer("final $_resultVar = await $_dioVar.fetch")
               .call([options], {}, [refer("void")]).statement,
         );
-        blocks.add(Code("""
+        blocks.add(
+          Code("""
       final httpResponse = HttpResponse(null, $_resultVar);
       $returnAsyncWrapper httpResponse;
-      """));
+      """),
+        );
       } else {
         blocks.add(
           refer("await $_dioVar.fetch")
@@ -487,74 +536,106 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       if (_typeChecker(List).isExactlyType(returnType) ||
           _typeChecker(BuiltList).isExactlyType(returnType)) {
         if (_isBasicType(innerReturnType)) {
-          blocks.add(declareFinal(_resultVar)
-              .assign(
-              refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
-              .statement);
+          blocks.add(
+            declareFinal(_resultVar)
+                .assign(
+                  refer("await $_dioVar.fetch<List<dynamic>>").call([options]),
+                )
+                .statement,
+          );
 
-          blocks.add(declareFinal('value')
-              .assign(refer('$_resultVar.data')
-              .propertyIf(thisNullable: returnType.isNullable, name: 'cast')
-              .call([], {}, [
-            refer(
-                '${_displayString(innerReturnType, withNullability: innerReturnType?.isNullable ?? false)}')
-          ]))
-              .statement);
+          blocks.add(
+            declareFinal('value')
+                .assign(
+                  refer('$_resultVar.data')
+                      .propertyIf(
+                          thisNullable: returnType.isNullable, name: 'cast')
+                      .call([], {}, [
+                    refer(
+                      '${_displayString(innerReturnType, withNullability: innerReturnType?.isNullable ?? false)}',
+                    )
+                  ]),
+                )
+                .statement,
+          );
         } else {
-          blocks.add(declareFinal(_resultVar)
-              .assign(
-              refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
-              .statement);
+          blocks.add(
+            declareFinal(_resultVar)
+                .assign(
+                  refer("await $_dioVar.fetch<List<dynamic>>").call([options]),
+                )
+                .statement,
+          );
           if (clientAnnotation.parser == retrofit.Parser.FlutterCompute) {
-            blocks.add(declareVar('value')
-                .assign(refer('$_resultVar.data').conditionalIsNullIf(
-                thisNullable: returnType.isNullable,
-                whenFalse: refer('await compute').call([
-                  refer(
-                      'deserialize${_displayString(innerReturnType)}List'),
-                  refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
-                ])))
-                .statement);
+            blocks.add(
+              declareVar('value')
+                  .assign(
+                    refer('$_resultVar.data').conditionalIsNullIf(
+                      thisNullable: returnType.isNullable,
+                      whenFalse: refer('await compute').call([
+                        refer(
+                          'deserialize${_displayString(innerReturnType)}List',
+                        ),
+                        refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
+                      ]),
+                    ),
+                  )
+                  .statement,
+            );
           } else {
             final Reference mapperCode;
             switch (clientAnnotation.parser) {
               case retrofit.Parser.MapSerializable:
                 mapperCode = refer(
-                    '(dynamic i) => ${_displayString(innerReturnType)}.fromMap(i as Map<String,dynamic>)');
+                  '(dynamic i) => ${_displayString(innerReturnType)}.fromMap(i as Map<String,dynamic>)',
+                );
                 break;
               case retrofit.Parser.JsonSerializable:
                 if (innerReturnType?.isNullable == true) {
                   mapperCode = refer(
-                      '(dynamic i) => i == null ? null : ${_displayString(innerReturnType)}.fromJson(i as Map<String,dynamic>)');
+                    '(dynamic i) => i == null ? null : ${_displayString(innerReturnType)}.fromJson(i as Map<String,dynamic>)',
+                  );
                 } else {
                   mapperCode = refer(
-                      '(dynamic i) => ${_displayString(innerReturnType)}.fromJson(i as Map<String,dynamic>)');
+                    '(dynamic i) => ${_displayString(innerReturnType)}.fromJson(i as Map<String,dynamic>)',
+                  );
                 }
                 break;
               case retrofit.Parser.DartJsonMapper:
                 mapperCode = refer(
-                    '(dynamic i) => JsonMapper.fromMap<${_displayString(innerReturnType)}>(i as Map<String,dynamic>)!');
+                  '(dynamic i) => JsonMapper.fromMap<${_displayString(innerReturnType)}>(i as Map<String,dynamic>)!',
+                );
                 break;
               case retrofit.Parser.FlutterCompute:
                 throw Exception('Unreachable code');
             }
-            blocks.add(declareVar('value')
-                .assign(refer('$_resultVar.data')
-                .propertyIf(
-                thisNullable: returnType.isNullable, name: 'map')
-                .call([mapperCode])
-                .property('toList')
-                .call([]))
-                .statement);
+            blocks.add(
+              declareVar('value')
+                  .assign(
+                    refer('$_resultVar.data')
+                        .propertyIf(
+                          thisNullable: returnType.isNullable,
+                          name: 'map',
+                        )
+                        .call([mapperCode])
+                        .property('toList')
+                        .call([]),
+                  )
+                  .statement,
+            );
           }
         }
       } else if (_typeChecker(Map).isExactlyType(returnType) ||
           _typeChecker(BuiltMap).isExactlyType(returnType)) {
         final types = _getResponseInnerTypes(returnType)!;
-        blocks.add(declareFinal(_resultVar)
-            .assign(refer("await $_dioVar.fetch<Map<String,dynamic>>")
-            .call([options]))
-            .statement);
+        blocks.add(
+          declareFinal(_resultVar)
+              .assign(
+                refer("await $_dioVar.fetch<Map<String,dynamic>>")
+                    .call([options]),
+              )
+              .statement,
+        );
 
         /// assume the first type is a basic type
         if (types.length > 1) {
@@ -611,20 +692,31 @@ You should create a new class to encapsulate the response.
                 break;
             }
             if (future) {
-              blocks.add(declareVar('value')
-                  .assign(refer('Map.fromEntries').call([
-                refer('await Future.wait').call([
-                  refer('$_resultVar.data!.entries.map').call([mapperCode])
-                ])
-              ]))
-                  .statement);
+              blocks.add(
+                declareVar('value')
+                    .assign(
+                      refer('Map.fromEntries').call([
+                        refer('await Future.wait').call([
+                          refer('$_resultVar.data!.entries.map')
+                              .call([mapperCode])
+                        ])
+                      ]),
+                    )
+                    .statement,
+              );
             } else {
-              blocks.add(declareVar('value')
-                  .assign(refer('$_resultVar.data')
-                  .propertyIf(
-                  thisNullable: returnType.isNullable, name: 'map')
-                  .call([mapperCode]))
-                  .statement);
+              blocks.add(
+                declareVar('value')
+                    .assign(
+                      refer('$_resultVar.data')
+                          .propertyIf(
+                        thisNullable: returnType.isNullable,
+                        name: 'map',
+                      )
+                          .call([mapperCode]),
+                    )
+                    .statement,
+              );
             }
           } else if (!_isBasicType(secondType)) {
             final Reference mapperCode;
@@ -632,16 +724,19 @@ You should create a new class to encapsulate the response.
             switch (clientAnnotation.parser) {
               case retrofit.Parser.MapSerializable:
                 mapperCode = refer(
-                    '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromMap(v as Map<String, dynamic>))');
+                  '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromMap(v as Map<String, dynamic>))',
+                );
                 break;
               case retrofit.Parser.JsonSerializable:
                 mapperCode = refer(
-                    '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromJson(v as Map<String, dynamic>))');
+                  '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromJson(v as Map<String, dynamic>))',
+                );
 
                 break;
               case retrofit.Parser.DartJsonMapper:
                 mapperCode = refer(
-                    '(k, dynamic v) => MapEntry(k, JsonMapper.fromMap<${_displayString(secondType)}>(v as Map<String, dynamic>)!)');
+                  '(k, dynamic v) => MapEntry(k, JsonMapper.fromMap<${_displayString(secondType)}>(v as Map<String, dynamic>)!)',
+                );
                 break;
               case retrofit.Parser.FlutterCompute:
                 log.warning('''
@@ -656,72 +751,103 @@ You should create a new class to encapsulate the response.
                 break;
             }
             if (future) {
-              blocks.add(declareVar('value')
-                  .assign(refer('$_resultVar.data').conditionalIsNullIf(
-                  thisNullable: returnType.isNullable,
-                  whenFalse: refer('Map.fromEntries').call([
-                    refer('await Future.wait').call([
-                      refer('$_resultVar.data!.entries.map')
-                          .call([mapperCode])
-                    ])
-                  ])))
-                  .statement);
+              blocks.add(
+                declareVar('value')
+                    .assign(
+                      refer('$_resultVar.data').conditionalIsNullIf(
+                        thisNullable: returnType.isNullable,
+                        whenFalse: refer('Map.fromEntries').call([
+                          refer('await Future.wait').call([
+                            refer('$_resultVar.data!.entries.map')
+                                .call([mapperCode])
+                          ])
+                        ]),
+                      ),
+                    )
+                    .statement,
+              );
             } else {
-              blocks.add(declareVar('value')
-                  .assign(refer('$_resultVar.data')
-                  .propertyIf(
-                  thisNullable: returnType.isNullable, name: 'map')
-                  .call([mapperCode]))
-                  .statement);
+              blocks.add(
+                declareVar('value')
+                    .assign(
+                      refer('$_resultVar.data')
+                          .propertyIf(
+                        thisNullable: returnType.isNullable,
+                        name: 'map',
+                      )
+                          .call([mapperCode]),
+                    )
+                    .statement,
+              );
             }
           } else {
-            blocks.add(declareFinal('value')
-                .assign(refer('$_resultVar.data')
-                .propertyIf(
-                thisNullable: returnType.isNullable, name: 'cast')
-                .call([], {}, [
-              refer('${_displayString(firstType)}'),
-              refer('${_displayString(secondType)}'),
-            ]))
-                .statement);
+            blocks.add(
+              declareFinal('value')
+                  .assign(
+                    refer('$_resultVar.data')
+                        .propertyIf(
+                      thisNullable: returnType.isNullable,
+                      name: 'cast',
+                    )
+                        .call([], {}, [
+                      refer('${_displayString(firstType)}'),
+                      refer('${_displayString(secondType)}'),
+                    ]),
+                  )
+                  .statement,
+            );
           }
         } else {
           blocks.add(Code("final value = $_resultVar.data!;"));
         }
       } else {
         if (_isBasicType(returnType)) {
-          blocks.add(declareFinal(_resultVar)
-              .assign(
-              refer("await $_dioVar.fetch<${_displayString(returnType)}>")
-                  .call([options]))
-              .statement);
-          blocks.add(declareFinal('value')
-              .assign(refer('$_resultVar.data')
-              .asNoNullIf(returnNullable: returnType.isNullable))
-              .statement);
+          blocks.add(
+            declareFinal(_resultVar)
+                .assign(
+                  refer("await $_dioVar.fetch<${_displayString(returnType)}>")
+                      .call([options]),
+                )
+                .statement,
+          );
+          blocks.add(
+            declareFinal('value')
+                .assign(
+                  refer('$_resultVar.data')
+                      .asNoNullIf(returnNullable: returnType.isNullable),
+                )
+                .statement,
+          );
         } else if (returnType.toString() == 'dynamic') {
-          blocks.add(declareFinal(_resultVar)
-              .assign(refer("await $_dioVar.fetch").call([options]))
-              .statement);
+          blocks.add(
+            declareFinal(_resultVar)
+                .assign(refer("await $_dioVar.fetch").call([options]))
+                .statement,
+          );
           blocks.add(Code("final value = $_resultVar.data;"));
         } else {
           final fetchType = returnType.isNullable
               ? "Map<String,dynamic>?"
               : "Map<String,dynamic>";
-          blocks.add(declareFinal(_resultVar)
-              .assign(refer("await $_dioVar"
-              ".fetch<$fetchType>")
-              .call([options]))
-              .statement);
+          blocks.add(
+            declareFinal(_resultVar)
+                .assign(
+                  refer("await $_dioVar"
+                          ".fetch<$fetchType>")
+                      .call([options]),
+                )
+                .statement,
+          );
           Expression mapperCode;
           switch (clientAnnotation.parser) {
             case retrofit.Parser.MapSerializable:
               mapperCode = refer(
-                  '${_displayString(returnType)}.fromMap($_resultVar.data!)');
+                '${_displayString(returnType)}.fromMap($_resultVar.data!)',
+              );
               break;
             case retrofit.Parser.JsonSerializable:
               final genericArgumentFactories =
-              isGenericArgumentFactories(returnType);
+                  isGenericArgumentFactories(returnType);
 
               var typeArgs = returnType is ParameterizedType
                   ? returnType.typeArguments
@@ -730,40 +856,52 @@ You should create a new class to encapsulate the response.
               if (typeArgs.length > 0 && genericArgumentFactories) {
                 //Remove the outermost nullable modifier
                 //see NullableDynamicNullableInnerGenericTypeShouldBeCastedAsMap from generator/test/src/generator_test_src.dart:1529
-                var displayString = _displayString(returnType,
-                    withNullability: innerReturnType?.isNullable ?? false);
+                var displayString = _displayString(
+                  returnType,
+                  withNullability: innerReturnType?.isNullable ?? false,
+                );
                 displayString = displayString.endsWith("?")
                     ? displayString.substring(0, displayString.length - 1)
                     : displayString;
                 mapperCode = refer(
-                    '${displayString}.fromJson($_resultVar.data!,${_getInnerJsonSerializableMapperFn(returnType)})');
+                  '${displayString}.fromJson($_resultVar.data!,${_getInnerJsonSerializableMapperFn(returnType)})',
+                );
               } else {
                 mapperCode = refer(
-                    '${_displayString(returnType)}.fromJson($_resultVar.data!)');
+                  '${_displayString(returnType)}.fromJson($_resultVar.data!)',
+                );
               }
               break;
             case retrofit.Parser.DartJsonMapper:
               mapperCode = refer(
-                  'JsonMapper.fromMap<${_displayString(returnType)}>($_resultVar.data!)!');
+                'JsonMapper.fromMap<${_displayString(returnType)}>($_resultVar.data!)!',
+              );
               break;
             case retrofit.Parser.FlutterCompute:
               mapperCode = refer(
-                  'await compute(deserialize${_displayString(returnType)}, $_resultVar.data!)');
+                'await compute(deserialize${_displayString(returnType)}, $_resultVar.data!)',
+              );
               break;
           }
-          blocks.add(declareFinal('value')
-              .assign(refer('$_resultVar.data').conditionalIsNullIf(
-            thisNullable: returnType.isNullable,
-            whenFalse: mapperCode,
-          ))
-              .statement);
+          blocks.add(
+            declareFinal('value')
+                .assign(
+                  refer('$_resultVar.data').conditionalIsNullIf(
+                    thisNullable: returnType.isNullable,
+                    whenFalse: mapperCode,
+                  ),
+                )
+                .statement,
+          );
         }
       }
       if (isWrappered) {
-        blocks.add(Code("""
+        blocks.add(
+          Code("""
       final httpResponse = HttpResponse(value, $_resultVar);
       $returnAsyncWrapper httpResponse;
-      """));
+      """),
+        );
       } else {
         blocks.add(Code("$returnAsyncWrapper value;"));
       }
@@ -778,7 +916,7 @@ You should create a new class to encapsulate the response.
       return false;
     }
     final constDartObj =
-    metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
+        metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
     var genericArgumentFactories = false;
     if (constDartObj != null &&
         (!_typeChecker(List).isExactlyType(dartType) &&
@@ -801,7 +939,7 @@ You should create a new class to encapsulate the response.
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
         var typeArgs =
-        genericType is ParameterizedType ? genericType.typeArguments : [];
+            genericType is ParameterizedType ? genericType.typeArguments : [];
         var mapperVal;
 
         var genericTypeString = "${_displayString(genericType)}";
@@ -847,10 +985,10 @@ You should create a new class to encapsulate the response.
           } else {
             if (isGenericArgumentFactories(arg))
               mappedVal +=
-              "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(arg)}),";
+                  "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(arg)}),";
             else
               mappedVal +=
-              "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
+                  "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
           }
           else {
             mappedVal += "${_getInnerJsonSerializableMapperFn(arg)}";
@@ -878,20 +1016,20 @@ You should create a new class to encapsulate the response.
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
         var typeArgs =
-        genericType is ParameterizedType ? genericType.typeArguments : [];
+            genericType is ParameterizedType ? genericType.typeArguments : [];
         var mapperVal;
 
         if (typeArgs.length > 0 &&
             isGenericArgumentFactories(genericType) &&
             genericType != null) {
           mapperVal =
-          '(value) => value.map((value) => ${_getInnerJsonDeSerializableMapperFn(genericType)}).toList()';
+              '(value) => value.map((value) => ${_getInnerJsonDeSerializableMapperFn(genericType)}).toList()';
         } else {
           if (_isBasicType(genericType)) {
             mapperVal = '(value) => value';
           } else {
             mapperVal =
-            '(value) => value.map((value) => value.toJson()).toList()';
+                '(value) => value.map((value) => value.toJson()).toList()';
           }
         }
         return mapperVal;
@@ -905,7 +1043,7 @@ You should create a new class to encapsulate the response.
           } else {
             if (isGenericArgumentFactories(arg))
               mappedVal =
-              '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
+                  '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
             else {
               mappedVal = "(value) => value";
             }
@@ -926,10 +1064,11 @@ You should create a new class to encapsulate the response.
   }
 
   Expression _parseOptions(
-      MethodElement m,
-      Map<String, Expression> namedArguments,
-      List<Code> blocks,
-      Map<String, Expression> extraOptions) {
+    MethodElement m,
+    Map<String, Expression> namedArguments,
+    List<Code> blocks,
+    Map<String, Expression> extraOptions,
+  ) {
     final annoOptions = _getAnnotation(m, retrofit.DioOptions);
     if (annoOptions == null) {
       final args = Map<String, Expression>.from(extraOptions)
@@ -963,43 +1102,57 @@ You should create a new class to encapsulate the response.
             .newInstance([], args)
             .property('compose')
             .call(
-          [refer(_dioVar).property('options'), path],
-          composeArguments,
-        )
+              [refer(_dioVar).property('options'), path],
+              composeArguments,
+            )
             .property('copyWith')
             .call([], {
-          _baseUrlVar: baseUrl.ifNullThen(
-              refer(_dioVar).property('options').property('baseUrl'))
-        })
+              _baseUrlVar: baseUrl.ifNullThen(
+                refer(_dioVar).property('options').property('baseUrl'),
+              )
+            })
       ], {}, [
         type
       ]);
     } else {
       hasCustomOptions = true;
-      blocks.add(declareFinal("newOptions")
-          .assign(refer("newRequestOptions")
-          .call([refer(annoOptions.item1.displayName)]))
-          .statement);
+      blocks.add(
+        declareFinal("newOptions")
+            .assign(
+              refer("newRequestOptions")
+                  .call([refer(annoOptions.item1.displayName)]),
+            )
+            .statement,
+      );
       final newOptions = refer("newOptions");
-      blocks.add(newOptions
-          .property(_extraVar)
-          .property('addAll')
-          .call([extraOptions.remove(_extraVar)!]).statement);
-      blocks.add(newOptions.property('headers').property('addAll').call(
-          [refer(_dioVar).property('options').property('headers')]).statement);
-      blocks.add(newOptions
-          .property('headers')
-          .property('addAll')
-          .call([extraOptions.remove('headers')!]).statement);
+      blocks.add(
+        newOptions
+            .property(_extraVar)
+            .property('addAll')
+            .call([extraOptions.remove(_extraVar)!]).statement,
+      );
+      blocks.add(
+        newOptions.property('headers').property('addAll').call(
+          [refer(_dioVar).property('options').property('headers')],
+        ).statement,
+      );
+      blocks.add(
+        newOptions
+            .property('headers')
+            .property('addAll')
+            .call([extraOptions.remove('headers')!]).statement,
+      );
       return newOptions
           .property('copyWith')
           .call(
-          [],
-          Map.from(extraOptions)
-            ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
-            ..[_path] = namedArguments[_path]!
-            ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
-                refer(_dioVar).property('options').property('baseUrl')))
+            [],
+            Map.from(extraOptions)
+              ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
+              ..[_path] = namedArguments[_path]!
+              ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
+                    refer(_dioVar).property('options').property('baseUrl'),
+                  ),
+          )
           .cascade('data')
           .assign(namedArguments[_dataVar]!);
     }
@@ -1011,13 +1164,15 @@ You should create a new class to encapsulate the response.
         ..name = "newRequestOptions"
         ..returns = refer("RequestOptions")
 
-      /// required parameters
-        ..requiredParameters.add(Parameter((p) {
-          p.name = "options";
-          p.type = refer("Object?").type;
-        }))
+        /// required parameters
+        ..requiredParameters.add(
+          Parameter((p) {
+            p.name = "options";
+            p.type = refer("Object?").type;
+          }),
+        )
 
-      /// add method body
+        /// add method body
         ..body = Code('''
          if (options is RequestOptions) {
             return options as RequestOptions;
@@ -1090,7 +1245,10 @@ You should create a new class to encapsulate the response.
   }
 
   void _generateQueries(
-      MethodElement m, List<Code> blocks, String _queryParamsVar) {
+    MethodElement m,
+    List<Code> blocks,
+    String _queryParamsVar,
+  ) {
     final queries = _getAnnotations(m, retrofit.Query);
     final queryParameters = queries.map((p, ConstantReader r) {
       final key = r.peek("value")?.stringValue ?? p.displayName;
@@ -1116,7 +1274,8 @@ You should create a new class to encapsulate the response.
             break;
           case retrofit.Parser.FlutterCompute:
             value = refer(
-                'await compute(serialize${_displayString(p.type)}, ${p.displayName})');
+              'await compute(serialize${_displayString(p.type)}, ${p.displayName})',
+            );
             break;
         }
       }
@@ -1124,9 +1283,12 @@ You should create a new class to encapsulate the response.
     });
 
     final queryMap = _getAnnotations(m, retrofit.Queries);
-    blocks.add(declareFinal(_queryParamsVar)
-        .assign(literalMap(queryParameters, refer("String"), refer("dynamic")))
-        .statement);
+    blocks.add(
+      declareFinal(_queryParamsVar)
+          .assign(
+              literalMap(queryParameters, refer("String"), refer("dynamic")))
+          .statement,
+    );
     for (final p in queryMap.keys) {
       final type = p.type;
       final displayName = p.displayName;
@@ -1150,7 +1312,8 @@ You should create a new class to encapsulate the response.
             break;
           case retrofit.Parser.FlutterCompute:
             value = refer(
-                'await compute(serialize${_displayString(p.type)}, ${p.displayName})');
+              'await compute(serialize${_displayString(p.type)}, ${p.displayName})',
+            );
             break;
         }
       }
@@ -1175,12 +1338,17 @@ You should create a new class to encapsulate the response.
   }
 
   void _generateRequestBody(
-      List<Code> blocks, String _dataVar, MethodElement m) {
+    List<Code> blocks,
+    String _dataVar,
+    MethodElement m,
+  ) {
     final _noBody = _getMethodAnnotationByType(m, retrofit.NoBody);
     if (_noBody != null) {
-      blocks.add(declareFinal(_dataVar, type: refer('String?'))
-          .assign(refer('null'))
-          .statement);
+      blocks.add(
+        declareFinal(_dataVar, type: refer('String?'))
+            .assign(refer('null'))
+            .statement,
+      );
       return;
     }
 
@@ -1191,45 +1359,73 @@ You should create a new class to encapsulate the response.
           annotation!.item2.peek('nullToAbsent')?.boolValue ?? false;
       final bodyTypeElement = _bodyName.type.element2;
       if (TypeChecker.fromRuntime(Map).isAssignableFromType(_bodyName.type)) {
-        blocks.add(declareFinal(_dataVar)
-            .assign(literalMap({}, refer("String"), refer("dynamic")))
-            .statement);
+        blocks.add(
+          declareFinal(_dataVar)
+              .assign(literalMap({}, refer("String"), refer("dynamic")))
+              .statement,
+        );
 
-        blocks.add(refer("$_dataVar.addAll").call([
-          refer(
-              "${_bodyName.displayName}${m.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''}")
-        ]).statement);
+        blocks.add(
+          refer("$_dataVar.addAll").call([
+            refer(
+              "${_bodyName.displayName}${m.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''}",
+            )
+          ]).statement,
+        );
         if (nullToAbsent)
           blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
       } else if (bodyTypeElement != null &&
           ((_typeChecker(List).isExactly(bodyTypeElement) ||
-              _typeChecker(BuiltList).isExactly(bodyTypeElement)) &&
+                  _typeChecker(BuiltList).isExactly(bodyTypeElement)) &&
               !_isBasicInnerType(_bodyName.type))) {
         switch (clientAnnotation.parser) {
           case retrofit.Parser.JsonSerializable:
           case retrofit.Parser.DartJsonMapper:
-            blocks.add(declareFinal(_dataVar).assign(refer('''
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(
+                    refer('''
             ${_bodyName.displayName}.map((e) => e.toJson()).toList()
-            ''')).statement);
+            '''),
+                  )
+                  .statement,
+            );
             break;
           case retrofit.Parser.MapSerializable:
-            blocks.add(declareFinal(_dataVar).assign(refer('''
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(
+                    refer('''
             ${_bodyName.displayName}.map((e) => e.toMap()).toList()
-            ''')).statement);
+            '''),
+                  )
+                  .statement,
+            );
             break;
           case retrofit.Parser.FlutterCompute:
-            blocks.add(declareFinal(_dataVar).assign(refer('''
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(
+                    refer('''
             await compute(serialize${_displayString(_genericOf(_bodyName.type))}List, ${_bodyName.displayName})
-            ''')).statement);
+            '''),
+                  )
+                  .statement,
+            );
             break;
         }
       } else if (bodyTypeElement != null &&
           _typeChecker(File).isExactly(bodyTypeElement)) {
-        blocks.add(declareFinal(_dataVar)
-            .assign(refer("Stream").property("fromIterable").call([
-          refer("${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])")
-        ]))
-            .statement);
+        blocks.add(
+          declareFinal(_dataVar)
+              .assign(
+                refer("Stream").property("fromIterable").call([
+                  refer(
+                      "${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])")
+                ]),
+              )
+              .statement,
+        );
       } else if (_bodyName.type.element2 is ClassElement) {
         final ele = _bodyName.type.element2 as ClassElement;
         if (clientAnnotation.parser == retrofit.Parser.MapSerializable) {
@@ -1237,44 +1433,56 @@ You should create a new class to encapsulate the response.
           if (toMap == null) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toMap()` method which return a Map.\n"
-                    "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
-            blocks.add(declareFinal(_dataVar)
-                .assign(refer(_bodyName.displayName))
-                .statement);
+                "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(refer(_bodyName.displayName))
+                  .statement,
+            );
           } else {
-            blocks.add(declareFinal(_dataVar)
-                .assign(literalMap({}, refer("String"), refer("dynamic")))
-                .statement);
-            blocks.add(refer("$_dataVar.addAll").call([
-              refer("${_bodyName.displayName}?.toMap() ?? <String,dynamic>{}")
-            ]).statement);
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(literalMap({}, refer("String"), refer("dynamic")))
+                  .statement,
+            );
+            blocks.add(
+              refer("$_dataVar.addAll").call([
+                refer("${_bodyName.displayName}?.toMap() ?? <String,dynamic>{}")
+              ]).statement,
+            );
           }
         } else {
           if (_missingToJson(ele)) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toJson()` method which return a Map.\n"
-                    "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
-            blocks.add(declareFinal(_dataVar)
-                .assign(refer(_bodyName.displayName))
-                .statement);
+                "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(refer(_bodyName.displayName))
+                  .statement,
+            );
           } else if (_missingSerialize(ele.enclosingElement3, _bodyName.type)) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `serialize${_displayString(_bodyName.type)}()` method which returns a Map.\n"
-                    "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
-            blocks.add(declareFinal(_dataVar)
-                .assign(refer(_bodyName.displayName))
-                .statement);
+                "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(refer(_bodyName.displayName))
+                  .statement,
+            );
           } else {
-            blocks.add(declareFinal(_dataVar)
-                .assign(literalMap({}, refer("String"), refer("dynamic")))
-                .statement);
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(literalMap({}, refer("String"), refer("dynamic")))
+                  .statement,
+            );
 
             final _bodyType = _bodyName.type;
             final genericArgumentFactories =
-            isGenericArgumentFactories(_bodyType);
+                isGenericArgumentFactories(_bodyType);
 
             var typeArgs =
-            _bodyType is ParameterizedType ? _bodyType.typeArguments : [];
+                _bodyType is ParameterizedType ? _bodyType.typeArguments : [];
 
             String toJsonCode = '';
             if (typeArgs.length > 0 && genericArgumentFactories) {
@@ -1286,34 +1494,44 @@ You should create a new class to encapsulate the response.
               case retrofit.Parser.DartJsonMapper:
                 if (_bodyName.type.nullabilitySuffix !=
                     NullabilitySuffix.question) {
-                  blocks.add(refer("$_dataVar.addAll").call([
-                    refer('${_bodyName.displayName}.toJson($toJsonCode)')
-                  ]).statement);
+                  blocks.add(
+                    refer("$_dataVar.addAll").call([
+                      refer('${_bodyName.displayName}.toJson($toJsonCode)')
+                    ]).statement,
+                  );
                 } else {
-                  blocks.add(refer("$_dataVar.addAll").call([
-                    refer(
-                        '${_bodyName.displayName}?.toJson($toJsonCode) ?? <String,dynamic>{}')
-                  ]).statement);
+                  blocks.add(
+                    refer("$_dataVar.addAll").call([
+                      refer(
+                        '${_bodyName.displayName}?.toJson($toJsonCode) ?? <String,dynamic>{}',
+                      )
+                    ]).statement,
+                  );
                 }
                 break;
               case retrofit.Parser.FlutterCompute:
                 if (_bodyName.type.nullabilitySuffix !=
                     NullabilitySuffix.question) {
-                  blocks.add(refer("$_dataVar.addAll").call([
-                    refer(
-                        'await compute(serialize${_displayString(_bodyName.type)}, ${_bodyName.displayName})')
-                  ]).statement);
+                  blocks.add(
+                    refer("$_dataVar.addAll").call([
+                      refer(
+                        'await compute(serialize${_displayString(_bodyName.type)}, ${_bodyName.displayName})',
+                      )
+                    ]).statement,
+                  );
                 } else {
-                  blocks.add(refer("$_dataVar.addAll").call([
-                    refer('''${_bodyName.displayName} == null
+                  blocks.add(
+                    refer("$_dataVar.addAll").call([
+                      refer('''${_bodyName.displayName} == null
                       ? <String, dynamic>{}
                       : await compute(serialize${_displayString(_bodyName.type)}, ${_bodyName.displayName})
                   ''')
-                  ]).statement);
+                    ]).statement,
+                  );
                 }
                 break;
               case retrofit.Parser.MapSerializable:
-              // Unreachable code
+                // Unreachable code
                 break;
             }
 
@@ -1323,9 +1541,9 @@ You should create a new class to encapsulate the response.
         }
       } else {
         /// @Body annotations with no type are assinged as is
-        blocks.add(declareFinal(_dataVar)
-            .assign(refer(_bodyName.displayName))
-            .statement);
+        blocks.add(
+          declareFinal(_dataVar).assign(refer(_bodyName.displayName)).statement,
+        );
       }
 
       return;
@@ -1338,7 +1556,8 @@ You should create a new class to encapsulate the response.
       final isFileField = _typeChecker(File).isAssignableFromType(p.type);
       if (isFileField) {
         log.severe(
-            'File is not support by @Field(). Please use @Part() instead.');
+          'File is not support by @Field(). Please use @Part() instead.',
+        );
       }
       return MapEntry(literal(fieldName), refer(p.displayName));
     });
@@ -1354,22 +1573,36 @@ You should create a new class to encapsulate the response.
     final parts = _getAnnotations(m, retrofit.Part);
     if (parts.isNotEmpty) {
       if (m.parameters.length == 1 && m.parameters.first.type.isDartCoreMap) {
-        blocks.add(declareFinal(_dataVar)
-            .assign(refer('FormData').newInstanceNamed('fromMap',
-            [CodeExpression(Code(m.parameters.first.displayName))]))
-            .statement);
+        blocks.add(
+          declareFinal(_dataVar)
+              .assign(
+                refer('FormData').newInstanceNamed(
+                  'fromMap',
+                  [CodeExpression(Code(m.parameters.first.displayName))],
+                ),
+              )
+              .statement,
+        );
         return;
       } else if (m.parameters.length == 2 &&
           m.parameters[1].type.isDartCoreMap) {
-        blocks.add(declareFinal(_dataVar)
-            .assign(refer('FormData').newInstanceNamed(
-            'fromMap', [CodeExpression(Code(m.parameters[1].displayName))]))
-            .statement);
+        blocks.add(
+          declareFinal(_dataVar)
+              .assign(
+                refer('FormData').newInstanceNamed(
+                  'fromMap',
+                  [CodeExpression(Code(m.parameters[1].displayName))],
+                ),
+              )
+              .statement,
+        );
         return;
       }
-      blocks.add(declareFinal(_dataVar)
-          .assign(refer('FormData').newInstance([]))
-          .statement);
+      blocks.add(
+        declareFinal(_dataVar)
+            .assign(refer('FormData').newInstance([]))
+            .statement,
+      );
 
       parts.forEach((p, r) {
         final fieldName = r.peek("name")?.stringValue ??
@@ -1383,7 +1616,7 @@ You should create a new class to encapsulate the response.
           final fileName = fileNameValue != null
               ? literalString(fileNameValue)
               : refer(p.displayName)
-              .property('path.split(Platform.pathSeparator).last');
+                  .property('path.split(Platform.pathSeparator).last');
 
           final uploadFileInfo = refer('$MultipartFile.fromFileSync').call([
             refer(p.displayName).property('path')
@@ -1391,32 +1624,33 @@ You should create a new class to encapsulate the response.
             'filename': fileName,
             if (contentType != null)
               'contentType':
-              refer("MediaType", 'package:http_parser/http_parser.dart')
-                  .property('parse')
-                  .call([literal(contentType)])
+                  refer("MediaType", 'package:http_parser/http_parser.dart')
+                      .property('parse')
+                      .call([literal(contentType)])
           });
 
           final optinalFile = m.parameters
-              .firstWhereOrNull((pp) => pp.displayName == p.displayName)
-              ?.isOptional ??
+                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+                  ?.isOptional ??
               false;
 
           final returnCode =
               refer(_dataVar).property('files').property("add").call([
-                refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
-              ]).statement;
+            refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
+          ]).statement;
           if (optinalFile) {
             final condication =
                 refer(p.displayName).notEqualTo(literalNull).code;
             blocks.addAll(
-                [Code("if("), condication, Code(") {"), returnCode, Code("}")]);
+              [Code("if("), condication, Code(") {"), returnCode, Code("}")],
+            );
           } else {
             blocks.add(returnCode);
           }
         } else if (_displayString(p.type) == "List<int>") {
           final optionalFile = m.parameters
-              .firstWhereOrNull((pp) => pp.displayName == p.displayName)
-              ?.isOptional ??
+                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+                  ?.isOptional ??
               false;
           final fileName = r.peek("fileName")?.stringValue;
           final conType = contentType == null
@@ -1424,7 +1658,7 @@ You should create a new class to encapsulate the response.
               : 'contentType: MediaType.parse(${literal(contentType)}),';
           final returnCode =
               refer(_dataVar).property('files').property("add").call([
-                refer(''' 
+            refer(''' 
                   MapEntry(
                 '${fieldName}',
                 MultipartFile.fromBytes(${p.displayName},
@@ -1433,11 +1667,12 @@ You should create a new class to encapsulate the response.
                     ${conType}
                     ))
                   ''')
-              ]).statement;
+          ]).statement;
           if (optionalFile) {
             final condition = refer(p.displayName).notEqualTo(literalNull).code;
             blocks.addAll(
-                [Code("if("), condition, Code(") {"), returnCode, Code("}")]);
+              [Code("if("), condition, Code(") {"), returnCode, Code("}")],
+            );
           } else {
             blocks.add(returnCode);
           }
@@ -1450,9 +1685,9 @@ You should create a new class to encapsulate the response.
             final conType = contentType == null
                 ? ""
                 : 'contentType: MediaType.parse(${literal(contentType)}),';
-            blocks
-                .add(refer(_dataVar).property('files').property("addAll").call([
-              refer(''' 
+            blocks.add(
+              refer(_dataVar).property('files').property("addAll").call([
+                refer(''' 
                   ${p.displayName}.map((i) => MapEntry(
                 '${fieldName}',
                 MultipartFile.fromBytes(i,
@@ -1460,7 +1695,8 @@ You should create a new class to encapsulate the response.
                     ${conType}
                     )))
                   ''')
-            ]).statement);
+              ]).statement,
+            );
           } else if (_isBasicType(innerType) ||
               ((innerType != null) &&
                   (_typeChecker(Map).isExactlyType(innerType) ||
@@ -1469,14 +1705,16 @@ You should create a new class to encapsulate the response.
                       _typeChecker(BuiltList).isExactlyType(innerType)))) {
             var value = _isBasicType(innerType) ? 'i' : 'jsonEncode(i)';
             var nullableInfix =
-            (p.type.nullabilitySuffix == NullabilitySuffix.question)
-                ? '?'
-                : '';
-            blocks.add(refer('''
+                (p.type.nullabilitySuffix == NullabilitySuffix.question)
+                    ? '?'
+                    : '';
+            blocks.add(
+              refer('''
             ${p.displayName}$nullableInfix.forEach((i){
               ${_dataVar}.fields.add(MapEntry(${literal(fieldName)},${value}));
             })
-            ''').statement);
+            ''').statement,
+            );
           } else if (innerType != null &&
               _typeChecker(File).isExactlyType(innerType)) {
             final conType = contentType == null
@@ -1485,9 +1723,9 @@ You should create a new class to encapsulate the response.
             if (p.type.isNullable) {
               blocks.add(Code("if (${p.displayName} != null) {"));
             }
-            blocks
-                .add(refer(_dataVar).property('files').property("addAll").call([
-              refer(''' 
+            blocks.add(
+              refer(_dataVar).property('files').property("addAll").call([
+                refer(''' 
                   ${p.displayName}.map((i) => MapEntry(
                 '${fieldName}',
                 MultipartFile.fromFileSync(i.path,
@@ -1495,7 +1733,8 @@ You should create a new class to encapsulate the response.
                     ${conType}
                     )))
                   ''')
-            ]).statement);
+              ]).statement,
+            );
             if (p.type.isNullable) {
               blocks.add(Code("}"));
             }
@@ -1504,14 +1743,15 @@ You should create a new class to encapsulate the response.
             if (p.type.isNullable) {
               blocks.add(Code("if (${p.displayName} != null) {"));
             }
-            blocks
-                .add(refer(_dataVar).property('files').property("addAll").call([
-              refer(''' 
+            blocks.add(
+              refer(_dataVar).property('files').property("addAll").call([
+                refer(''' 
                   ${p.displayName}.map((i) => MapEntry(
                 '${fieldName}',
                 i))
                   ''')
-            ]).statement);
+              ]).statement,
+            );
             if (p.type.isNullable) {
               blocks.add(Code("}"));
             }
@@ -1520,11 +1760,13 @@ You should create a new class to encapsulate the response.
             if (_missingToJson(ele)) {
               throw Exception("toJson() method have to add to ${p.type}");
             } else {
-              blocks
-                  .add(refer(_dataVar).property('fields').property("add").call([
-                refer("MapEntry").newInstance(
-                    [literal(fieldName), refer("jsonEncode(${p.displayName})")])
-              ]).statement);
+              blocks.add(
+                refer(_dataVar).property('fields').property("add").call([
+                  refer("MapEntry").newInstance(
+                    [literal(fieldName), refer("jsonEncode(${p.displayName})")],
+                  )
+                ]).statement,
+              );
             }
           } else {
             throw Exception("Unknown error!");
@@ -1533,62 +1775,76 @@ You should create a new class to encapsulate the response.
           if (p.type.nullabilitySuffix == NullabilitySuffix.question) {
             blocks.add(Code("if (${p.displayName} != null) {"));
           }
-          blocks.add(refer(_dataVar).property('fields').property("add").call([
-            refer("MapEntry").newInstance([
-              literal(fieldName),
-              if (_typeChecker(String).isExactlyType(p.type))
-                refer(p.displayName)
-              else
-                refer(p.displayName).property('toString').call([])
-            ])
-          ]).statement);
+          blocks.add(
+            refer(_dataVar).property('fields').property("add").call([
+              refer("MapEntry").newInstance([
+                literal(fieldName),
+                if (_typeChecker(String).isExactlyType(p.type))
+                  refer(p.displayName)
+                else
+                  refer(p.displayName).property('toString').call([])
+              ])
+            ]).statement,
+          );
           if (p.type.nullabilitySuffix == NullabilitySuffix.question) {
             blocks.add(Code("}"));
           }
         } else if (_typeChecker(Map).isExactlyType(p.type) ||
             _typeChecker(BuiltMap).isExactlyType(p.type)) {
-          blocks.add(refer(_dataVar).property('fields').property("add").call([
-            refer("MapEntry").newInstance(
-                [literal(fieldName), refer("jsonEncode(${p.displayName})")])
-          ]).statement);
+          blocks.add(
+            refer(_dataVar).property('fields').property("add").call([
+              refer("MapEntry").newInstance(
+                [literal(fieldName), refer("jsonEncode(${p.displayName})")],
+              )
+            ]).statement,
+          );
         } else if (p.type.element2 is ClassElement) {
           final ele = p.type.element2 as ClassElement;
           if (_missingToJson(ele)) {
             throw Exception("toJson() method have to add to ${p.type}");
           } else {
-            blocks.add(refer(_dataVar).property('fields').property("add").call([
-              refer("MapEntry").newInstance([
-                literal(fieldName),
-                refer(
-                    "jsonEncode(${p.displayName}${p.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''})")
-              ])
-            ]).statement);
+            blocks.add(
+              refer(_dataVar).property('fields').property("add").call([
+                refer("MapEntry").newInstance([
+                  literal(fieldName),
+                  refer(
+                    "jsonEncode(${p.displayName}${p.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''})",
+                  )
+                ])
+              ]).statement,
+            );
           }
         } else {
-          blocks.add(refer(_dataVar).property('fields').property("add").call([
-            refer("MapEntry")
-                .newInstance([literal(fieldName), refer(p.displayName)])
-          ]).statement);
+          blocks.add(
+            refer(_dataVar).property('fields').property("add").call([
+              refer("MapEntry")
+                  .newInstance([literal(fieldName), refer(p.displayName)])
+            ]).statement,
+          );
         }
       });
       return;
     }
 
     /// There is no body
-    blocks.add(declareFinal(_dataVar)
-        .assign(literalMap({}, refer("String"), refer("dynamic")))
-        .statement);
+    blocks.add(
+      declareFinal(_dataVar)
+          .assign(literalMap({}, refer("String"), refer("dynamic")))
+          .statement,
+    );
   }
 
   Map<String, Expression> _generateHeaders(MethodElement m) {
     final headers = _getMethodAnnotations(m, retrofit.Headers)
         .map((e) => e.peek('value'))
-        .map((value) => value?.mapValue.map((k, v) {
-      return MapEntry(
-        k?.toStringValue() ?? 'null',
-        literal(v?.toStringValue()),
-      );
-    }))
+        .map(
+          (value) => value?.mapValue.map((k, v) {
+            return MapEntry(
+              k?.toStringValue() ?? 'null',
+              literal(v?.toStringValue()),
+            );
+          }),
+        )
         .fold<Map<String, Expression>>({}, (p, e) => p..addAll(e ?? {}));
 
     final annosInParam = _getAnnotations(m, retrofit.Header);
@@ -1644,38 +1900,47 @@ You should create a new class to encapsulate the response.
   }
 
   void _generateExtra(
-      MethodElement m, List<Code> blocks, String localExtraVar) {
-    blocks.add(declareConst(localExtraVar)
-        .assign(literalMap(
-      _getMethodAnnotations(m, retrofit.Extra)
-          .map((e) => e.peek('data'))
-          .map((data) => data?.mapValue.map((k, v) {
-        return MapEntry(
-          k?.toStringValue() ??
-              (throw InvalidGenerationSourceError(
-                'Invalid key for extra Map, only `String` keys are supported',
-                element: m,
-                todo: 'Make sure all keys are of string type',
-              )),
-          v?.toBoolValue() ??
-              v?.toDoubleValue() ??
-              v?.toIntValue() ??
-              v?.toStringValue() ??
-              v?.toListValue() ??
-              v?.toMapValue() ??
-              v?.toSetValue() ??
-              v?.toSymbolValue() ??
-              (v?.toTypeValue() ??
-                  (v != null
-                      ? Code(revivedLiteral(v))
-                      : Code('null'))),
-        );
-      }))
-          .fold<Map<String, Object>>({}, (p, e) => p..addAll(e ?? {})),
-      refer('String'),
-      refer('dynamic'),
-    ))
-        .statement);
+    MethodElement m,
+    List<Code> blocks,
+    String localExtraVar,
+  ) {
+    blocks.add(
+      declareConst(localExtraVar)
+          .assign(
+            literalMap(
+              _getMethodAnnotations(m, retrofit.Extra)
+                  .map((e) => e.peek('data'))
+                  .map(
+                    (data) => data?.mapValue.map((k, v) {
+                      return MapEntry(
+                        k?.toStringValue() ??
+                            (throw InvalidGenerationSourceError(
+                              'Invalid key for extra Map, only `String` keys are supported',
+                              element: m,
+                              todo: 'Make sure all keys are of string type',
+                            )),
+                        v?.toBoolValue() ??
+                            v?.toDoubleValue() ??
+                            v?.toIntValue() ??
+                            v?.toStringValue() ??
+                            v?.toListValue() ??
+                            v?.toMapValue() ??
+                            v?.toSetValue() ??
+                            v?.toSymbolValue() ??
+                            (v?.toTypeValue() ??
+                                (v != null
+                                    ? Code(revivedLiteral(v))
+                                    : Code('null'))),
+                      );
+                    }),
+                  )
+                  .fold<Map<String, Object>>({}, (p, e) => p..addAll(e ?? {})),
+              refer('String'),
+              refer('dynamic'),
+            ),
+          )
+          .statement,
+    );
   }
 
   bool _missingToJson(ClassElement ele) {
@@ -1697,24 +1962,29 @@ You should create a new class to encapsulate the response.
       case retrofit.Parser.MapSerializable:
         return false;
       case retrofit.Parser.FlutterCompute:
-        return !ele.functions.any((element) =>
-        element.name == 'serialize${_displayString(type)}' &&
-            element.parameters.length == 1 &&
-            _displayString(element.parameters[0].type) == _displayString(type));
+        return !ele.functions.any(
+          (element) =>
+              element.name == 'serialize${_displayString(type)}' &&
+              element.parameters.length == 1 &&
+              _displayString(element.parameters[0].type) ==
+                  _displayString(type),
+        );
     }
   }
 }
 
 Builder generatorFactoryBuilder(BuilderOptions options) => SharedPartBuilder(
-    [RetrofitGenerator(RetrofitOptions.fromOptions(options))], "retrofit");
+      [RetrofitGenerator(RetrofitOptions.fromOptions(options))],
+      "retrofit",
+    );
 
 /// Returns `$revived($args $kwargs)`, this won't have ending semi-colon (`;`).
 /// [object] must not be null.
 /// [object] is assumed to be a constant.
 String revivedLiteral(
-    Object object, {
-      DartEmitter? dartEmitter,
-    }) {
+  Object object, {
+  DartEmitter? dartEmitter,
+}) {
   dartEmitter ??= DartEmitter();
 
   ArgumentError.checkNotNull(object, 'object');
@@ -1730,8 +2000,11 @@ String revivedLiteral(
     revived = object.revive();
   }
   if (revived == null) {
-    throw ArgumentError.value(object, 'object',
-        'Only `Revivable`, `DartObject`, `ConstantReader` are supported values');
+    throw ArgumentError.value(
+      object,
+      'object',
+      'Only `Revivable`, `DartObject`, `ConstantReader` are supported values',
+    );
   }
 
   String instantiation = '';
@@ -1780,9 +2053,12 @@ String revivedLiteral(
     }
 
     if (constant.isMap) {
-      return literalMap(Map.fromIterables(
+      return literalMap(
+        Map.fromIterables(
           constant.mapValue.keys.map(objectToSpec),
-          constant.mapValue.values.map(objectToSpec)));
+          constant.mapValue.values.map(objectToSpec),
+        ),
+      );
       // return literal(constant.mapValue);
     }
 
@@ -1828,7 +2104,7 @@ String revivedLiteral(
 extension DartTypeStreamAnnotation on DartType {
   bool get isDartAsyncStream {
     final element =
-    this.element2 != null ? null : this.element2 as ClassElement;
+        this.element2 != null ? null : this.element2 as ClassElement;
     if (element == null) {
       return false;
     }
@@ -1841,7 +2117,7 @@ String _displayString(dynamic e, {bool withNullability = false}) {
     return e.getDisplayString(withNullability: withNullability);
   } catch (error) {
     if (error is TypeError) {
-      return e.getDisplayString();
+      return e.getDisplayString(withNullability: withNullability);
     } else {
       rethrow;
     }

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -436,9 +436,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       namedArguments[_onReceiveProgress] =
           refer(receiveProgress.item1.displayName);
 
-    final wrapperedReturnType = _getResponseType(m.returnType);
-    final autoCastResponse = (globalOptions.autoCastResponse ??
-        (clientAnnotation.autoCastResponse ?? true));
+    final wrappedReturnType = _getResponseType(m.returnType);
+    final autoCastResponse = globalOptions.autoCastResponse ??
+        (clientAnnotation.autoCastResponse ?? true);
 
     final options = _parseOptions(m, namedArguments, blocks, extraOptions);
 
@@ -450,8 +450,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       return Block.of(blocks);
     }
 
-    if (wrapperedReturnType == null ||
-        "void" == wrapperedReturnType.toString()) {
+    if (wrappedReturnType == null || "void" == wrappedReturnType.toString()) {
       blocks.add(
         refer("await $_dioVar.fetch")
             .call([options], {}, [refer("void")]).statement,

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -24,8 +24,8 @@ class RetrofitOptions {
 
   RetrofitOptions.fromOptions([BuilderOptions? options])
       : autoCastResponse =
-      (options?.config['auto_cast_response']?.toString() ?? 'true') ==
-          'true';
+            (options?.config['auto_cast_response']?.toString() ?? 'true') ==
+                'true';
 }
 
 class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
@@ -46,7 +46,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   static const _path = 'path';
   var hasCustomOptions = false;
 
-  /// Global options sepcefied in the `build.yaml`
+  /// Global options specified in the `build.yaml`
   final RetrofitOptions globalOptions;
 
   RetrofitGenerator(this.globalOptions);
@@ -87,7 +87,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         ..fields.addAll([_buildDioFiled(), _buildBaseUrlFiled(baseUrl)])
         ..constructors.addAll(
           annotClassConsts.map(
-                (e) => _generateConstructor(baseUrl, superClassConst: e),
+            (e) => _generateConstructor(baseUrl, superClassConst: e),
           ),
         )
         ..methods.addAll(_parseMethods(element));
@@ -114,16 +114,16 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     ..modifier = FieldModifier.final$);
 
   Field _buildBaseUrlFiled(String? url) => Field((m) {
-    m
-      ..name = _baseUrlVar
-      ..type = refer("String?")
-      ..modifier = FieldModifier.var$;
-  });
+        m
+          ..name = _baseUrlVar
+          ..type = refer("String?")
+          ..modifier = FieldModifier.var$;
+      });
 
   Constructor _generateConstructor(
-      String? url, {
-        ConstructorElement? superClassConst,
-      }) =>
+    String? url, {
+    ConstructorElement? superClassConst,
+  }) =>
       Constructor((c) {
         c.requiredParameters.add(Parameter((p) => p
           ..name = _dioVar
@@ -167,20 +167,20 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       });
 
   Iterable<Method> _parseMethods(ClassElement element) => (<MethodElement>[]
-    ..addAll(element.methods)
-    ..addAll(element.mixins.expand((i) => i.methods)))
-      .where((MethodElement m) {
-    final methodAnnot = _getMethodAnnotation(m);
-    return methodAnnot != null &&
-        m.isAbstract &&
-        (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
-  }).map((m) => _generateMethod(m)!);
+            ..addAll(element.methods)
+            ..addAll(element.mixins.expand((i) => i.methods)))
+          .where((MethodElement m) {
+        final methodAnnot = _getMethodAnnotation(m);
+        return methodAnnot != null &&
+            m.isAbstract &&
+            (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
+      }).map((m) => _generateMethod(m)!);
 
   String _generateTypeParameterizedName(TypeParameterizedElement element) =>
       element.displayName +
-          (element.typeParameters.isNotEmpty
-              ? '<${element.typeParameters.join(',')}>'
-              : '');
+      (element.typeParameters.isNotEmpty
+          ? '<${element.typeParameters.join(',')}>'
+          : '');
 
   final _methodsAnnotations = const [
     retrofit.GET,
@@ -205,7 +205,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   ConstantReader? _getMethodAnnotationByType(MethodElement method, Type type) {
     final annot =
-    _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
+        _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
     if (annot != null) return ConstantReader(annot);
     return null;
   }
@@ -305,15 +305,15 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   Method? _generateMethod(MethodElement m) {
-    final httpMehod = _getMethodAnnotation(m);
-    if (httpMehod == null) {
+    final httpMethod = _getMethodAnnotation(m);
+    if (httpMethod == null) {
       return null;
     }
 
     return Method((mm) {
       mm
         ..returns =
-        refer(_displayString(m.type.returnType, withNullability: true))
+            refer(_displayString(m.type.returnType, withNullability: true))
         ..name = m.displayName
         ..types.addAll(m.typeParameters.map((e) => refer(e.name)))
         ..modifier = m.returnType.isDartAsyncFuture
@@ -325,22 +325,22 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       mm.requiredParameters.addAll(m.parameters
           .where((it) => it.isRequiredPositional)
           .map((it) => Parameter((p) => p
-        ..name = it.name
-        ..named = it.isNamed)));
+            ..name = it.name
+            ..named = it.isNamed)));
 
       /// optional positional or named parameters
       mm.optionalParameters.addAll(m.parameters
           .where((i) => i.isOptional || i.isRequiredNamed)
           .map((it) => Parameter((p) => p
-        ..required = (it.isNamed &&
-            it.type.nullabilitySuffix == NullabilitySuffix.none &&
-            !it.hasDefaultValue)
-        ..name = it.name
-        ..named = it.isNamed
-        ..defaultTo = it.defaultValueCode == null
-            ? null
-            : Code(it.defaultValueCode!))));
-      mm.body = _generateRequest(m, httpMehod);
+            ..required = (it.isNamed &&
+                it.type.nullabilitySuffix == NullabilitySuffix.none &&
+                !it.hasDefaultValue)
+            ..name = it.name
+            ..named = it.isNamed
+            ..defaultTo = it.defaultValueCode == null
+                ? null
+                : Code(it.defaultValueCode!))));
+      mm.body = _generateRequest(m, httpMethod);
     });
   }
 
@@ -357,7 +357,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   Code _generateRequest(MethodElement m, ConstantReader httpMethod) {
     final returnAsyncWrapper =
-    m.returnType.isDartAsyncFuture ? 'return' : 'yield';
+        m.returnType.isDartAsyncFuture ? 'return' : 'yield';
     final path = _generatePath(m, httpMethod);
     final blocks = <Code>[];
 
@@ -367,9 +367,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     Map<String, Expression> headers = _generateHeaders(m);
     blocks.add(declareFinal(_localHeadersVar)
         .assign(literalMap(
-        headers.map((k, v) => MapEntry(literalString(k, raw: true), v)),
-        refer("String"),
-        refer("dynamic")))
+            headers.map((k, v) => MapEntry(literalString(k, raw: true), v)),
+            refer("String"),
+            refer("dynamic")))
         .statement);
 
     if (headers.isNotEmpty) {
@@ -406,10 +406,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       log.info("ResponseType  :  ${v?.getField("index")?.toIntValue()}");
       final rsType = ResponseType.values.firstWhere((it) {
         return responseType
-            .peek("responseType")
-            ?.objectValue
-            .getField('index')
-            ?.toIntValue() ==
+                .peek("responseType")
+                ?.objectValue
+                .getField('index')
+                ?.toIntValue() ==
             it.index;
       }, orElse: () {
         log.warning("responseType cast error!!!!");
@@ -459,13 +459,12 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       return Block.of(blocks);
     }
 
-    final bool isWrappered =
-    _typeChecker(retrofit.HttpResponse).isExactlyType(wrapperedReturnType);
-    final returnType = isWrappered
-        ? _getResponseType(wrapperedReturnType)
-        : wrapperedReturnType;
+    final bool isWrapped =
+        _typeChecker(retrofit.HttpResponse).isExactlyType(wrappedReturnType);
+    final returnType =
+        isWrapped ? _getResponseType(wrappedReturnType) : wrappedReturnType;
     if (returnType == null || "void" == returnType.toString()) {
-      if (isWrappered) {
+      if (isWrapped) {
         blocks.add(
           refer("final $_resultVar = await $_dioVar.fetch")
               .call([options], {}, [refer("void")]).statement,
@@ -488,31 +487,31 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         if (_isBasicType(innerReturnType)) {
           blocks.add(declareFinal(_resultVar)
               .assign(
-              refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
+                  refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
               .statement);
 
           blocks.add(declareFinal('value')
               .assign(refer('$_resultVar.data')
-              .propertyIf(thisNullable: returnType.isNullable, name: 'cast')
-              .call([], {}, [
-            refer(
-                '${_displayString(innerReturnType, withNullability: innerReturnType?.isNullable ?? false)}')
-          ]))
+                  .propertyIf(thisNullable: returnType.isNullable, name: 'cast')
+                  .call([], {}, [
+                refer(
+                    '${_displayString(innerReturnType, withNullability: innerReturnType?.isNullable ?? false)}')
+              ]))
               .statement);
         } else {
           blocks.add(declareFinal(_resultVar)
               .assign(
-              refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
+                  refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
               .statement);
           if (clientAnnotation.parser == retrofit.Parser.FlutterCompute) {
             blocks.add(declareVar('value')
                 .assign(refer('$_resultVar.data').conditionalIsNullIf(
-                thisNullable: returnType.isNullable,
-                whenFalse: refer('await compute').call([
-                  refer(
-                      'deserialize${_displayString(innerReturnType)}List'),
-                  refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
-                ])))
+                    thisNullable: returnType.isNullable,
+                    whenFalse: refer('await compute').call([
+                      refer(
+                          'deserialize${_displayString(innerReturnType)}List'),
+                      refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
+                    ])))
                 .statement);
           } else {
             final Reference mapperCode;
@@ -539,11 +538,11 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             }
             blocks.add(declareVar('value')
                 .assign(refer('$_resultVar.data')
-                .propertyIf(
-                thisNullable: returnType.isNullable, name: 'map')
-                .call([mapperCode])
-                .property('toList')
-                .call([]))
+                    .propertyIf(
+                        thisNullable: returnType.isNullable, name: 'map')
+                    .call([mapperCode])
+                    .property('toList')
+                    .call([]))
                 .statement);
           }
         }
@@ -552,7 +551,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         final types = _getResponseInnerTypes(returnType)!;
         blocks.add(declareFinal(_resultVar)
             .assign(refer("await $_dioVar.fetch<Map<String,dynamic>>")
-            .call([options]))
+                .call([options]))
             .statement);
 
         /// assume the first type is a basic type
@@ -612,17 +611,17 @@ You should create a new class to encapsulate the response.
             if (future) {
               blocks.add(declareVar('value')
                   .assign(refer('Map.fromEntries').call([
-                refer('await Future.wait').call([
-                  refer('$_resultVar.data!.entries.map').call([mapperCode])
-                ])
-              ]))
+                    refer('await Future.wait').call([
+                      refer('$_resultVar.data!.entries.map').call([mapperCode])
+                    ])
+                  ]))
                   .statement);
             } else {
               blocks.add(declareVar('value')
                   .assign(refer('$_resultVar.data')
-                  .propertyIf(
-                  thisNullable: returnType.isNullable, name: 'map')
-                  .call([mapperCode]))
+                      .propertyIf(
+                          thisNullable: returnType.isNullable, name: 'map')
+                      .call([mapperCode]))
                   .statement);
             }
           } else if (!_isBasicType(secondType)) {
@@ -657,31 +656,31 @@ You should create a new class to encapsulate the response.
             if (future) {
               blocks.add(declareVar('value')
                   .assign(refer('$_resultVar.data').conditionalIsNullIf(
-                  thisNullable: returnType.isNullable,
-                  whenFalse: refer('Map.fromEntries').call([
-                    refer('await Future.wait').call([
-                      refer('$_resultVar.data!.entries.map')
-                          .call([mapperCode])
-                    ])
-                  ])))
+                      thisNullable: returnType.isNullable,
+                      whenFalse: refer('Map.fromEntries').call([
+                        refer('await Future.wait').call([
+                          refer('$_resultVar.data!.entries.map')
+                              .call([mapperCode])
+                        ])
+                      ])))
                   .statement);
             } else {
               blocks.add(declareVar('value')
                   .assign(refer('$_resultVar.data')
-                  .propertyIf(
-                  thisNullable: returnType.isNullable, name: 'map')
-                  .call([mapperCode]))
+                      .propertyIf(
+                          thisNullable: returnType.isNullable, name: 'map')
+                      .call([mapperCode]))
                   .statement);
             }
           } else {
             blocks.add(declareFinal('value')
                 .assign(refer('$_resultVar.data')
-                .propertyIf(
-                thisNullable: returnType.isNullable, name: 'cast')
-                .call([], {}, [
-              refer('${_displayString(firstType)}'),
-              refer('${_displayString(secondType)}'),
-            ]))
+                    .propertyIf(
+                        thisNullable: returnType.isNullable, name: 'cast')
+                    .call([], {}, [
+                  refer('${_displayString(firstType)}'),
+                  refer('${_displayString(secondType)}'),
+                ]))
                 .statement);
           }
         } else {
@@ -691,12 +690,12 @@ You should create a new class to encapsulate the response.
         if (_isBasicType(returnType)) {
           blocks.add(declareFinal(_resultVar)
               .assign(
-              refer("await $_dioVar.fetch<${_displayString(returnType)}>")
-                  .call([options]))
+                  refer("await $_dioVar.fetch<${_displayString(returnType)}>")
+                      .call([options]))
               .statement);
           blocks.add(declareFinal('value')
               .assign(refer('$_resultVar.data')
-              .asNoNullIf(returnNullable: returnType.isNullable))
+                  .asNoNullIf(returnNullable: returnType.isNullable))
               .statement);
         } else if (returnType.toString() == 'dynamic') {
           blocks.add(declareFinal(_resultVar)
@@ -709,8 +708,8 @@ You should create a new class to encapsulate the response.
               : "Map<String,dynamic>";
           blocks.add(declareFinal(_resultVar)
               .assign(refer("await $_dioVar"
-              ".fetch<$fetchType>")
-              .call([options]))
+                      ".fetch<$fetchType>")
+                  .call([options]))
               .statement);
           Expression mapperCode;
           switch (clientAnnotation.parser) {
@@ -720,7 +719,7 @@ You should create a new class to encapsulate the response.
               break;
             case retrofit.Parser.JsonSerializable:
               final genericArgumentFactories =
-              isGenericArgumentFactories(returnType);
+                  isGenericArgumentFactories(returnType);
 
               var typeArgs = returnType is ParameterizedType
                   ? returnType.typeArguments
@@ -752,13 +751,13 @@ You should create a new class to encapsulate the response.
           }
           blocks.add(declareFinal('value')
               .assign(refer('$_resultVar.data').conditionalIsNullIf(
-            thisNullable: returnType.isNullable,
-            whenFalse: mapperCode,
-          ))
+                thisNullable: returnType.isNullable,
+                whenFalse: mapperCode,
+              ))
               .statement);
         }
       }
-      if (isWrappered) {
+      if (isWrapped) {
         blocks.add(Code("""
       final httpResponse = HttpResponse(value, $_resultVar);
       $returnAsyncWrapper httpResponse;
@@ -777,7 +776,7 @@ You should create a new class to encapsulate the response.
       return false;
     }
     final constDartObj =
-    metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
+        metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
     var genericArgumentFactories = false;
     if (constDartObj != null &&
         (!_typeChecker(List).isExactlyType(dartType) &&
@@ -800,7 +799,7 @@ You should create a new class to encapsulate the response.
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
         var typeArgs =
-        genericType is ParameterizedType ? genericType.typeArguments : [];
+            genericType is ParameterizedType ? genericType.typeArguments : [];
         var mapperVal;
 
         var genericTypeString = "${_displayString(genericType)}";
@@ -846,10 +845,10 @@ You should create a new class to encapsulate the response.
           } else {
             if (isGenericArgumentFactories(arg))
               mappedVal +=
-              "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(arg)}),";
+                  "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(arg)}),";
             else
               mappedVal +=
-              "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
+                  "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
           }
           else {
             mappedVal += "${_getInnerJsonSerializableMapperFn(arg)}";
@@ -877,20 +876,20 @@ You should create a new class to encapsulate the response.
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
         var typeArgs =
-        genericType is ParameterizedType ? genericType.typeArguments : [];
+            genericType is ParameterizedType ? genericType.typeArguments : [];
         var mapperVal;
 
         if (typeArgs.length > 0 &&
             isGenericArgumentFactories(genericType) &&
             genericType != null) {
           mapperVal =
-          '(value) => value.map((value) => ${_getInnerJsonDeSerializableMapperFn(genericType)}).toList()';
+              '(value) => value.map((value) => ${_getInnerJsonDeSerializableMapperFn(genericType)}).toList()';
         } else {
           if (_isBasicType(genericType)) {
             mapperVal = '(value) => value';
           } else {
             mapperVal =
-            '(value) => value.map((value) => value.toJson()).toList()';
+                '(value) => value.map((value) => value.toJson()).toList()';
           }
         }
         return mapperVal;
@@ -904,7 +903,7 @@ You should create a new class to encapsulate the response.
           } else {
             if (isGenericArgumentFactories(arg))
               mappedVal =
-              '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
+                  '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
             else {
               mappedVal = "(value) => value";
             }
@@ -962,14 +961,14 @@ You should create a new class to encapsulate the response.
             .newInstance([], args)
             .property('compose')
             .call(
-          [refer(_dioVar).property('options'), path],
-          composeArguments,
-        )
+              [refer(_dioVar).property('options'), path],
+              composeArguments,
+            )
             .property('copyWith')
             .call([], {
-          _baseUrlVar: baseUrl.ifNullThen(
-              refer(_dioVar).property('options').property('baseUrl'))
-        })
+              _baseUrlVar: baseUrl.ifNullThen(
+                  refer(_dioVar).property('options').property('baseUrl'))
+            })
       ], {}, [
         type
       ]);
@@ -977,7 +976,7 @@ You should create a new class to encapsulate the response.
       hasCustomOptions = true;
       blocks.add(declareFinal("newOptions")
           .assign(refer("newRequestOptions")
-          .call([refer(annoOptions.item1.displayName)]))
+              .call([refer(annoOptions.item1.displayName)]))
           .statement);
       final newOptions = refer("newOptions");
       blocks.add(newOptions
@@ -993,12 +992,12 @@ You should create a new class to encapsulate the response.
       return newOptions
           .property('copyWith')
           .call(
-          [],
-          Map.from(extraOptions)
-            ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
-            ..[_path] = namedArguments[_path]!
-            ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
-                refer(_dioVar).property('options').property('baseUrl')))
+              [],
+              Map.from(extraOptions)
+                ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
+                ..[_path] = namedArguments[_path]!
+                ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
+                    refer(_dioVar).property('options').property('baseUrl')))
           .cascade('data')
           .assign(namedArguments[_dataVar]!);
     }
@@ -1010,13 +1009,13 @@ You should create a new class to encapsulate the response.
         ..name = "newRequestOptions"
         ..returns = refer("RequestOptions")
 
-      /// required parameters
+        /// required parameters
         ..requiredParameters.add(Parameter((p) {
           p.name = "options";
           p.type = refer("Object?").type;
         }))
 
-      /// add method body
+        /// add method body
         ..body = Code('''
          if (options is RequestOptions) {
             return options as RequestOptions;
@@ -1084,8 +1083,8 @@ You should create a new class to encapsulate the response.
   }
 
   bool _isBasicInnerType(DartType returnType) {
-    var innnerType = _genericOf(returnType);
-    return _isBasicType(innnerType);
+    var innerType = _genericOf(returnType);
+    return _isBasicType(innerType);
   }
 
   void _generateQueries(
@@ -1202,7 +1201,7 @@ You should create a new class to encapsulate the response.
           blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
       } else if (bodyTypeElement != null &&
           ((_typeChecker(List).isExactly(bodyTypeElement) ||
-              _typeChecker(BuiltList).isExactly(bodyTypeElement)) &&
+                  _typeChecker(BuiltList).isExactly(bodyTypeElement)) &&
               !_isBasicInnerType(_bodyName.type))) {
         switch (clientAnnotation.parser) {
           case retrofit.Parser.JsonSerializable:
@@ -1226,8 +1225,8 @@ You should create a new class to encapsulate the response.
           _typeChecker(File).isExactly(bodyTypeElement)) {
         blocks.add(declareFinal(_dataVar)
             .assign(refer("Stream").property("fromIterable").call([
-          refer("${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])")
-        ]))
+              refer("${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])")
+            ]))
             .statement);
       } else if (_bodyName.type.element2 is ClassElement) {
         final ele = _bodyName.type.element2 as ClassElement;
@@ -1236,7 +1235,7 @@ You should create a new class to encapsulate the response.
           if (toMap == null) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toMap()` method which return a Map.\n"
-                    "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
+                "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
             blocks.add(declareFinal(_dataVar)
                 .assign(refer(_bodyName.displayName))
                 .statement);
@@ -1252,14 +1251,14 @@ You should create a new class to encapsulate the response.
           if (_missingToJson(ele)) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toJson()` method which return a Map.\n"
-                    "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
+                "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
             blocks.add(declareFinal(_dataVar)
                 .assign(refer(_bodyName.displayName))
                 .statement);
           } else if (_missingSerialize(ele.enclosingElement3, _bodyName.type)) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `serialize${_displayString(_bodyName.type)}()` method which returns a Map.\n"
-                    "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
+                "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
             blocks.add(declareFinal(_dataVar)
                 .assign(refer(_bodyName.displayName))
                 .statement);
@@ -1270,10 +1269,10 @@ You should create a new class to encapsulate the response.
 
             final _bodyType = _bodyName.type;
             final genericArgumentFactories =
-            isGenericArgumentFactories(_bodyType);
+                isGenericArgumentFactories(_bodyType);
 
             var typeArgs =
-            _bodyType is ParameterizedType ? _bodyType.typeArguments : [];
+                _bodyType is ParameterizedType ? _bodyType.typeArguments : [];
 
             String toJsonCode = '';
             if (typeArgs.length > 0 && genericArgumentFactories) {
@@ -1312,7 +1311,7 @@ You should create a new class to encapsulate the response.
                 }
                 break;
               case retrofit.Parser.MapSerializable:
-              // Unreachable code
+                // Unreachable code
                 break;
             }
 
@@ -1321,7 +1320,7 @@ You should create a new class to encapsulate the response.
           }
         }
       } else {
-        /// @Body annotations with no type are assinged as is
+        /// @Body annotations with no type are assigned as is
         blocks.add(declareFinal(_dataVar)
             .assign(refer(_bodyName.displayName))
             .statement);
@@ -1355,14 +1354,14 @@ You should create a new class to encapsulate the response.
       if (m.parameters.length == 1 && m.parameters.first.type.isDartCoreMap) {
         blocks.add(declareFinal(_dataVar)
             .assign(refer('FormData').newInstanceNamed('fromMap',
-            [CodeExpression(Code(m.parameters.first.displayName))]))
+                [CodeExpression(Code(m.parameters.first.displayName))]))
             .statement);
         return;
       } else if (m.parameters.length == 2 &&
           m.parameters[1].type.isDartCoreMap) {
         blocks.add(declareFinal(_dataVar)
             .assign(refer('FormData').newInstanceNamed(
-            'fromMap', [CodeExpression(Code(m.parameters[1].displayName))]))
+                'fromMap', [CodeExpression(Code(m.parameters[1].displayName))]))
             .statement);
         return;
       }
@@ -1382,7 +1381,7 @@ You should create a new class to encapsulate the response.
           final fileName = fileNameValue != null
               ? literalString(fileNameValue)
               : refer(p.displayName)
-              .property('path.split(Platform.pathSeparator).last');
+                  .property('path.split(Platform.pathSeparator).last');
 
           final uploadFileInfo = refer('$MultipartFile.fromFileSync').call([
             refer(p.displayName).property('path')
@@ -1390,21 +1389,21 @@ You should create a new class to encapsulate the response.
             'filename': fileName,
             if (contentType != null)
               'contentType':
-              refer("MediaType", 'package:http_parser/http_parser.dart')
-                  .property('parse')
-                  .call([literal(contentType)])
+                  refer("MediaType", 'package:http_parser/http_parser.dart')
+                      .property('parse')
+                      .call([literal(contentType)])
           });
 
-          final optinalFile = m.parameters
-              .firstWhereOrNull((pp) => pp.displayName == p.displayName)
-              ?.isOptional ??
+          final optionalFile = m.parameters
+                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+                  ?.isOptional ??
               false;
 
           final returnCode =
               refer(_dataVar).property('files').property("add").call([
-                refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
-              ]).statement;
-          if (optinalFile) {
+            refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
+          ]).statement;
+          if (optionalFile) {
             final condication =
                 refer(p.displayName).notEqualTo(literalNull).code;
             blocks.addAll(
@@ -1414,8 +1413,8 @@ You should create a new class to encapsulate the response.
           }
         } else if (_displayString(p.type) == "List<int>") {
           final optionalFile = m.parameters
-              .firstWhereOrNull((pp) => pp.displayName == p.displayName)
-              ?.isOptional ??
+                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+                  ?.isOptional ??
               false;
           final fileName = r.peek("fileName")?.stringValue;
           final conType = contentType == null
@@ -1423,7 +1422,7 @@ You should create a new class to encapsulate the response.
               : 'contentType: MediaType.parse(${literal(contentType)}),';
           final returnCode =
               refer(_dataVar).property('files').property("add").call([
-                refer(''' 
+            refer(''' 
                   MapEntry(
                 '${fieldName}',
                 MultipartFile.fromBytes(${p.displayName},
@@ -1432,7 +1431,7 @@ You should create a new class to encapsulate the response.
                     ${conType}
                     ))
                   ''')
-              ]).statement;
+          ]).statement;
           if (optionalFile) {
             final condition = refer(p.displayName).notEqualTo(literalNull).code;
             blocks.addAll(
@@ -1468,9 +1467,9 @@ You should create a new class to encapsulate the response.
                       _typeChecker(BuiltList).isExactlyType(innerType)))) {
             var value = _isBasicType(innerType) ? 'i' : 'jsonEncode(i)';
             var nullableInfix =
-            (p.type.nullabilitySuffix == NullabilitySuffix.question)
-                ? '?'
-                : '';
+                (p.type.nullabilitySuffix == NullabilitySuffix.question)
+                    ? '?'
+                    : '';
             blocks.add(refer('''
             ${p.displayName}$nullableInfix.forEach((i){
               ${_dataVar}.fields.add(MapEntry(${literal(fieldName)},${value}));
@@ -1583,11 +1582,11 @@ You should create a new class to encapsulate the response.
     final headers = _getMethodAnnotations(m, retrofit.Headers)
         .map((e) => e.peek('value'))
         .map((value) => value?.mapValue.map((k, v) {
-      return MapEntry(
-        k?.toStringValue() ?? 'null',
-        literal(v?.toStringValue()),
-      );
-    }))
+              return MapEntry(
+                k?.toStringValue() ?? 'null',
+                literal(v?.toStringValue()),
+              );
+            }))
         .fold<Map<String, Expression>>({}, (p, e) => p..addAll(e ?? {}));
 
     final annosInParam = _getAnnotations(m, retrofit.Header);
@@ -1646,34 +1645,34 @@ You should create a new class to encapsulate the response.
       MethodElement m, List<Code> blocks, String localExtraVar) {
     blocks.add(declareConst(localExtraVar)
         .assign(literalMap(
-      _getMethodAnnotations(m, retrofit.Extra)
-          .map((e) => e.peek('data'))
-          .map((data) => data?.mapValue.map((k, v) {
-        return MapEntry(
-          k?.toStringValue() ??
-              (throw InvalidGenerationSourceError(
-                'Invalid key for extra Map, only `String` keys are supported',
-                element: m,
-                todo: 'Make sure all keys are of string type',
-              )),
-          v?.toBoolValue() ??
-              v?.toDoubleValue() ??
-              v?.toIntValue() ??
-              v?.toStringValue() ??
-              v?.toListValue() ??
-              v?.toMapValue() ??
-              v?.toSetValue() ??
-              v?.toSymbolValue() ??
-              (v?.toTypeValue() ??
-                  (v != null
-                      ? Code(revivedLiteral(v))
-                      : Code('null'))),
-        );
-      }))
-          .fold<Map<String, Object>>({}, (p, e) => p..addAll(e ?? {})),
-      refer('String'),
-      refer('dynamic'),
-    ))
+          _getMethodAnnotations(m, retrofit.Extra)
+              .map((e) => e.peek('data'))
+              .map((data) => data?.mapValue.map((k, v) {
+                    return MapEntry(
+                      k?.toStringValue() ??
+                          (throw InvalidGenerationSourceError(
+                            'Invalid key for extra Map, only `String` keys are supported',
+                            element: m,
+                            todo: 'Make sure all keys are of string type',
+                          )),
+                      v?.toBoolValue() ??
+                          v?.toDoubleValue() ??
+                          v?.toIntValue() ??
+                          v?.toStringValue() ??
+                          v?.toListValue() ??
+                          v?.toMapValue() ??
+                          v?.toSetValue() ??
+                          v?.toSymbolValue() ??
+                          (v?.toTypeValue() ??
+                              (v != null
+                                  ? Code(revivedLiteral(v))
+                                  : Code('null'))),
+                    );
+                  }))
+              .fold<Map<String, Object>>({}, (p, e) => p..addAll(e ?? {})),
+          refer('String'),
+          refer('dynamic'),
+        ))
         .statement);
   }
 
@@ -1697,7 +1696,7 @@ You should create a new class to encapsulate the response.
         return false;
       case retrofit.Parser.FlutterCompute:
         return !ele.functions.any((element) =>
-        element.name == 'serialize${_displayString(type)}' &&
+            element.name == 'serialize${_displayString(type)}' &&
             element.parameters.length == 1 &&
             _displayString(element.parameters[0].type) == _displayString(type));
     }
@@ -1711,9 +1710,9 @@ Builder generatorFactoryBuilder(BuilderOptions options) => SharedPartBuilder(
 /// [object] must not be null.
 /// [object] is assumed to be a constant.
 String revivedLiteral(
-    Object object, {
-      DartEmitter? dartEmitter,
-    }) {
+  Object object, {
+  DartEmitter? dartEmitter,
+}) {
   dartEmitter ??= DartEmitter();
 
   ArgumentError.checkNotNull(object, 'object');
@@ -1827,7 +1826,7 @@ String revivedLiteral(
 extension DartTypeStreamAnnotation on DartType {
   bool get isDartAsyncStream {
     final element =
-    this.element2 != null ? null : this.element2 as ClassElement;
+        this.element2 != null ? null : this.element2 as ClassElement;
     if (element == null) {
       return false;
     }

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1655,12 +1655,11 @@ You should create a new class to encapsulate the response.
             refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
           ]).statement;
           if (optionalFile) {
-            final condication =
-                refer(p.displayName).notEqualTo(literalNull).code;
+            final condition = refer(p.displayName).notEqualTo(literalNull).code;
             blocks.addAll(
               [
                 const Code("if("),
-                condication,
+                condition,
                 const Code(") {"),
                 returnCode,
                 const Code("}")

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -23,7 +23,9 @@ class RetrofitOptions {
   RetrofitOptions({this.autoCastResponse});
 
   RetrofitOptions.fromOptions([BuilderOptions? options])
-      : autoCastResponse = (options?.config['auto_cast_response']?.toString() ?? 'true') == 'true';
+      : autoCastResponse =
+            (options?.config['auto_cast_response']?.toString() ?? 'true') ==
+                'true';
 }
 
 class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
@@ -71,16 +73,17 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   String _implementClass(ClassElement element, ConstantReader? annotation) {
     final className = element.name;
-    final enumString = (annotation?.peek('parser')?.revive().accessor);
-    final parser = retrofit.Parser.values.firstWhereOrNull((e) => e.toString() == enumString);
+    final enumString = annotation?.peek('parser')?.revive().accessor;
+    final parser = retrofit.Parser.values
+        .firstWhereOrNull((e) => e.toString() == enumString);
     clientAnnotation = retrofit.RestApi(
-      autoCastResponse: (annotation?.peek('autoCastResponse')?.boolValue),
-      baseUrl: (annotation?.peek(_baseUrlVar)?.stringValue ?? ''),
-      parser: (parser ?? retrofit.Parser.JsonSerializable),
+      autoCastResponse: annotation?.peek('autoCastResponse')?.boolValue,
+      baseUrl: annotation?.peek(_baseUrlVar)?.stringValue ?? '',
+      parser: parser ?? retrofit.Parser.JsonSerializable,
     );
     final baseUrl = clientAnnotation.baseUrl;
-    final annotClassConsts =
-        element.constructors.where((c) => !c.isFactory && !c.isDefaultConstructor);
+    final annotClassConsts = element.constructors
+        .where((c) => !c.isFactory && !c.isDefaultConstructor);
     final classBuilder = Class((c) {
       c
         ..name = '_$className'
@@ -105,7 +108,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     });
 
     final emitter = DartEmitter();
-    return DartFormatter().format([_analyzerIgnores, classBuilder.accept(emitter)].join('\n\n'));
+    return DartFormatter()
+        .format([_analyzerIgnores, classBuilder.accept(emitter)].join('\n\n'));
   }
 
   Field _buildDioFiled() => Field(
@@ -169,11 +173,14 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               );
             }
           });
-          final paramList = constParams.map((e) => (e.isNamed ? '${e.name}: ' : '') + '${e.name}');
-          c.initializers.add(Code('$superConstName(' + paramList.join(',') + ')'));
+          final paramList = constParams
+              .map((e) => (e.isNamed ? '${e.name}: ' : '') + '${e.name}');
+          c.initializers
+              .add(Code('$superConstName(' + paramList.join(',') + ')'));
         }
         final block = [
-          if (url != null && url.isNotEmpty) Code("${_baseUrlVar} ??= ${literal(url)};"),
+          if (url != null && url.isNotEmpty)
+            Code("${_baseUrlVar} ??= ${literal(url)};"),
         ];
 
         if (!block.isEmpty) {
@@ -193,7 +200,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   String _generateTypeParameterizedName(TypeParameterizedElement element) =>
       element.displayName +
-      (element.typeParameters.isNotEmpty ? '<${element.typeParameters.join(',')}>' : '');
+      (element.typeParameters.isNotEmpty
+          ? '<${element.typeParameters.join(',')}>'
+          : '');
 
   final _methodsAnnotations = const [
     retrofit.GET,
@@ -217,7 +226,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   ConstantReader? _getMethodAnnotationByType(MethodElement method, Type type) {
-    final annot = _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
+    final annot =
+        _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
     if (annot != null) return ConstantReader(annot);
     return null;
   }
@@ -251,13 +261,19 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return _getMethodAnnotationByType(method, retrofit.DioResponseType);
   }
 
-  Iterable<ConstantReader> _getMethodAnnotations(MethodElement method, Type type) {
+  Iterable<ConstantReader> _getMethodAnnotations(
+    MethodElement method,
+    Type type,
+  ) {
     return _typeChecker(type)
         .annotationsOf(method, throwOnUnresolved: false)
         .map((e) => ConstantReader(e));
   }
 
-  Map<ParameterElement, ConstantReader> _getAnnotations(MethodElement m, Type type) {
+  Map<ParameterElement, ConstantReader> _getAnnotations(
+    MethodElement m,
+    Type type,
+  ) {
     var annot = <ParameterElement, ConstantReader>{};
     for (final p in m.parameters) {
       final a = _typeChecker(type).firstAnnotationOf(p);
@@ -268,7 +284,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return annot;
   }
 
-  Tuple2<ParameterElement, ConstantReader>? _getAnnotation(MethodElement m, Type type) {
+  Tuple2<ParameterElement, ConstantReader>? _getAnnotation(
+    MethodElement m,
+    Type type,
+  ) {
     for (final p in m.parameters) {
       final a = _typeChecker(type).firstAnnotationOf(p);
       if (a != null) {
@@ -279,11 +298,15 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   List<DartType>? _genericListOf(DartType type) {
-    return type is ParameterizedType && type.typeArguments.isNotEmpty ? type.typeArguments : null;
+    return type is ParameterizedType && type.typeArguments.isNotEmpty
+        ? type.typeArguments
+        : null;
   }
 
   DartType? _genericOf(DartType type) {
-    return type is InterfaceType && type.typeArguments.isNotEmpty ? type.typeArguments.first : null;
+    return type is InterfaceType && type.typeArguments.isNotEmpty
+        ? type.typeArguments.first
+        : null;
   }
 
   DartType? _getResponseType(DartType type) {
@@ -304,8 +327,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     if (generic.isDynamic) return null;
 
-    if (_typeChecker(List).isExactlyType(type) || _typeChecker(BuiltList).isExactlyType(type))
-      return generic;
+    if (_typeChecker(List).isExactlyType(type) ||
+        _typeChecker(BuiltList).isExactlyType(type)) return generic;
 
     return _getResponseInnerType(generic);
   }
@@ -318,12 +341,14 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     return Method((mm) {
       mm
-        ..returns = refer(_displayString(m.type.returnType, withNullability: true))
+        ..returns =
+            refer(_displayString(m.type.returnType, withNullability: true))
         ..name = m.displayName
         ..types.addAll(m.typeParameters.map((e) => refer(e.name)))
-        ..modifier =
-            m.returnType.isDartAsyncFuture ? MethodModifier.async : MethodModifier.asyncStar
-        ..annotations.add(CodeExpression(Code('override')));
+        ..modifier = m.returnType.isDartAsyncFuture
+            ? MethodModifier.async
+            : MethodModifier.asyncStar
+        ..annotations.add(const CodeExpression(Code('override')));
 
       /// required parameters
       mm.requiredParameters.addAll(
@@ -346,7 +371,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                       !it.hasDefaultValue)
                   ..name = it.name
                   ..named = it.isNamed
-                  ..defaultTo = it.defaultValueCode == null ? null : Code(it.defaultValueCode!),
+                  ..defaultTo = it.defaultValueCode == null
+                      ? null
+                      : Code(it.defaultValueCode!),
               ),
             ),
       );
@@ -368,7 +395,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   Code _generateRequest(MethodElement m, ConstantReader httpMethod) {
-    final returnAsyncWrapper = m.returnType.isDartAsyncFuture ? 'return' : 'yield';
+    final returnAsyncWrapper =
+        m.returnType.isDartAsyncFuture ? 'return' : 'yield';
     final path = _generatePath(m, httpMethod);
     final blocks = <Code>[];
 
@@ -389,7 +417,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     );
 
     if (headers.isNotEmpty) {
-      blocks.add(Code("${_localHeadersVar}.removeWhere((k, v) => v == null);"));
+      blocks.add(
+          const Code("${_localHeadersVar}.removeWhere((k, v) => v == null);"));
     }
 
     _generateRequestBody(blocks, _localDataVar, m);
@@ -401,7 +430,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     };
 
     final contentTypeInHeader = headers.entries
-        .firstWhereOrNull((i) => "Content-Type".toLowerCase() == i.key.toLowerCase())
+        .firstWhereOrNull(
+          (i) => "Content-Type".toLowerCase() == i.key.toLowerCase(),
+        )
         ?.value;
     if (contentTypeInHeader != null) {
       extraOptions[_contentType] = contentTypeInHeader;
@@ -409,7 +440,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final contentType = _getContentTypeAnnotation(m);
     if (contentType != null) {
-      extraOptions[_contentType] = literal(contentType.peek("mime")?.stringValue);
+      extraOptions[_contentType] =
+          literal(contentType.peek("mime")?.stringValue);
     }
 
     extraOptions[_baseUrlVar] = refer(_baseUrlVar);
@@ -420,7 +452,11 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       log.info("ResponseType  :  ${v?.getField("index")?.toIntValue()}");
       final rsType = ResponseType.values.firstWhere(
         (it) {
-          return responseType.peek("responseType")?.objectValue.getField('index')?.toIntValue() ==
+          return responseType
+                  .peek("responseType")
+                  ?.objectValue
+                  .getField('index')
+                  ?.toIntValue() ==
               it.index;
         },
         orElse: () {
@@ -437,7 +473,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     namedArguments[_dataVar] = refer(_localDataVar);
 
     final cancelToken = _getAnnotation(m, retrofit.CancelRequest);
-    if (cancelToken != null) namedArguments[_cancelToken] = refer(cancelToken.item1.displayName);
+    if (cancelToken != null)
+      namedArguments[_cancelToken] = refer(cancelToken.item1.displayName);
 
     final sendProgress = _getAnnotation(m, retrofit.SendProgress);
     if (sendProgress != null)
@@ -445,11 +482,12 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final receiveProgress = _getAnnotation(m, retrofit.ReceiveProgress);
     if (receiveProgress != null)
-      namedArguments[_onReceiveProgress] = refer(receiveProgress.item1.displayName);
+      namedArguments[_onReceiveProgress] =
+          refer(receiveProgress.item1.displayName);
 
     final wrappedReturnType = _getResponseType(m.returnType);
-    final autoCastResponse =
-        globalOptions.autoCastResponse ?? (clientAnnotation.autoCastResponse ?? true);
+    final autoCastResponse = globalOptions.autoCastResponse ??
+        (clientAnnotation.autoCastResponse ?? true);
 
     final options = _parseOptions(m, namedArguments, blocks, extraOptions);
 
@@ -463,14 +501,17 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     if (wrappedReturnType == null || "void" == wrappedReturnType.toString()) {
       blocks.add(
-        refer("await $_dioVar.fetch").call([options], {}, [refer("void")]).statement,
+        refer("await $_dioVar.fetch")
+            .call([options], {}, [refer("void")]).statement,
       );
       blocks.add(Code("$returnAsyncWrapper null;"));
       return Block.of(blocks);
     }
 
-    final bool isWrapped = _typeChecker(retrofit.HttpResponse).isExactlyType(wrappedReturnType);
-    final returnType = isWrapped ? _getResponseType(wrappedReturnType) : wrappedReturnType;
+    final bool isWrapped =
+        _typeChecker(retrofit.HttpResponse).isExactlyType(wrappedReturnType);
+    final returnType =
+        isWrapped ? _getResponseType(wrappedReturnType) : wrappedReturnType;
     if (returnType == null || "void" == returnType.toString()) {
       if (isWrapped) {
         blocks.add(
@@ -485,7 +526,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         );
       } else {
         blocks.add(
-          refer("await $_dioVar.fetch").call([options], {}, [refer("void")]).statement,
+          refer("await $_dioVar.fetch")
+              .call([options], {}, [refer("void")]).statement,
         );
         blocks.add(Code("$returnAsyncWrapper null;"));
       }
@@ -496,7 +538,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         if (_isBasicType(innerReturnType)) {
           blocks.add(
             declareFinal(_resultVar)
-                .assign(refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
+                .assign(
+                  refer("await $_dioVar.fetch<List<dynamic>>").call([options]),
+                )
                 .statement,
           );
 
@@ -504,7 +548,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             declareFinal(_valueVar)
                 .assign(
                   refer('$_resultVar.data')
-                      .propertyIf(thisNullable: returnType.isNullable, name: 'cast')
+                      .propertyIf(
+                    thisNullable: returnType.isNullable,
+                    name: 'cast',
+                  )
                       .call([], {}, [
                     refer(
                       '${_displayString(innerReturnType, withNullability: innerReturnType?.isNullable ?? false)}',
@@ -516,7 +563,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         } else {
           blocks.add(
             declareFinal(_resultVar)
-                .assign(refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
+                .assign(
+                  refer("await $_dioVar.fetch<List<dynamic>>").call([options]),
+                )
                 .statement,
           );
           if (clientAnnotation.parser == retrofit.Parser.FlutterCompute) {
@@ -526,7 +575,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                     refer('$_resultVar.data').conditionalIsNullIf(
                       thisNullable: returnType.isNullable,
                       whenFalse: refer('await compute').call([
-                        refer('deserialize${_displayString(innerReturnType)}List'),
+                        refer(
+                          'deserialize${_displayString(innerReturnType)}List',
+                        ),
                         refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
                       ]),
                     ),
@@ -564,7 +615,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               declareVar(_valueVar)
                   .assign(
                     refer('$_resultVar.data')
-                        .propertyIf(thisNullable: returnType.isNullable, name: 'map')
+                        .propertyIf(
+                          thisNullable: returnType.isNullable,
+                          name: 'map',
+                        )
                         .call([mapperCode])
                         .property('toList')
                         .call([]),
@@ -578,7 +632,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         final types = _getResponseInnerTypes(returnType)!;
         blocks.add(
           declareFinal(_resultVar)
-              .assign(refer("await $_dioVar.fetch<Map<String,dynamic>>").call([options]))
+              .assign(
+                refer("await $_dioVar.fetch<Map<String,dynamic>>")
+                    .call([options]),
+              )
               .statement,
         );
 
@@ -642,7 +699,8 @@ You should create a new class to encapsulate the response.
                     .assign(
                       refer('Map.fromEntries').call([
                         refer('await Future.wait').call([
-                          refer('$_resultVar.data!.entries.map').call([mapperCode])
+                          refer('$_resultVar.data!.entries.map')
+                              .call([mapperCode])
                         ])
                       ]),
                     )
@@ -653,7 +711,10 @@ You should create a new class to encapsulate the response.
                 declareVar(_valueVar)
                     .assign(
                       refer('$_resultVar.data')
-                          .propertyIf(thisNullable: returnType.isNullable, name: 'map')
+                          .propertyIf(
+                        thisNullable: returnType.isNullable,
+                        name: 'map',
+                      )
                           .call([mapperCode]),
                     )
                     .statement,
@@ -699,7 +760,8 @@ You should create a new class to encapsulate the response.
                         thisNullable: returnType.isNullable,
                         whenFalse: refer('Map.fromEntries').call([
                           refer('await Future.wait').call([
-                            refer('$_resultVar.data!.entries.map').call([mapperCode])
+                            refer('$_resultVar.data!.entries.map')
+                                .call([mapperCode])
                           ])
                         ]),
                       ),
@@ -711,7 +773,10 @@ You should create a new class to encapsulate the response.
                 declareVar(_valueVar)
                     .assign(
                       refer('$_resultVar.data')
-                          .propertyIf(thisNullable: returnType.isNullable, name: 'map')
+                          .propertyIf(
+                        thisNullable: returnType.isNullable,
+                        name: 'map',
+                      )
                           .call([mapperCode]),
                     )
                     .statement,
@@ -722,7 +787,10 @@ You should create a new class to encapsulate the response.
               declareFinal(_valueVar)
                   .assign(
                     refer('$_resultVar.data')
-                        .propertyIf(thisNullable: returnType.isNullable, name: 'cast')
+                        .propertyIf(
+                      thisNullable: returnType.isNullable,
+                      name: 'cast',
+                    )
                         .call([], {}, [
                       refer('${_displayString(firstType)}'),
                       refer('${_displayString(secondType)}'),
@@ -732,19 +800,24 @@ You should create a new class to encapsulate the response.
             );
           }
         } else {
-          blocks.add(Code("final value = $_resultVar.data!;"));
+          blocks.add(const Code("final value = $_resultVar.data!;"));
         }
       } else {
         if (_isBasicType(returnType)) {
           blocks.add(
             declareFinal(_resultVar)
                 .assign(
-                    refer("await $_dioVar.fetch<${_displayString(returnType)}>").call([options]))
+                  refer("await $_dioVar.fetch<${_displayString(returnType)}>")
+                      .call([options]),
+                )
                 .statement,
           );
           blocks.add(
             declareFinal(_valueVar)
-                .assign(refer('$_resultVar.data').asNoNullIf(returnNullable: returnType.isNullable))
+                .assign(
+                  refer('$_resultVar.data')
+                      .asNoNullIf(returnNullable: returnType.isNullable),
+                )
                 .statement,
           );
         } else if (returnType.toString() == 'dynamic') {
@@ -753,9 +826,11 @@ You should create a new class to encapsulate the response.
                 .assign(refer("await $_dioVar.fetch").call([options]))
                 .statement,
           );
-          blocks.add(Code("final value = $_resultVar.data;"));
+          blocks.add(const Code("final value = $_resultVar.data;"));
         } else {
-          final fetchType = returnType.isNullable ? "Map<String,dynamic>?" : "Map<String,dynamic>";
+          final fetchType = returnType.isNullable
+              ? "Map<String,dynamic>?"
+              : "Map<String,dynamic>";
           blocks.add(
             declareFinal(_resultVar)
                 .assign(
@@ -768,13 +843,17 @@ You should create a new class to encapsulate the response.
           Expression mapperCode;
           switch (clientAnnotation.parser) {
             case retrofit.Parser.MapSerializable:
-              mapperCode = refer('${_displayString(returnType)}.fromMap($_resultVar.data!)');
+              mapperCode = refer(
+                '${_displayString(returnType)}.fromMap($_resultVar.data!)',
+              );
               break;
             case retrofit.Parser.JsonSerializable:
-              final genericArgumentFactories = isGenericArgumentFactories(returnType);
+              final genericArgumentFactories =
+                  isGenericArgumentFactories(returnType);
 
-              var typeArgs =
-                  returnType is ParameterizedType ? returnType.typeArguments : <DartType>[];
+              var typeArgs = returnType is ParameterizedType
+                  ? returnType.typeArguments
+                  : <DartType>[];
 
               if (typeArgs.length > 0 && genericArgumentFactories) {
                 //Remove the outermost nullable modifier
@@ -790,12 +869,15 @@ You should create a new class to encapsulate the response.
                   '${displayString}.fromJson($_resultVar.data!,${_getInnerJsonSerializableMapperFn(returnType)})',
                 );
               } else {
-                mapperCode = refer('${_displayString(returnType)}.fromJson($_resultVar.data!)');
+                mapperCode = refer(
+                  '${_displayString(returnType)}.fromJson($_resultVar.data!)',
+                );
               }
               break;
             case retrofit.Parser.DartJsonMapper:
-              mapperCode =
-                  refer('JsonMapper.fromMap<${_displayString(returnType)}>($_resultVar.data!)!');
+              mapperCode = refer(
+                'JsonMapper.fromMap<${_displayString(returnType)}>($_resultVar.data!)!',
+              );
               break;
             case retrofit.Parser.FlutterCompute:
               mapperCode = refer(
@@ -835,14 +917,15 @@ You should create a new class to encapsulate the response.
     if (metaData == null || dartType == null) {
       return false;
     }
-    final constDartObj = metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
+    final constDartObj =
+        metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
     var genericArgumentFactories = false;
     if (constDartObj != null &&
         (!_typeChecker(List).isExactlyType(dartType) &&
             !_typeChecker(BuiltList).isExactlyType(dartType))) {
       try {
         final annotation = ConstantReader(constDartObj);
-        final obj = (annotation.peek('genericArgumentFactories'));
+        final obj = annotation.peek('genericArgumentFactories');
         // ignore: invalid_null_aware_operator
         genericArgumentFactories = obj?.boolValue ?? false;
       } catch (e) {}
@@ -852,17 +935,22 @@ You should create a new class to encapsulate the response.
   }
 
   String _getInnerJsonSerializableMapperFn(DartType dartType) {
-    var typeArgs = dartType is ParameterizedType ? dartType.typeArguments : <DartType>[];
+    var typeArgs =
+        dartType is ParameterizedType ? dartType.typeArguments : <DartType>[];
     if (typeArgs.length > 0) {
       if (_typeChecker(List).isExactlyType(dartType) ||
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
-        var typeArgs = genericType is ParameterizedType ? genericType.typeArguments : <DartType>[];
+        var typeArgs = genericType is ParameterizedType
+            ? genericType.typeArguments
+            : <DartType>[];
         String mapperVal;
 
         var genericTypeString = "${_displayString(genericType)}";
 
-        if (typeArgs.length > 0 && isGenericArgumentFactories(genericType) && genericType != null) {
+        if (typeArgs.length > 0 &&
+            isGenericArgumentFactories(genericType) &&
+            genericType != null) {
           mapperVal = """
     (json)=> (json as List<dynamic>)
             .map<${genericTypeString}>((i) => ${genericTypeString}.fromJson(
@@ -894,7 +982,8 @@ You should create a new class to encapsulate the response.
         var mappedVal = '';
         for (DartType arg in typeArgs) {
           // print(arg);
-          var typeArgs = arg is ParameterizedType ? arg.typeArguments : <DartType>[];
+          var typeArgs =
+              arg is ParameterizedType ? arg.typeArguments : <DartType>[];
           if (typeArgs.length > 0) if (_typeChecker(List).isExactlyType(arg) ||
               _typeChecker(BuiltList).isExactlyType(arg)) {
             mappedVal += "${_getInnerJsonSerializableMapperFn(arg)}";
@@ -903,7 +992,8 @@ You should create a new class to encapsulate the response.
               mappedVal +=
                   "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(arg)}),";
             else
-              mappedVal += "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
+              mappedVal +=
+                  "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
           }
           else {
             mappedVal += "${_getInnerJsonSerializableMapperFn(arg)}";
@@ -925,35 +1015,43 @@ You should create a new class to encapsulate the response.
   }
 
   String _getInnerJsonDeSerializableMapperFn(DartType dartType) {
-    var typeArgs = dartType is ParameterizedType ? dartType.typeArguments : <DartType>[];
+    var typeArgs =
+        dartType is ParameterizedType ? dartType.typeArguments : <DartType>[];
     if (typeArgs.length > 0) {
       if (_typeChecker(List).isExactlyType(dartType) ||
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
-        var typeArgs = genericType is ParameterizedType ? genericType.typeArguments : <DartType>[];
+        var typeArgs = genericType is ParameterizedType
+            ? genericType.typeArguments
+            : <DartType>[];
         String mapperVal;
 
-        if (typeArgs.length > 0 && isGenericArgumentFactories(genericType) && genericType != null) {
+        if (typeArgs.length > 0 &&
+            isGenericArgumentFactories(genericType) &&
+            genericType != null) {
           mapperVal =
               '(value) => value.map((value) => ${_getInnerJsonDeSerializableMapperFn(genericType)}).toList()';
         } else {
           if (_isBasicType(genericType)) {
             mapperVal = '(value) => value';
           } else {
-            mapperVal = '(value) => value.map((value) => value.toJson()).toList()';
+            mapperVal =
+                '(value) => value.map((value) => value.toJson()).toList()';
           }
         }
         return mapperVal;
       } else {
         var mappedVal = '';
         for (DartType arg in typeArgs) {
-          var typeArgs = arg is ParameterizedType ? arg.typeArguments : <DartType>[];
+          var typeArgs =
+              arg is ParameterizedType ? arg.typeArguments : <DartType>[];
           if (typeArgs.length > 0) if (_typeChecker(List).isExactlyType(arg) ||
               _typeChecker(BuiltList).isExactlyType(arg)) {
             mappedVal = "${_getInnerJsonDeSerializableMapperFn(arg)}";
           } else {
             if (isGenericArgumentFactories(arg))
-              mappedVal = '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
+              mappedVal =
+                  '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
             else {
               mappedVal = "(value) => value";
             }
@@ -981,7 +1079,8 @@ You should create a new class to encapsulate the response.
   ) {
     final annoOptions = _getAnnotation(m, retrofit.DioOptions);
     if (annoOptions == null) {
-      final args = Map<String, Expression>.from(extraOptions)..addAll(namedArguments);
+      final args = Map<String, Expression>.from(extraOptions)
+        ..addAll(namedArguments);
       final path = args.remove(_path)!;
       final dataVar = args.remove(_dataVar)!;
       final queryParams = args.remove(_queryParamsVar)!;
@@ -1016,8 +1115,9 @@ You should create a new class to encapsulate the response.
             )
             .property('copyWith')
             .call([], {
-              _baseUrlVar:
-                  baseUrl.ifNullThen(refer(_dioVar).property('options').property('baseUrl'))
+              _baseUrlVar: baseUrl.ifNullThen(
+                refer(_dioVar).property('options').property('baseUrl'),
+              )
             })
       ], {}, [
         type
@@ -1026,7 +1126,10 @@ You should create a new class to encapsulate the response.
       hasCustomOptions = true;
       blocks.add(
         declareFinal("newOptions")
-            .assign(refer("newRequestOptions").call([refer(annoOptions.item1.displayName)]))
+            .assign(
+              refer("newRequestOptions")
+                  .call([refer(annoOptions.item1.displayName)]),
+            )
             .statement,
       );
       final newOptions = refer("newOptions");
@@ -1037,10 +1140,9 @@ You should create a new class to encapsulate the response.
             .call([extraOptions.remove(_extraVar)!]).statement,
       );
       blocks.add(
-        newOptions
-            .property('headers')
-            .property('addAll')
-            .call([refer(_dioVar).property('options').property('headers')]).statement,
+        newOptions.property('headers').property('addAll').call(
+          [refer(_dioVar).property('options').property('headers')],
+        ).statement,
       );
       blocks.add(
         newOptions
@@ -1055,9 +1157,9 @@ You should create a new class to encapsulate the response.
             Map.from(extraOptions)
               ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
               ..[_path] = namedArguments[_path]!
-              ..[_baseUrlVar] = extraOptions
-                  .remove(_baseUrlVar)!
-                  .ifNullThen(refer(_dioVar).property('options').property('baseUrl')),
+              ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
+                    refer(_dioVar).property('options').property('baseUrl'),
+                  ),
           )
           .cascade('data')
           .assign(namedArguments[_dataVar]!);
@@ -1079,7 +1181,7 @@ You should create a new class to encapsulate the response.
         )
 
         /// add method body
-        ..body = Code('''
+        ..body = const Code('''
          if (options is RequestOptions) {
             return options as RequestOptions;
           }
@@ -1119,7 +1221,7 @@ You should create a new class to encapsulate the response.
         ..types = ListBuilder(<Reference>[t])
         ..returns = refer('RequestOptions')
         ..requiredParameters = ListBuilder(<Parameter>[optionsParam])
-        ..body = Code('''if (T != dynamic &&
+        ..body = const Code('''if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||
             requestOptions.responseType == ResponseType.stream)) {
       if (T == String) {
@@ -1150,12 +1252,18 @@ You should create a new class to encapsulate the response.
     return _isBasicType(innerType);
   }
 
-  void _generateQueries(MethodElement m, List<Code> blocks, String _queryParamsVar) {
+  void _generateQueries(
+    MethodElement m,
+    List<Code> blocks,
+    String _queryParamsVar,
+  ) {
     final queries = _getAnnotations(m, retrofit.Query);
     final queryParameters = queries.map((p, ConstantReader r) {
       final key = r.peek("value")?.stringValue ?? p.displayName;
       final Expression value;
-      if (_isBasicType(p.type) || p.type.isDartCoreList || p.type.isDartCoreMap) {
+      if (_isBasicType(p.type) ||
+          p.type.isDartCoreList ||
+          p.type.isDartCoreMap) {
         value = refer(p.displayName);
       } else {
         switch (clientAnnotation.parser) {
@@ -1173,7 +1281,9 @@ You should create a new class to encapsulate the response.
             value = refer(p.displayName);
             break;
           case retrofit.Parser.FlutterCompute:
-            value = refer('await compute(serialize${_displayString(p.type)}, ${p.displayName})');
+            value = refer(
+              'await compute(serialize${_displayString(p.type)}, ${p.displayName})',
+            );
             break;
         }
       }
@@ -1183,7 +1293,9 @@ You should create a new class to encapsulate the response.
     final queryMap = _getAnnotations(m, retrofit.Queries);
     blocks.add(
       declareFinal(_queryParamsVar)
-          .assign(literalMap(queryParameters, refer("String"), refer("dynamic")))
+          .assign(
+            literalMap(queryParameters, refer("String"), refer("dynamic")),
+          )
           .statement,
     );
     for (final p in queryMap.keys) {
@@ -1208,7 +1320,9 @@ You should create a new class to encapsulate the response.
             value = refer(displayName);
             break;
           case retrofit.Parser.FlutterCompute:
-            value = refer('await compute(serialize${_displayString(p.type)}, ${p.displayName})');
+            value = refer(
+              'await compute(serialize${_displayString(p.type)}, ${p.displayName})',
+            );
             break;
         }
       }
@@ -1226,24 +1340,35 @@ You should create a new class to encapsulate the response.
       blocks.add(refer('$_queryParamsVar.addAll').call([expression]).statement);
     }
 
-    if (m.parameters.any((p) => (p.type.nullabilitySuffix == NullabilitySuffix.question))) {
+    if (m.parameters
+        .any((p) => p.type.nullabilitySuffix == NullabilitySuffix.question)) {
       blocks.add(Code("$_queryParamsVar.removeWhere((k, v) => v == null);"));
     }
   }
 
-  void _generateRequestBody(List<Code> blocks, String _dataVar, MethodElement m) {
+  void _generateRequestBody(
+    List<Code> blocks,
+    String _dataVar,
+    MethodElement m,
+  ) {
     final _noBody = _getMethodAnnotationByType(m, retrofit.NoBody);
     if (_noBody != null) {
-      blocks.add(declareFinal(_dataVar, type: refer('String?')).assign(refer('null')).statement);
+      blocks.add(
+        declareFinal(_dataVar, type: refer('String?'))
+            .assign(refer('null'))
+            .statement,
+      );
       return;
     }
 
     var annotation = _getAnnotation(m, retrofit.Body);
     final _bodyName = annotation?.item1;
     if (_bodyName != null) {
-      final nullToAbsent = annotation!.item2.peek('nullToAbsent')?.boolValue ?? false;
+      final nullToAbsent =
+          annotation!.item2.peek('nullToAbsent')?.boolValue ?? false;
       final bodyTypeElement = _bodyName.type.element2;
-      if (TypeChecker.fromRuntime(Map).isAssignableFromType(_bodyName.type)) {
+      if (const TypeChecker.fromRuntime(Map)
+          .isAssignableFromType(_bodyName.type)) {
         blocks.add(
           declareFinal(_dataVar)
               .assign(literalMap({}, refer("String"), refer("dynamic")))
@@ -1257,7 +1382,8 @@ You should create a new class to encapsulate the response.
             )
           ]).statement,
         );
-        if (nullToAbsent) blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
+        if (nullToAbsent)
+          blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
       } else if (bodyTypeElement != null &&
           ((_typeChecker(List).isExactly(bodyTypeElement) ||
                   _typeChecker(BuiltList).isExactly(bodyTypeElement)) &&
@@ -1298,13 +1424,16 @@ You should create a new class to encapsulate the response.
             );
             break;
         }
-      } else if (bodyTypeElement != null && _typeChecker(File).isExactly(bodyTypeElement)) {
+      } else if (bodyTypeElement != null &&
+          _typeChecker(File).isExactly(bodyTypeElement)) {
         blocks.add(
           declareFinal(_dataVar)
               .assign(
-                refer("Stream")
-                    .property("fromIterable")
-                    .call([refer("${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])")]),
+                refer("Stream").property("fromIterable").call([
+                  refer(
+                    "${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])",
+                  )
+                ]),
               )
               .statement,
         );
@@ -1316,7 +1445,11 @@ You should create a new class to encapsulate the response.
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toMap()` method which return a Map.\n"
                 "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
-            blocks.add(declareFinal(_dataVar).assign(refer(_bodyName.displayName)).statement);
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(refer(_bodyName.displayName))
+                  .statement,
+            );
           } else {
             blocks.add(
               declareFinal(_dataVar)
@@ -1325,7 +1458,11 @@ You should create a new class to encapsulate the response.
             );
             blocks.add(
               refer("$_dataVar.addAll").call(
-                [refer("${_bodyName.displayName}?.toMap() ?? <String,dynamic>{}")],
+                [
+                  refer(
+                    "${_bodyName.displayName}?.toMap() ?? <String,dynamic>{}",
+                  )
+                ],
               ).statement,
             );
           }
@@ -1334,12 +1471,20 @@ You should create a new class to encapsulate the response.
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toJson()` method which return a Map.\n"
                 "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
-            blocks.add(declareFinal(_dataVar).assign(refer(_bodyName.displayName)).statement);
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(refer(_bodyName.displayName))
+                  .statement,
+            );
           } else if (_missingSerialize(ele.enclosingElement3, _bodyName.type)) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `serialize${_displayString(_bodyName.type)}()` method which returns a Map.\n"
                 "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
-            blocks.add(declareFinal(_dataVar).assign(refer(_bodyName.displayName)).statement);
+            blocks.add(
+              declareFinal(_dataVar)
+                  .assign(refer(_bodyName.displayName))
+                  .statement,
+            );
           } else {
             blocks.add(
               declareFinal(_dataVar)
@@ -1348,9 +1493,12 @@ You should create a new class to encapsulate the response.
             );
 
             final _bodyType = _bodyName.type;
-            final genericArgumentFactories = isGenericArgumentFactories(_bodyType);
+            final genericArgumentFactories =
+                isGenericArgumentFactories(_bodyType);
 
-            var typeArgs = _bodyType is ParameterizedType ? _bodyType.typeArguments : <DartType>[];
+            var typeArgs = _bodyType is ParameterizedType
+                ? _bodyType.typeArguments
+                : <DartType>[];
 
             String toJsonCode = '';
             if (typeArgs.length > 0 && genericArgumentFactories) {
@@ -1360,21 +1508,26 @@ You should create a new class to encapsulate the response.
             switch (clientAnnotation.parser) {
               case retrofit.Parser.JsonSerializable:
               case retrofit.Parser.DartJsonMapper:
-                if (_bodyName.type.nullabilitySuffix != NullabilitySuffix.question) {
+                if (_bodyName.type.nullabilitySuffix !=
+                    NullabilitySuffix.question) {
                   blocks.add(
-                    refer("$_dataVar.addAll")
-                        .call([refer('${_bodyName.displayName}.toJson($toJsonCode)')]).statement,
+                    refer("$_dataVar.addAll").call([
+                      refer('${_bodyName.displayName}.toJson($toJsonCode)')
+                    ]).statement,
                   );
                 } else {
                   blocks.add(
                     refer("$_dataVar.addAll").call([
-                      refer('${_bodyName.displayName}?.toJson($toJsonCode) ?? <String,dynamic>{}')
+                      refer(
+                        '${_bodyName.displayName}?.toJson($toJsonCode) ?? <String,dynamic>{}',
+                      )
                     ]).statement,
                   );
                 }
                 break;
               case retrofit.Parser.FlutterCompute:
-                if (_bodyName.type.nullabilitySuffix != NullabilitySuffix.question) {
+                if (_bodyName.type.nullabilitySuffix !=
+                    NullabilitySuffix.question) {
                   blocks.add(
                     refer("$_dataVar.addAll").call([
                       refer(
@@ -1398,12 +1551,15 @@ You should create a new class to encapsulate the response.
                 break;
             }
 
-            if (nullToAbsent) blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
+            if (nullToAbsent)
+              blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
           }
         }
       } else {
         /// @Body annotations with no type are assigned as is
-        blocks.add(declareFinal(_dataVar).assign(refer(_bodyName.displayName)).statement);
+        blocks.add(
+          declareFinal(_dataVar).assign(refer(_bodyName.displayName)).statement,
+        );
       }
 
       return;
@@ -1415,7 +1571,9 @@ You should create a new class to encapsulate the response.
       final fieldName = r.peek("value")?.stringValue ?? p.displayName;
       final isFileField = _typeChecker(File).isAssignableFromType(p.type);
       if (isFileField) {
-        log.severe('File is not support by @Field(). Please use @Part() instead.');
+        log.severe(
+          'File is not support by @Field(). Please use @Part() instead.',
+        );
       }
       return MapEntry(literal(fieldName), refer(p.displayName));
     });
@@ -1442,22 +1600,30 @@ You should create a new class to encapsulate the response.
               .statement,
         );
         return;
-      } else if (m.parameters.length == 2 && m.parameters[1].type.isDartCoreMap) {
+      } else if (m.parameters.length == 2 &&
+          m.parameters[1].type.isDartCoreMap) {
         blocks.add(
           declareFinal(_dataVar)
               .assign(
                 refer('FormData').newInstanceNamed(
-                    'fromMap', [CodeExpression(Code(m.parameters[1].displayName))]),
+                  'fromMap',
+                  [CodeExpression(Code(m.parameters[1].displayName))],
+                ),
               )
               .statement,
         );
         return;
       }
-      blocks.add(declareFinal(_dataVar).assign(refer('FormData').newInstance([])).statement);
+      blocks.add(
+        declareFinal(_dataVar)
+            .assign(refer('FormData').newInstance([]))
+            .statement,
+      );
 
       parts.forEach((p, r) {
-        final fieldName =
-            r.peek("name")?.stringValue ?? r.peek("value")?.stringValue ?? p.displayName;
+        final fieldName = r.peek("name")?.stringValue ??
+            r.peek("value")?.stringValue ??
+            p.displayName;
         final isFileField = _typeChecker(File).isAssignableFromType(p.type);
         final contentType = r.peek('contentType')?.stringValue;
 
@@ -1465,39 +1631,55 @@ You should create a new class to encapsulate the response.
           final fileNameValue = r.peek("fileName")?.stringValue;
           final fileName = fileNameValue != null
               ? literalString(fileNameValue)
-              : refer(p.displayName).property('path.split(Platform.pathSeparator).last');
+              : refer(p.displayName)
+                  .property('path.split(Platform.pathSeparator).last');
 
           final uploadFileInfo = refer('$MultipartFile.fromFileSync').call([
             refer(p.displayName).property('path')
           ], {
             'filename': fileName,
             if (contentType != null)
-              'contentType': refer("MediaType", 'package:http_parser/http_parser.dart')
-                  .property('parse')
-                  .call([literal(contentType)])
+              'contentType':
+                  refer("MediaType", 'package:http_parser/http_parser.dart')
+                      .property('parse')
+                      .call([literal(contentType)])
           });
 
-          final optionalFile =
-              m.parameters.firstWhereOrNull((pp) => pp.displayName == p.displayName)?.isOptional ??
-                  false;
+          final optionalFile = m.parameters
+                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+                  ?.isOptional ??
+              false;
 
-          final returnCode = refer(_dataVar).property('files').property("add").call([
+          final returnCode =
+              refer(_dataVar).property('files').property("add").call([
             refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
           ]).statement;
           if (optionalFile) {
-            final condication = refer(p.displayName).notEqualTo(literalNull).code;
-            blocks.addAll([Code("if("), condication, Code(") {"), returnCode, Code("}")]);
+            final condication =
+                refer(p.displayName).notEqualTo(literalNull).code;
+            blocks.addAll(
+              [
+                const Code("if("),
+                condication,
+                const Code(") {"),
+                returnCode,
+                const Code("}")
+              ],
+            );
           } else {
             blocks.add(returnCode);
           }
         } else if (_displayString(p.type) == "List<int>") {
-          final optionalFile =
-              m.parameters.firstWhereOrNull((pp) => pp.displayName == p.displayName)?.isOptional ??
-                  false;
+          final optionalFile = m.parameters
+                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+                  ?.isOptional ??
+              false;
           final fileName = r.peek("fileName")?.stringValue;
-          final conType =
-              contentType == null ? "" : 'contentType: MediaType.parse(${literal(contentType)}),';
-          final returnCode = refer(_dataVar).property('files').property("add").call([
+          final conType = contentType == null
+              ? ""
+              : 'contentType: MediaType.parse(${literal(contentType)}),';
+          final returnCode =
+              refer(_dataVar).property('files').property("add").call([
             refer(''' 
                   MapEntry(
                 '${fieldName}',
@@ -1510,7 +1692,15 @@ You should create a new class to encapsulate the response.
           ]).statement;
           if (optionalFile) {
             final condition = refer(p.displayName).notEqualTo(literalNull).code;
-            blocks.addAll([Code("if("), condition, Code(") {"), returnCode, Code("}")]);
+            blocks.addAll(
+              [
+                const Code("if("),
+                condition,
+                const Code(") {"),
+                returnCode,
+                const Code("}")
+              ],
+            );
           } else {
             blocks.add(returnCode);
           }
@@ -1520,8 +1710,9 @@ You should create a new class to encapsulate the response.
 
           if (_displayString(innerType) == "List<int>") {
             final fileName = r.peek("fileName")?.stringValue;
-            final conType =
-                contentType == null ? "" : 'contentType: MediaType.parse(${literal(contentType)}),';
+            final conType = contentType == null
+                ? ""
+                : 'contentType: MediaType.parse(${literal(contentType)}),';
             blocks.add(
               refer(_dataVar).property('files').property("addAll").call([
                 refer(''' 
@@ -1541,7 +1732,10 @@ You should create a new class to encapsulate the response.
                       _typeChecker(List).isExactlyType(innerType) ||
                       _typeChecker(BuiltList).isExactlyType(innerType)))) {
             var value = _isBasicType(innerType) ? 'i' : 'jsonEncode(i)';
-            var nullableInfix = (p.type.nullabilitySuffix == NullabilitySuffix.question) ? '?' : '';
+            var nullableInfix =
+                (p.type.nullabilitySuffix == NullabilitySuffix.question)
+                    ? '?'
+                    : '';
             blocks.add(
               refer('''
             ${p.displayName}$nullableInfix.forEach((i){
@@ -1549,9 +1743,11 @@ You should create a new class to encapsulate the response.
             })
             ''').statement,
             );
-          } else if (innerType != null && _typeChecker(File).isExactlyType(innerType)) {
-            final conType =
-                contentType == null ? "" : 'contentType: MediaType.parse(${literal(contentType)}),';
+          } else if (innerType != null &&
+              _typeChecker(File).isExactlyType(innerType)) {
+            final conType = contentType == null
+                ? ""
+                : 'contentType: MediaType.parse(${literal(contentType)}),';
             if (p.type.isNullable) {
               blocks.add(Code("if (${p.displayName} != null) {"));
             }
@@ -1568,9 +1764,10 @@ You should create a new class to encapsulate the response.
               ]).statement,
             );
             if (p.type.isNullable) {
-              blocks.add(Code("}"));
+              blocks.add(const Code("}"));
             }
-          } else if (innerType != null && _typeChecker(MultipartFile).isExactlyType(innerType)) {
+          } else if (innerType != null &&
+              _typeChecker(MultipartFile).isExactlyType(innerType)) {
             if (p.type.isNullable) {
               blocks.add(Code("if (${p.displayName} != null) {"));
             }
@@ -1584,7 +1781,7 @@ You should create a new class to encapsulate the response.
               ]).statement,
             );
             if (p.type.isNullable) {
-              blocks.add(Code("}"));
+              blocks.add(const Code("}"));
             }
           } else if (innerType?.element2 is ClassElement) {
             final ele = innerType!.element2 as ClassElement;
@@ -1593,8 +1790,10 @@ You should create a new class to encapsulate the response.
             } else {
               blocks.add(
                 refer(_dataVar).property('fields').property("add").call([
-                  refer("MapEntry")
-                      .newInstance([literal(fieldName), refer("jsonEncode(${p.displayName})")])
+                  refer("MapEntry").newInstance([
+                    literal(fieldName),
+                    refer("jsonEncode(${p.displayName})")
+                  ])
                 ]).statement,
               );
             }
@@ -1617,14 +1816,15 @@ You should create a new class to encapsulate the response.
             ]).statement,
           );
           if (p.type.nullabilitySuffix == NullabilitySuffix.question) {
-            blocks.add(Code("}"));
+            blocks.add(const Code("}"));
           }
         } else if (_typeChecker(Map).isExactlyType(p.type) ||
             _typeChecker(BuiltMap).isExactlyType(p.type)) {
           blocks.add(
             refer(_dataVar).property('fields').property("add").call([
-              refer("MapEntry")
-                  .newInstance([literal(fieldName), refer("jsonEncode(${p.displayName})")])
+              refer("MapEntry").newInstance(
+                [literal(fieldName), refer("jsonEncode(${p.displayName})")],
+              )
             ]).statement,
           );
         } else if (p.type.element2 is ClassElement) {
@@ -1646,7 +1846,8 @@ You should create a new class to encapsulate the response.
         } else {
           blocks.add(
             refer(_dataVar).property('fields').property("add").call([
-              refer("MapEntry").newInstance([literal(fieldName), refer(p.displayName)])
+              refer("MapEntry")
+                  .newInstance([literal(fieldName), refer(p.displayName)])
             ]).statement,
           );
         }
@@ -1656,7 +1857,9 @@ You should create a new class to encapsulate the response.
 
     /// There is no body
     blocks.add(
-      declareFinal(_dataVar).assign(literalMap({}, refer("String"), refer("dynamic"))).statement,
+      declareFinal(_dataVar)
+          .assign(literalMap({}, refer("String"), refer("dynamic")))
+          .statement,
     );
   }
 
@@ -1697,7 +1900,8 @@ You should create a new class to encapsulate the response.
       final noStore = cache.peek('noStore')?.boolValue;
       final noTransform = cache.peek('noTransform')?.boolValue;
       final onlyIfCached = cache.peek('onlyIfCached')?.boolValue;
-      final other = (cache.peek('other')?.listValue ?? const []).map((e) => e.toStringValue());
+      final other = (cache.peek('other')?.listValue ?? const [])
+          .map((e) => e.toStringValue());
       final otherResult = <String>[];
 
       other.forEach((element) {
@@ -1724,7 +1928,11 @@ You should create a new class to encapsulate the response.
     return result;
   }
 
-  void _generateExtra(MethodElement m, List<Code> blocks, String localExtraVar) {
+  void _generateExtra(
+    MethodElement m,
+    List<Code> blocks,
+    String localExtraVar,
+  ) {
     blocks.add(
       declareConst(localExtraVar)
           .assign(
@@ -1749,7 +1957,9 @@ You should create a new class to encapsulate the response.
                             v?.toSetValue() ??
                             v?.toSymbolValue() ??
                             (v?.toTypeValue() ??
-                                (v != null ? Code(revivedLiteral(v)) : Code('null'))),
+                                (v != null
+                                    ? Code(revivedLiteral(v))
+                                    : const Code('null'))),
                       );
                     }),
                   )
@@ -1785,14 +1995,17 @@ You should create a new class to encapsulate the response.
           (element) =>
               element.name == 'serialize${_displayString(type)}' &&
               element.parameters.length == 1 &&
-              _displayString(element.parameters[0].type) == _displayString(type),
+              _displayString(element.parameters[0].type) ==
+                  _displayString(type),
         );
     }
   }
 }
 
-Builder generatorFactoryBuilder(BuilderOptions options) =>
-    SharedPartBuilder([RetrofitGenerator(RetrofitOptions.fromOptions(options))], "retrofit");
+Builder generatorFactoryBuilder(BuilderOptions options) => SharedPartBuilder(
+      [RetrofitGenerator(RetrofitOptions.fromOptions(options))],
+      "retrofit",
+    );
 
 /// Returns `$revived($args $kwargs)`, this won't have ending semi-colon (`;`).
 /// [object] must not be null.
@@ -1829,7 +2042,8 @@ String revivedLiteral(
   /// If this is a class instantiation then `location[1]` will be populated
   /// with the class name
   if (location.length > 1) {
-    instantiation = location[1] + (revived.accessor.isNotEmpty ? '.${revived.accessor}' : '');
+    instantiation = location[1] +
+        (revived.accessor.isNotEmpty ? '.${revived.accessor}' : '');
   } else {
     /// Getters, Setters, Methods can't be declared as constants so this
     /// literal must either be a top-level constant or a static constant and
@@ -1896,8 +2110,8 @@ String revivedLiteral(
 
     /// Perhaps an object instantiation?
     /// In that case, try initializing it and remove `const` to reduce noise
-    final revived =
-        revivedLiteral(constant.revive(), dartEmitter: dartEmitter).replaceFirst('const ', '');
+    final revived = revivedLiteral(constant.revive(), dartEmitter: dartEmitter)
+        .replaceFirst('const ', '');
     return Code(revived);
   }
 
@@ -1918,7 +2132,8 @@ String revivedLiteral(
 
 extension DartTypeStreamAnnotation on DartType {
   bool get isDartAsyncStream {
-    final element = this.element2 != null ? null : this.element2 as ClassElement;
+    final element =
+        this.element2 != null ? null : this.element2 as ClassElement;
     if (element == null) {
       return false;
     }
@@ -1945,19 +2160,24 @@ extension DartTypeExt on DartType {
 extension ReferenceExt on Reference {
   Reference asNoNull() => refer('${this.symbol}!');
 
-  Reference asNoNullIf({required bool returnNullable}) => returnNullable ? this : this.asNoNull();
+  Reference asNoNullIf({required bool returnNullable}) =>
+      returnNullable ? this : this.asNoNull();
 
   Expression propertyIf({
     required bool thisNullable,
     required String name,
   }) =>
-      thisNullable ? this.nullSafeProperty(name) : this.asNoNull().property(name);
+      thisNullable
+          ? this.nullSafeProperty(name)
+          : this.asNoNull().property(name);
 
   Expression conditionalIsNullIf({
     required bool thisNullable,
     required Expression whenFalse,
   }) =>
-      thisNullable ? this.equalTo(literalNull).conditional(literalNull, whenFalse) : whenFalse;
+      thisNullable
+          ? this.equalTo(literalNull).conditional(literalNull, whenFalse)
+          : whenFalse;
 }
 
 extension IterableExtension<T> on Iterable<T> {

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -24,8 +24,8 @@ class RetrofitOptions {
 
   RetrofitOptions.fromOptions([BuilderOptions? options])
       : autoCastResponse =
-            (options?.config['auto_cast_response']?.toString() ?? 'true') ==
-                'true';
+      (options?.config['auto_cast_response']?.toString() ?? 'true') ==
+          'true';
 }
 
 class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
@@ -87,7 +87,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         ..fields.addAll([_buildDioFiled(), _buildBaseUrlFiled(baseUrl)])
         ..constructors.addAll(
           annotClassConsts.map(
-            (e) => _generateConstructor(baseUrl, superClassConst: e),
+                (e) => _generateConstructor(baseUrl, superClassConst: e),
           ),
         )
         ..methods.addAll(_parseMethods(element));
@@ -114,16 +114,16 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     ..modifier = FieldModifier.final$);
 
   Field _buildBaseUrlFiled(String? url) => Field((m) {
-        m
-          ..name = _baseUrlVar
-          ..type = refer("String?")
-          ..modifier = FieldModifier.var$;
-      });
+    m
+      ..name = _baseUrlVar
+      ..type = refer("String?")
+      ..modifier = FieldModifier.var$;
+  });
 
   Constructor _generateConstructor(
-    String? url, {
-    ConstructorElement? superClassConst,
-  }) =>
+      String? url, {
+        ConstructorElement? superClassConst,
+      }) =>
       Constructor((c) {
         c.requiredParameters.add(Parameter((p) => p
           ..name = _dioVar
@@ -167,20 +167,20 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       });
 
   Iterable<Method> _parseMethods(ClassElement element) => (<MethodElement>[]
-            ..addAll(element.methods)
-            ..addAll(element.mixins.expand((i) => i.methods)))
-          .where((MethodElement m) {
-        final methodAnnot = _getMethodAnnotation(m);
-        return methodAnnot != null &&
-            m.isAbstract &&
-            (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
-      }).map((m) => _generateMethod(m)!);
+    ..addAll(element.methods)
+    ..addAll(element.mixins.expand((i) => i.methods)))
+      .where((MethodElement m) {
+    final methodAnnot = _getMethodAnnotation(m);
+    return methodAnnot != null &&
+        m.isAbstract &&
+        (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
+  }).map((m) => _generateMethod(m)!);
 
   String _generateTypeParameterizedName(TypeParameterizedElement element) =>
       element.displayName +
-      (element.typeParameters.isNotEmpty
-          ? '<${element.typeParameters.join(',')}>'
-          : '');
+          (element.typeParameters.isNotEmpty
+              ? '<${element.typeParameters.join(',')}>'
+              : '');
 
   final _methodsAnnotations = const [
     retrofit.GET,
@@ -205,7 +205,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   ConstantReader? _getMethodAnnotationByType(MethodElement method, Type type) {
     final annot =
-        _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
+    _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
     if (annot != null) return ConstantReader(annot);
     return null;
   }
@@ -313,7 +313,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return Method((mm) {
       mm
         ..returns =
-            refer(_displayString(m.type.returnType, withNullability: true))
+        refer(_displayString(m.type.returnType, withNullability: true))
         ..name = m.displayName
         ..types.addAll(m.typeParameters.map((e) => refer(e.name)))
         ..modifier = m.returnType.isDartAsyncFuture
@@ -325,21 +325,21 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       mm.requiredParameters.addAll(m.parameters
           .where((it) => it.isRequiredPositional)
           .map((it) => Parameter((p) => p
-            ..name = it.name
-            ..named = it.isNamed)));
+        ..name = it.name
+        ..named = it.isNamed)));
 
       /// optional positional or named parameters
       mm.optionalParameters.addAll(m.parameters
           .where((i) => i.isOptional || i.isRequiredNamed)
           .map((it) => Parameter((p) => p
-            ..required = (it.isNamed &&
-                it.type.nullabilitySuffix == NullabilitySuffix.none &&
-                !it.hasDefaultValue)
-            ..name = it.name
-            ..named = it.isNamed
-            ..defaultTo = it.defaultValueCode == null
-                ? null
-                : Code(it.defaultValueCode!))));
+        ..required = (it.isNamed &&
+            it.type.nullabilitySuffix == NullabilitySuffix.none &&
+            !it.hasDefaultValue)
+        ..name = it.name
+        ..named = it.isNamed
+        ..defaultTo = it.defaultValueCode == null
+            ? null
+            : Code(it.defaultValueCode!))));
       mm.body = _generateRequest(m, httpMehod);
     });
   }
@@ -349,14 +349,15 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     String? definePath = method.peek("path")?.stringValue;
     paths.forEach((k, v) {
       final value = v.peek("value")?.stringValue ?? k.displayName;
-      definePath = definePath?.replaceFirst("{$value}", "\${${k.displayName}${k.type.element?.kind == ElementKind.ENUM ? '.name' : ''}}");
+      definePath = definePath?.replaceFirst("{$value}",
+          "\${${k.displayName}${k.type.element2?.kind == ElementKind.ENUM ? '.name' : ''}}");
     });
     return literal(definePath);
   }
 
   Code _generateRequest(MethodElement m, ConstantReader httpMethod) {
     final returnAsyncWrapper =
-        m.returnType.isDartAsyncFuture ? 'return' : 'yield';
+    m.returnType.isDartAsyncFuture ? 'return' : 'yield';
     final path = _generatePath(m, httpMethod);
     final blocks = <Code>[];
 
@@ -364,11 +365,11 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     _generateQueries(m, blocks, _queryParamsVar);
     Map<String, Expression> headers = _generateHeaders(m);
-    blocks.add(literalMap(
-            headers.map((k, v) => MapEntry(literalString(k, raw: true), v)),
-            refer("String"),
-            refer("dynamic"))
-        .assignFinal(_localHeadersVar)
+    blocks.add(declareFinal(_localHeadersVar)
+        .assign(literalMap(
+        headers.map((k, v) => MapEntry(literalString(k, raw: true), v)),
+        refer("String"),
+        refer("dynamic")))
         .statement);
 
     if (headers.isNotEmpty) {
@@ -405,10 +406,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       log.info("ResponseType  :  ${v?.getField("index")?.toIntValue()}");
       final rsType = ResponseType.values.firstWhere((it) {
         return responseType
-                .peek("responseType")
-                ?.objectValue
-                .getField('index')
-                ?.toIntValue() ==
+            .peek("responseType")
+            ?.objectValue
+            .getField('index')
+            ?.toIntValue() ==
             it.index;
       }, orElse: () {
         log.warning("responseType cast error!!!!");
@@ -460,7 +461,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     }
 
     final bool isWrappered =
-        _typeChecker(retrofit.HttpResponse).isExactlyType(wrapperedReturnType);
+    _typeChecker(retrofit.HttpResponse).isExactlyType(wrapperedReturnType);
     final returnType = isWrappered
         ? _getResponseType(wrapperedReturnType)
         : wrapperedReturnType;
@@ -486,38 +487,33 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       if (_typeChecker(List).isExactlyType(returnType) ||
           _typeChecker(BuiltList).isExactlyType(returnType)) {
         if (_isBasicType(innerReturnType)) {
-          blocks.add(
-            refer("await $_dioVar.fetch<List<dynamic>>")
-                .call([options])
-                .assignFinal(_resultVar)
-                .statement,
-          );
+          blocks.add(declareFinal(_resultVar)
+              .assign(
+              refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
+              .statement);
 
-          blocks.add(refer('$_resultVar.data')
+          blocks.add(declareFinal('value')
+              .assign(refer('$_resultVar.data')
               .propertyIf(thisNullable: returnType.isNullable, name: 'cast')
               .call([], {}, [
-                refer(
-                    '${_displayString(innerReturnType, withNullability: innerReturnType?.isNullable ?? false)}')
-              ])
-              .assignFinal('value')
+            refer(
+                '${_displayString(innerReturnType, withNullability: innerReturnType?.isNullable ?? false)}')
+          ]))
               .statement);
         } else {
-          blocks.add(
-            refer("await $_dioVar.fetch<List<dynamic>>")
-                .call([options])
-                .assignFinal(_resultVar)
-                .statement,
-          );
+          blocks.add(declareFinal(_resultVar)
+              .assign(
+              refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
+              .statement);
           if (clientAnnotation.parser == retrofit.Parser.FlutterCompute) {
-            blocks.add(refer('$_resultVar.data')
-                .conditionalIsNullIf(
-                    thisNullable: returnType.isNullable,
-                    whenFalse: refer('await compute').call([
-                      refer(
-                          'deserialize${_displayString(innerReturnType)}List'),
-                      refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
-                    ]))
-                .assignVar('value')
+            blocks.add(declareVar('value')
+                .assign(refer('$_resultVar.data').conditionalIsNullIf(
+                thisNullable: returnType.isNullable,
+                whenFalse: refer('await compute').call([
+                  refer(
+                      'deserialize${_displayString(innerReturnType)}List'),
+                  refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
+                ])))
                 .statement);
           } else {
             final Reference mapperCode;
@@ -542,26 +538,23 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               case retrofit.Parser.FlutterCompute:
                 throw Exception('Unreachable code');
             }
-            blocks.add(
-              refer('$_resultVar.data')
-                  .propertyIf(thisNullable: returnType.isNullable, name: 'map')
-                  .call([mapperCode])
-                  .property('toList')
-                  .call([])
-                  .assignVar('value')
-                  .statement,
-            );
+            blocks.add(declareVar('value')
+                .assign(refer('$_resultVar.data')
+                .propertyIf(
+                thisNullable: returnType.isNullable, name: 'map')
+                .call([mapperCode])
+                .property('toList')
+                .call([]))
+                .statement);
           }
         }
       } else if (_typeChecker(Map).isExactlyType(returnType) ||
           _typeChecker(BuiltMap).isExactlyType(returnType)) {
         final types = _getResponseInnerTypes(returnType)!;
-        blocks.add(
-          refer("await $_dioVar.fetch<Map<String,dynamic>>")
-              .call([options])
-              .assignFinal(_resultVar)
-              .statement,
-        );
+        blocks.add(declareFinal(_resultVar)
+            .assign(refer("await $_dioVar.fetch<Map<String,dynamic>>")
+            .call([options]))
+            .statement);
 
         /// assume the first type is a basic type
         if (types.length > 1) {
@@ -618,19 +611,19 @@ You should create a new class to encapsulate the response.
                 break;
             }
             if (future) {
-              blocks.add(refer('Map.fromEntries')
-                  .call([
-                    refer('await Future.wait').call([
-                      refer('$_resultVar.data!.entries.map').call([mapperCode])
-                    ])
-                  ])
-                  .assignVar('value')
+              blocks.add(declareVar('value')
+                  .assign(refer('Map.fromEntries').call([
+                refer('await Future.wait').call([
+                  refer('$_resultVar.data!.entries.map').call([mapperCode])
+                ])
+              ]))
                   .statement);
             } else {
-              blocks.add(refer('$_resultVar.data')
-                  .propertyIf(thisNullable: returnType.isNullable, name: 'map')
-                  .call([mapperCode])
-                  .assignVar('value')
+              blocks.add(declareVar('value')
+                  .assign(refer('$_resultVar.data')
+                  .propertyIf(
+                  thisNullable: returnType.isNullable, name: 'map')
+                  .call([mapperCode]))
                   .statement);
             }
           } else if (!_isBasicType(secondType)) {
@@ -663,32 +656,33 @@ You should create a new class to encapsulate the response.
                 break;
             }
             if (future) {
-              blocks.add(refer('$_resultVar.data')
-                  .conditionalIsNullIf(
-                      thisNullable: returnType.isNullable,
-                      whenFalse: refer('Map.fromEntries').call([
-                        refer('await Future.wait').call([
-                          refer('$_resultVar.data!.entries.map')
-                              .call([mapperCode])
-                        ])
-                      ]))
-                  .assignVar('value')
+              blocks.add(declareVar('value')
+                  .assign(refer('$_resultVar.data').conditionalIsNullIf(
+                  thisNullable: returnType.isNullable,
+                  whenFalse: refer('Map.fromEntries').call([
+                    refer('await Future.wait').call([
+                      refer('$_resultVar.data!.entries.map')
+                          .call([mapperCode])
+                    ])
+                  ])))
                   .statement);
             } else {
-              blocks.add(refer('$_resultVar.data')
-                  .propertyIf(thisNullable: returnType.isNullable, name: 'map')
-                  .call([mapperCode])
-                  .assignVar('value')
+              blocks.add(declareVar('value')
+                  .assign(refer('$_resultVar.data')
+                  .propertyIf(
+                  thisNullable: returnType.isNullable, name: 'map')
+                  .call([mapperCode]))
                   .statement);
             }
           } else {
-            blocks.add(refer('$_resultVar.data')
-                .propertyIf(thisNullable: returnType.isNullable, name: 'cast')
+            blocks.add(declareFinal('value')
+                .assign(refer('$_resultVar.data')
+                .propertyIf(
+                thisNullable: returnType.isNullable, name: 'cast')
                 .call([], {}, [
-                  refer('${_displayString(firstType)}'),
-                  refer('${_displayString(secondType)}'),
-                ])
-                .assignFinal('value')
+              refer('${_displayString(firstType)}'),
+              refer('${_displayString(secondType)}'),
+            ]))
                 .statement);
           }
         } else {
@@ -696,34 +690,29 @@ You should create a new class to encapsulate the response.
         }
       } else {
         if (_isBasicType(returnType)) {
-          blocks.add(
-            refer("await $_dioVar.fetch<${_displayString(returnType)}>")
-                .call([options])
-                .assignFinal(_resultVar)
-                .statement,
-          );
-          blocks.add(refer('$_resultVar.data')
-              .asNoNullIf(returnNullable: returnType.isNullable)
-              .assignFinal('value')
+          blocks.add(declareFinal(_resultVar)
+              .assign(
+              refer("await $_dioVar.fetch<${_displayString(returnType)}>")
+                  .call([options]))
+              .statement);
+          blocks.add(declareFinal('value')
+              .assign(refer('$_resultVar.data')
+              .asNoNullIf(returnNullable: returnType.isNullable))
               .statement);
         } else if (returnType.toString() == 'dynamic') {
-          blocks.add(
-            refer("await $_dioVar.fetch")
-                .call([options])
-                .assignFinal(_resultVar)
-                .statement,
-          );
+          blocks.add(declareFinal(_resultVar)
+              .assign(refer("await $_dioVar.fetch").call([options]))
+              .statement);
           blocks.add(Code("final value = $_resultVar.data;"));
         } else {
           final fetchType = returnType.isNullable
               ? "Map<String,dynamic>?"
               : "Map<String,dynamic>";
-          blocks.add(
-            refer("await $_dioVar.fetch<$fetchType>")
-                .call([options])
-                .assignFinal(_resultVar)
-                .statement,
-          );
+          blocks.add(declareFinal(_resultVar)
+              .assign(refer("await $_dioVar"
+              ".fetch<$fetchType>")
+              .call([options]))
+              .statement);
           Expression mapperCode;
           switch (clientAnnotation.parser) {
             case retrofit.Parser.MapSerializable:
@@ -732,7 +721,7 @@ You should create a new class to encapsulate the response.
               break;
             case retrofit.Parser.JsonSerializable:
               final genericArgumentFactories =
-                  isGenericArgumentFactories(returnType);
+              isGenericArgumentFactories(returnType);
 
               var typeArgs = returnType is ParameterizedType
                   ? returnType.typeArguments
@@ -740,7 +729,7 @@ You should create a new class to encapsulate the response.
 
               if (typeArgs.length > 0 && genericArgumentFactories) {
                 //Remove the outermost nullable modifier
-                //see NullableDynamicNullableInnerGenericTypeShouldBeCastedAsMap from generator/test/src/generator_test_src.dart:1529 
+                //see NullableDynamicNullableInnerGenericTypeShouldBeCastedAsMap from generator/test/src/generator_test_src.dart:1529
                 var displayString = _displayString(returnType,
                     withNullability: innerReturnType?.isNullable ?? false);
                 displayString = displayString.endsWith("?")
@@ -762,12 +751,11 @@ You should create a new class to encapsulate the response.
                   'await compute(deserialize${_displayString(returnType)}, $_resultVar.data!)');
               break;
           }
-          blocks.add(refer('$_resultVar.data')
-              .conditionalIsNullIf(
-                thisNullable: returnType.isNullable,
-                whenFalse: mapperCode,
-              )
-              .assignFinal('value')
+          blocks.add(declareFinal('value')
+              .assign(refer('$_resultVar.data').conditionalIsNullIf(
+            thisNullable: returnType.isNullable,
+            whenFalse: mapperCode,
+          ))
               .statement);
         }
       }
@@ -785,12 +773,12 @@ You should create a new class to encapsulate the response.
   }
 
   bool isGenericArgumentFactories(DartType? dartType) {
-    final metaData = dartType?.element?.metadata;
+    final metaData = dartType?.element2?.metadata;
     if (metaData == null || dartType == null) {
       return false;
     }
     final constDartObj =
-        metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
+    metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
     var genericArgumentFactories = false;
     if (constDartObj != null &&
         (!_typeChecker(List).isExactlyType(dartType) &&
@@ -813,7 +801,7 @@ You should create a new class to encapsulate the response.
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
         var typeArgs =
-            genericType is ParameterizedType ? genericType.typeArguments : [];
+        genericType is ParameterizedType ? genericType.typeArguments : [];
         var mapperVal;
 
         var genericTypeString = "${_displayString(genericType)}";
@@ -859,10 +847,10 @@ You should create a new class to encapsulate the response.
           } else {
             if (isGenericArgumentFactories(arg))
               mappedVal +=
-                  "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(arg)}),";
+              "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(arg)}),";
             else
               mappedVal +=
-                  "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
+              "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
           }
           else {
             mappedVal += "${_getInnerJsonSerializableMapperFn(arg)}";
@@ -890,20 +878,20 @@ You should create a new class to encapsulate the response.
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
         var typeArgs =
-            genericType is ParameterizedType ? genericType.typeArguments : [];
+        genericType is ParameterizedType ? genericType.typeArguments : [];
         var mapperVal;
 
         if (typeArgs.length > 0 &&
             isGenericArgumentFactories(genericType) &&
             genericType != null) {
           mapperVal =
-              '(value) => value.map((value) => ${_getInnerJsonDeSerializableMapperFn(genericType)}).toList()';
+          '(value) => value.map((value) => ${_getInnerJsonDeSerializableMapperFn(genericType)}).toList()';
         } else {
           if (_isBasicType(genericType)) {
             mapperVal = '(value) => value';
           } else {
             mapperVal =
-                '(value) => value.map((value) => value.toJson()).toList()';
+            '(value) => value.map((value) => value.toJson()).toList()';
           }
         }
         return mapperVal;
@@ -917,7 +905,7 @@ You should create a new class to encapsulate the response.
           } else {
             if (isGenericArgumentFactories(arg))
               mappedVal =
-                  '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
+              '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
             else {
               mappedVal = "(value) => value";
             }
@@ -975,22 +963,22 @@ You should create a new class to encapsulate the response.
             .newInstance([], args)
             .property('compose')
             .call(
-              [refer(_dioVar).property('options'), path],
-              composeArguments,
-            )
+          [refer(_dioVar).property('options'), path],
+          composeArguments,
+        )
             .property('copyWith')
             .call([], {
-              _baseUrlVar: baseUrl.ifNullThen(
-                  refer(_dioVar).property('options').property('baseUrl'))
-            })
+          _baseUrlVar: baseUrl.ifNullThen(
+              refer(_dioVar).property('options').property('baseUrl'))
+        })
       ], {}, [
         type
       ]);
     } else {
       hasCustomOptions = true;
-      blocks.add(refer("newRequestOptions")
-          .call([refer(annoOptions.item1.displayName)])
-          .assignFinal("newOptions")
+      blocks.add(declareFinal("newOptions")
+          .assign(refer("newRequestOptions")
+          .call([refer(annoOptions.item1.displayName)]))
           .statement);
       final newOptions = refer("newOptions");
       blocks.add(newOptions
@@ -1006,12 +994,12 @@ You should create a new class to encapsulate the response.
       return newOptions
           .property('copyWith')
           .call(
-              [],
-              Map.from(extraOptions)
-                ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
-                ..[_path] = namedArguments[_path]!
-                ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
-                    refer(_dioVar).property('options').property('baseUrl')))
+          [],
+          Map.from(extraOptions)
+            ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
+            ..[_path] = namedArguments[_path]!
+            ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
+                refer(_dioVar).property('options').property('baseUrl')))
           .cascade('data')
           .assign(namedArguments[_dataVar]!);
     }
@@ -1023,13 +1011,13 @@ You should create a new class to encapsulate the response.
         ..name = "newRequestOptions"
         ..returns = refer("RequestOptions")
 
-        /// required parameters
+      /// required parameters
         ..requiredParameters.add(Parameter((p) {
           p.name = "options";
           p.type = refer("Object?").type;
         }))
 
-        /// add method body
+      /// add method body
         ..body = Code('''
          if (options is RequestOptions) {
             return options as RequestOptions;
@@ -1136,8 +1124,8 @@ You should create a new class to encapsulate the response.
     });
 
     final queryMap = _getAnnotations(m, retrofit.Queries);
-    blocks.add(literalMap(queryParameters, refer("String"), refer("dynamic"))
-        .assignFinal(_queryParamsVar)
+    blocks.add(declareFinal(_queryParamsVar)
+        .assign(literalMap(queryParameters, refer("String"), refer("dynamic")))
         .statement);
     for (final p in queryMap.keys) {
       final type = p.type;
@@ -1190,8 +1178,9 @@ You should create a new class to encapsulate the response.
       List<Code> blocks, String _dataVar, MethodElement m) {
     final _noBody = _getMethodAnnotationByType(m, retrofit.NoBody);
     if (_noBody != null) {
-      blocks
-          .add(refer('null').assignFinal(_dataVar, refer('String?')).statement);
+      blocks.add(declareFinal(_dataVar, type: refer('String?'))
+          .assign(refer('null'))
+          .statement);
       return;
     }
 
@@ -1200,10 +1189,10 @@ You should create a new class to encapsulate the response.
     if (_bodyName != null) {
       final nullToAbsent =
           annotation!.item2.peek('nullToAbsent')?.boolValue ?? false;
-      final bodyTypeElement = _bodyName.type.element;
+      final bodyTypeElement = _bodyName.type.element2;
       if (TypeChecker.fromRuntime(Map).isAssignableFromType(_bodyName.type)) {
-        blocks.add(literalMap({}, refer("String"), refer("dynamic"))
-            .assignFinal(_dataVar)
+        blocks.add(declareFinal(_dataVar)
+            .assign(literalMap({}, refer("String"), refer("dynamic")))
             .statement);
 
         blocks.add(refer("$_dataVar.addAll").call([
@@ -1214,48 +1203,47 @@ You should create a new class to encapsulate the response.
           blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
       } else if (bodyTypeElement != null &&
           ((_typeChecker(List).isExactly(bodyTypeElement) ||
-                  _typeChecker(BuiltList).isExactly(bodyTypeElement)) &&
+              _typeChecker(BuiltList).isExactly(bodyTypeElement)) &&
               !_isBasicInnerType(_bodyName.type))) {
         switch (clientAnnotation.parser) {
           case retrofit.Parser.JsonSerializable:
           case retrofit.Parser.DartJsonMapper:
-            blocks.add(refer('''
+            blocks.add(declareFinal(_dataVar).assign(refer('''
             ${_bodyName.displayName}.map((e) => e.toJson()).toList()
-            ''').assignFinal(_dataVar).statement);
+            ''')).statement);
             break;
           case retrofit.Parser.MapSerializable:
-            blocks.add(refer('''
+            blocks.add(declareFinal(_dataVar).assign(refer('''
             ${_bodyName.displayName}.map((e) => e.toMap()).toList()
-            ''').assignFinal(_dataVar).statement);
+            ''')).statement);
             break;
           case retrofit.Parser.FlutterCompute:
-            blocks.add(refer('''
+            blocks.add(declareFinal(_dataVar).assign(refer('''
             await compute(serialize${_displayString(_genericOf(_bodyName.type))}List, ${_bodyName.displayName})
-            ''').assignFinal(_dataVar).statement);
+            ''')).statement);
             break;
         }
       } else if (bodyTypeElement != null &&
           _typeChecker(File).isExactly(bodyTypeElement)) {
-        blocks.add(refer("Stream")
-            .property("fromIterable")
-            .call([
-              refer("${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])")
-            ])
-            .assignFinal(_dataVar)
+        blocks.add(declareFinal(_dataVar)
+            .assign(refer("Stream").property("fromIterable").call([
+          refer("${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])")
+        ]))
             .statement);
-      } else if (_bodyName.type.element is ClassElement) {
-        final ele = _bodyName.type.element as ClassElement;
+      } else if (_bodyName.type.element2 is ClassElement) {
+        final ele = _bodyName.type.element2 as ClassElement;
         if (clientAnnotation.parser == retrofit.Parser.MapSerializable) {
           final toMap = ele.lookUpMethod('toMap', ele.library);
           if (toMap == null) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toMap()` method which return a Map.\n"
-                "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
-            blocks.add(
-                refer(_bodyName.displayName).assignFinal(_dataVar).statement);
+                    "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
+            blocks.add(declareFinal(_dataVar)
+                .assign(refer(_bodyName.displayName))
+                .statement);
           } else {
-            blocks.add(literalMap({}, refer("String"), refer("dynamic"))
-                .assignFinal(_dataVar)
+            blocks.add(declareFinal(_dataVar)
+                .assign(literalMap({}, refer("String"), refer("dynamic")))
                 .statement);
             blocks.add(refer("$_dataVar.addAll").call([
               refer("${_bodyName.displayName}?.toMap() ?? <String,dynamic>{}")
@@ -1265,26 +1253,28 @@ You should create a new class to encapsulate the response.
           if (_missingToJson(ele)) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toJson()` method which return a Map.\n"
-                "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
-            blocks.add(
-                refer(_bodyName.displayName).assignFinal(_dataVar).statement);
-          } else if (_missingSerialize(ele.enclosingElement, _bodyName.type)) {
+                    "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
+            blocks.add(declareFinal(_dataVar)
+                .assign(refer(_bodyName.displayName))
+                .statement);
+          } else if (_missingSerialize(ele.enclosingElement3, _bodyName.type)) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `serialize${_displayString(_bodyName.type)}()` method which returns a Map.\n"
-                "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
-            blocks.add(
-                refer(_bodyName.displayName).assignFinal(_dataVar).statement);
+                    "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
+            blocks.add(declareFinal(_dataVar)
+                .assign(refer(_bodyName.displayName))
+                .statement);
           } else {
-            blocks.add(literalMap({}, refer("String"), refer("dynamic"))
-                .assignFinal(_dataVar)
+            blocks.add(declareFinal(_dataVar)
+                .assign(literalMap({}, refer("String"), refer("dynamic")))
                 .statement);
 
             final _bodyType = _bodyName.type;
             final genericArgumentFactories =
-                isGenericArgumentFactories(_bodyType);
+            isGenericArgumentFactories(_bodyType);
 
             var typeArgs =
-                _bodyType is ParameterizedType ? _bodyType.typeArguments : [];
+            _bodyType is ParameterizedType ? _bodyType.typeArguments : [];
 
             String toJsonCode = '';
             if (typeArgs.length > 0 && genericArgumentFactories) {
@@ -1323,7 +1313,7 @@ You should create a new class to encapsulate the response.
                 }
                 break;
               case retrofit.Parser.MapSerializable:
-                // Unreachable code
+              // Unreachable code
                 break;
             }
 
@@ -1333,8 +1323,9 @@ You should create a new class to encapsulate the response.
         }
       } else {
         /// @Body annotations with no type are assinged as is
-        blocks
-            .add(refer(_bodyName.displayName).assignFinal(_dataVar).statement);
+        blocks.add(declareFinal(_dataVar)
+            .assign(refer(_bodyName.displayName))
+            .statement);
       }
 
       return;
@@ -1353,7 +1344,7 @@ You should create a new class to encapsulate the response.
     });
 
     if (fields.isNotEmpty) {
-      blocks.add(literalMap(fields).assignFinal(_dataVar).statement);
+      blocks.add(declareFinal(_dataVar).assign(literalMap(fields)).statement);
       if (anyNullable) {
         blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
       }
@@ -1363,23 +1354,22 @@ You should create a new class to encapsulate the response.
     final parts = _getAnnotations(m, retrofit.Part);
     if (parts.isNotEmpty) {
       if (m.parameters.length == 1 && m.parameters.first.type.isDartCoreMap) {
-        blocks.add(refer('FormData')
-            .newInstanceNamed('fromMap',
-                [CodeExpression(Code(m.parameters.first.displayName))])
-            .assignFinal(_dataVar)
+        blocks.add(declareFinal(_dataVar)
+            .assign(refer('FormData').newInstanceNamed('fromMap',
+            [CodeExpression(Code(m.parameters.first.displayName))]))
             .statement);
         return;
       } else if (m.parameters.length == 2 &&
           m.parameters[1].type.isDartCoreMap) {
-        blocks.add(refer('FormData')
-            .newInstanceNamed(
-                'fromMap', [CodeExpression(Code(m.parameters[1].displayName))])
-            .assignFinal(_dataVar)
+        blocks.add(declareFinal(_dataVar)
+            .assign(refer('FormData').newInstanceNamed(
+            'fromMap', [CodeExpression(Code(m.parameters[1].displayName))]))
             .statement);
         return;
       }
-      blocks.add(
-          refer('FormData').newInstance([]).assignFinal(_dataVar).statement);
+      blocks.add(declareFinal(_dataVar)
+          .assign(refer('FormData').newInstance([]))
+          .statement);
 
       parts.forEach((p, r) {
         final fieldName = r.peek("name")?.stringValue ??
@@ -1393,7 +1383,7 @@ You should create a new class to encapsulate the response.
           final fileName = fileNameValue != null
               ? literalString(fileNameValue)
               : refer(p.displayName)
-                  .property('path.split(Platform.pathSeparator).last');
+              .property('path.split(Platform.pathSeparator).last');
 
           final uploadFileInfo = refer('$MultipartFile.fromFileSync').call([
             refer(p.displayName).property('path')
@@ -1401,20 +1391,20 @@ You should create a new class to encapsulate the response.
             'filename': fileName,
             if (contentType != null)
               'contentType':
-                  refer("MediaType", 'package:http_parser/http_parser.dart')
-                      .property('parse')
-                      .call([literal(contentType)])
+              refer("MediaType", 'package:http_parser/http_parser.dart')
+                  .property('parse')
+                  .call([literal(contentType)])
           });
 
           final optinalFile = m.parameters
-                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
-                  ?.isOptional ??
+              .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+              ?.isOptional ??
               false;
 
           final returnCode =
               refer(_dataVar).property('files').property("add").call([
-            refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
-          ]).statement;
+                refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
+              ]).statement;
           if (optinalFile) {
             final condication =
                 refer(p.displayName).notEqualTo(literalNull).code;
@@ -1425,8 +1415,8 @@ You should create a new class to encapsulate the response.
           }
         } else if (_displayString(p.type) == "List<int>") {
           final optionalFile = m.parameters
-                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
-                  ?.isOptional ??
+              .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+              ?.isOptional ??
               false;
           final fileName = r.peek("fileName")?.stringValue;
           final conType = contentType == null
@@ -1434,7 +1424,7 @@ You should create a new class to encapsulate the response.
               : 'contentType: MediaType.parse(${literal(contentType)}),';
           final returnCode =
               refer(_dataVar).property('files').property("add").call([
-            refer(''' 
+                refer(''' 
                   MapEntry(
                 '${fieldName}',
                 MultipartFile.fromBytes(${p.displayName},
@@ -1443,7 +1433,7 @@ You should create a new class to encapsulate the response.
                     ${conType}
                     ))
                   ''')
-          ]).statement;
+              ]).statement;
           if (optionalFile) {
             final condition = refer(p.displayName).notEqualTo(literalNull).code;
             blocks.addAll(
@@ -1479,9 +1469,9 @@ You should create a new class to encapsulate the response.
                       _typeChecker(BuiltList).isExactlyType(innerType)))) {
             var value = _isBasicType(innerType) ? 'i' : 'jsonEncode(i)';
             var nullableInfix =
-                (p.type.nullabilitySuffix == NullabilitySuffix.question)
-                    ? '?'
-                    : '';
+            (p.type.nullabilitySuffix == NullabilitySuffix.question)
+                ? '?'
+                : '';
             blocks.add(refer('''
             ${p.displayName}$nullableInfix.forEach((i){
               ${_dataVar}.fields.add(MapEntry(${literal(fieldName)},${value}));
@@ -1525,8 +1515,8 @@ You should create a new class to encapsulate the response.
             if (p.type.isNullable) {
               blocks.add(Code("}"));
             }
-          } else if (innerType?.element is ClassElement) {
-            final ele = innerType!.element as ClassElement;
+          } else if (innerType?.element2 is ClassElement) {
+            final ele = innerType!.element2 as ClassElement;
             if (_missingToJson(ele)) {
               throw Exception("toJson() method have to add to ${p.type}");
             } else {
@@ -1561,8 +1551,8 @@ You should create a new class to encapsulate the response.
             refer("MapEntry").newInstance(
                 [literal(fieldName), refer("jsonEncode(${p.displayName})")])
           ]).statement);
-        } else if (p.type.element is ClassElement) {
-          final ele = p.type.element as ClassElement;
+        } else if (p.type.element2 is ClassElement) {
+          final ele = p.type.element2 as ClassElement;
           if (_missingToJson(ele)) {
             throw Exception("toJson() method have to add to ${p.type}");
           } else {
@@ -1585,8 +1575,8 @@ You should create a new class to encapsulate the response.
     }
 
     /// There is no body
-    blocks.add(literalMap({}, refer("String"), refer("dynamic"))
-        .assignFinal(_dataVar)
+    blocks.add(declareFinal(_dataVar)
+        .assign(literalMap({}, refer("String"), refer("dynamic")))
         .statement);
   }
 
@@ -1595,10 +1585,10 @@ You should create a new class to encapsulate the response.
         .map((e) => e.peek('value'))
         .map((value) => value?.mapValue.map((k, v) {
       return MapEntry(
-                k?.toStringValue() ?? 'null',
-                literal(v?.toStringValue()),
-              );
-            }))
+        k?.toStringValue() ?? 'null',
+        literal(v?.toStringValue()),
+      );
+    }))
         .fold<Map<String, Expression>>({}, (p, e) => p..addAll(e ?? {}));
 
     final annosInParam = _getAnnotations(m, retrofit.Header);
@@ -1655,33 +1645,37 @@ You should create a new class to encapsulate the response.
 
   void _generateExtra(
       MethodElement m, List<Code> blocks, String localExtraVar) {
-      blocks.add(literalMap(
+    blocks.add(declareConst(localExtraVar)
+        .assign(literalMap(
       _getMethodAnnotations(m, retrofit.Extra)
           .map((e) => e.peek('data'))
           .map((data) => data?.mapValue.map((k, v) {
-              return MapEntry(
-                k?.toStringValue() ??
-                    (throw InvalidGenerationSourceError(
-                      'Invalid key for extra Map, only `String` keys are supported',
-                      element: m,
-                      todo: 'Make sure all keys are of string type',
-                    )),
-                v?.toBoolValue() ??
-                    v?.toDoubleValue() ??
-                    v?.toIntValue() ??
-                    v?.toStringValue() ??
-                    v?.toListValue() ??
-                    v?.toMapValue() ??
-                    v?.toSetValue() ??
-                    v?.toSymbolValue() ??
-                    (v?.toTypeValue() ??
-                        (v != null ? Code(revivedLiteral(v)) : Code('null'))),
-              );
-              }))
+        return MapEntry(
+          k?.toStringValue() ??
+              (throw InvalidGenerationSourceError(
+                'Invalid key for extra Map, only `String` keys are supported',
+                element: m,
+                todo: 'Make sure all keys are of string type',
+              )),
+          v?.toBoolValue() ??
+              v?.toDoubleValue() ??
+              v?.toIntValue() ??
+              v?.toStringValue() ??
+              v?.toListValue() ??
+              v?.toMapValue() ??
+              v?.toSetValue() ??
+              v?.toSymbolValue() ??
+              (v?.toTypeValue() ??
+                  (v != null
+                      ? Code(revivedLiteral(v))
+                      : Code('null'))),
+        );
+      }))
           .fold<Map<String, Object>>({}, (p, e) => p..addAll(e ?? {})),
-        refer('String'),
-        refer('dynamic'),
-      ).assignConst(localExtraVar).statement);
+      refer('String'),
+      refer('dynamic'),
+    ))
+        .statement);
   }
 
   bool _missingToJson(ClassElement ele) {
@@ -1704,7 +1698,7 @@ You should create a new class to encapsulate the response.
         return false;
       case retrofit.Parser.FlutterCompute:
         return !ele.functions.any((element) =>
-            element.name == 'serialize${_displayString(type)}' &&
+        element.name == 'serialize${_displayString(type)}' &&
             element.parameters.length == 1 &&
             _displayString(element.parameters[0].type) == _displayString(type));
     }
@@ -1718,9 +1712,9 @@ Builder generatorFactoryBuilder(BuilderOptions options) => SharedPartBuilder(
 /// [object] must not be null.
 /// [object] is assumed to be a constant.
 String revivedLiteral(
-  Object object, {
-  DartEmitter? dartEmitter,
-}) {
+    Object object, {
+      DartEmitter? dartEmitter,
+    }) {
   dartEmitter ??= DartEmitter();
 
   ArgumentError.checkNotNull(object, 'object');
@@ -1833,7 +1827,8 @@ String revivedLiteral(
 
 extension DartTypeStreamAnnotation on DartType {
   bool get isDartAsyncStream {
-    final element = this.element == null ? null : this.element as ClassElement;
+    final element =
+    this.element2 != null ? null : this.element2 as ClassElement;
     if (element == null) {
       return false;
     }

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -385,7 +385,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     final paths = _getAnnotations(m, retrofit.Path);
     String? definePath = method.peek("path")?.stringValue;
     paths.forEach((k, v) {
-      final value = v.peek("value")?.stringValue ?? k.displayName;
+      final value = v.peek(_valueVar)?.stringValue ?? k.displayName;
       definePath = definePath?.replaceFirst(
         "{$value}",
         "\${${k.displayName}${k.type.element2?.kind == ElementKind.ENUM ? '.name' : ''}}",
@@ -1259,7 +1259,7 @@ You should create a new class to encapsulate the response.
   ) {
     final queries = _getAnnotations(m, retrofit.Query);
     final queryParameters = queries.map((p, ConstantReader r) {
-      final key = r.peek("value")?.stringValue ?? p.displayName;
+      final key = r.peek(_valueVar)?.stringValue ?? p.displayName;
       final Expression value;
       if (_isBasicType(p.type) ||
           p.type.isDartCoreList ||
@@ -1568,7 +1568,7 @@ You should create a new class to encapsulate the response.
     var anyNullable = false;
     final fields = _getAnnotations(m, retrofit.Field).map((p, r) {
       anyNullable |= p.type.nullabilitySuffix == NullabilitySuffix.question;
-      final fieldName = r.peek("value")?.stringValue ?? p.displayName;
+      final fieldName = r.peek(_valueVar)?.stringValue ?? p.displayName;
       final isFileField = _typeChecker(File).isAssignableFromType(p.type);
       if (isFileField) {
         log.severe(
@@ -1622,7 +1622,7 @@ You should create a new class to encapsulate the response.
 
       parts.forEach((p, r) {
         final fieldName = r.peek("name")?.stringValue ??
-            r.peek("value")?.stringValue ??
+            r.peek(_valueVar)?.stringValue ??
             p.displayName;
         final isFileField = _typeChecker(File).isAssignableFromType(p.type);
         final contentType = r.peek('contentType')?.stringValue;
@@ -1878,7 +1878,7 @@ You should create a new class to encapsulate the response.
 
     final annotationsInParam = _getAnnotations(m, retrofit.Header);
     final headersInParams = annotationsInParam.map((k, v) {
-      final value = v.peek("value")?.stringValue ?? k.displayName;
+      final value = v.peek(_valueVar)?.stringValue ?? k.displayName;
       return MapEntry(value, refer(k.displayName));
     });
     headers.addAll(headersInParams);

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -24,8 +24,8 @@ class RetrofitOptions {
 
   RetrofitOptions.fromOptions([BuilderOptions? options])
       : autoCastResponse =
-            (options?.config['auto_cast_response']?.toString() ?? 'true') ==
-                'true';
+      (options?.config['auto_cast_response']?.toString() ?? 'true') ==
+          'true';
 }
 
 class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
@@ -56,10 +56,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   @override
   String generateForAnnotatedElement(
-    Element element,
-    ConstantReader annotation,
-    BuildStep buildStep,
-  ) {
+      Element element, ConstantReader annotation, BuildStep buildStep) {
     if (element is! ClassElement) {
       final name = element.displayName;
       throw InvalidGenerationSourceError(
@@ -90,7 +87,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         ..fields.addAll([_buildDioFiled(), _buildBaseUrlFiled(baseUrl)])
         ..constructors.addAll(
           annotClassConsts.map(
-            (e) => _generateConstructor(baseUrl, superClassConst: e),
+                (e) => _generateConstructor(baseUrl, superClassConst: e),
           ),
         )
         ..methods.addAll(_parseMethods(element));
@@ -111,40 +108,30 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         .format([_analyzerIgnores, classBuilder.accept(emitter)].join('\n\n'));
   }
 
-  Field _buildDioFiled() => Field(
-        (m) => m
-          ..name = _dioVar
-          ..type = refer("Dio")
-          ..modifier = FieldModifier.final$,
-      );
+  Field _buildDioFiled() => Field((m) => m
+    ..name = _dioVar
+    ..type = refer("Dio")
+    ..modifier = FieldModifier.final$);
 
   Field _buildBaseUrlFiled(String? url) => Field((m) {
-        m
-          ..name = _baseUrlVar
-          ..type = refer("String?")
-          ..modifier = FieldModifier.var$;
-      });
+    m
+      ..name = _baseUrlVar
+      ..type = refer("String?")
+      ..modifier = FieldModifier.var$;
+  });
 
   Constructor _generateConstructor(
-    String? url, {
-    ConstructorElement? superClassConst,
-  }) =>
+      String? url, {
+        ConstructorElement? superClassConst,
+      }) =>
       Constructor((c) {
-        c.requiredParameters.add(
-          Parameter(
-            (p) => p
-              ..name = _dioVar
-              ..toThis = true,
-          ),
-        );
-        c.optionalParameters.add(
-          Parameter(
-            (p) => p
-              ..named = true
-              ..name = _baseUrlVar
-              ..toThis = true,
-          ),
-        );
+        c.requiredParameters.add(Parameter((p) => p
+          ..name = _dioVar
+          ..toThis = true));
+        c.optionalParameters.add(Parameter((p) => p
+          ..named = true
+          ..name = _baseUrlVar
+          ..toThis = true));
         if (superClassConst != null) {
           var superConstName = 'super';
           if (superClassConst.name.isNotEmpty) {
@@ -154,22 +141,14 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           final constParams = superClassConst.parameters;
           constParams.forEach((element) {
             if (!element.isOptional || element.isPrivate) {
-              c.requiredParameters.add(
-                Parameter(
-                  (p) => p
-                    ..type = refer(_displayString(element.type))
-                    ..name = element.name,
-                ),
-              );
+              c.requiredParameters.add(Parameter((p) => p
+                ..type = refer(_displayString(element.type))
+                ..name = element.name));
             } else {
-              c.optionalParameters.add(
-                Parameter(
-                  (p) => p
-                    ..named = element.isNamed
-                    ..type = refer(_displayString(element.type))
-                    ..name = element.name,
-                ),
-              );
+              c.optionalParameters.add(Parameter((p) => p
+                ..named = element.isNamed
+                ..type = refer(_displayString(element.type))
+                ..name = element.name));
             }
           });
           final paramList = constParams
@@ -188,20 +167,20 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       });
 
   Iterable<Method> _parseMethods(ClassElement element) => (<MethodElement>[]
-            ..addAll(element.methods)
-            ..addAll(element.mixins.expand((i) => i.methods)))
-          .where((MethodElement m) {
-        final methodAnnot = _getMethodAnnotation(m);
-        return methodAnnot != null &&
-            m.isAbstract &&
-            (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
-      }).map((m) => _generateMethod(m)!);
+    ..addAll(element.methods)
+    ..addAll(element.mixins.expand((i) => i.methods)))
+      .where((MethodElement m) {
+    final methodAnnot = _getMethodAnnotation(m);
+    return methodAnnot != null &&
+        m.isAbstract &&
+        (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
+  }).map((m) => _generateMethod(m)!);
 
   String _generateTypeParameterizedName(TypeParameterizedElement element) =>
       element.displayName +
-      (element.typeParameters.isNotEmpty
-          ? '<${element.typeParameters.join(',')}>'
-          : '');
+          (element.typeParameters.isNotEmpty
+              ? '<${element.typeParameters.join(',')}>'
+              : '');
 
   final _methodsAnnotations = const [
     retrofit.GET,
@@ -226,7 +205,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   ConstantReader? _getMethodAnnotationByType(MethodElement method, Type type) {
     final annot =
-        _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
+    _typeChecker(type).firstAnnotationOf(method, throwOnUnresolved: false);
     if (annot != null) return ConstantReader(annot);
     return null;
   }
@@ -241,8 +220,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     if (multipart != null && formUrlEncoded != null) {
       throw InvalidGenerationSourceError(
-        'Two content-type annotation on one request ${method.name}',
-      );
+          'Two content-type annotation on one request ${method.name}');
     }
 
     return multipart ?? formUrlEncoded;
@@ -261,18 +239,14 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   Iterable<ConstantReader> _getMethodAnnotations(
-    MethodElement method,
-    Type type,
-  ) {
+      MethodElement method, Type type) {
     return _typeChecker(type)
         .annotationsOf(method, throwOnUnresolved: false)
         .map((e) => ConstantReader(e));
   }
 
   Map<ParameterElement, ConstantReader> _getAnnotations(
-    MethodElement m,
-    Type type,
-  ) {
+      MethodElement m, Type type) {
     var annot = <ParameterElement, ConstantReader>{};
     for (final p in m.parameters) {
       final a = _typeChecker(type).firstAnnotationOf(p);
@@ -284,9 +258,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   }
 
   Tuple2<ParameterElement, ConstantReader>? _getAnnotation(
-    MethodElement m,
-    Type type,
-  ) {
+      MethodElement m, Type type) {
     for (final p in m.parameters) {
       final a = _typeChecker(type).firstAnnotationOf(p);
       if (a != null) {
@@ -341,7 +313,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return Method((mm) {
       mm
         ..returns =
-            refer(_displayString(m.type.returnType, withNullability: true))
+        refer(_displayString(m.type.returnType, withNullability: true))
         ..name = m.displayName
         ..types.addAll(m.typeParameters.map((e) => refer(e.name)))
         ..modifier = m.returnType.isDartAsyncFuture
@@ -350,32 +322,24 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
         ..annotations.add(CodeExpression(Code('override')));
 
       /// required parameters
-      mm.requiredParameters.addAll(
-        m.parameters.where((it) => it.isRequiredPositional).map(
-              (it) => Parameter(
-                (p) => p
-                  ..name = it.name
-                  ..named = it.isNamed,
-              ),
-            ),
-      );
+      mm.requiredParameters.addAll(m.parameters
+          .where((it) => it.isRequiredPositional)
+          .map((it) => Parameter((p) => p
+        ..name = it.name
+        ..named = it.isNamed)));
 
       /// optional positional or named parameters
-      mm.optionalParameters.addAll(
-        m.parameters.where((i) => i.isOptional || i.isRequiredNamed).map(
-              (it) => Parameter(
-                (p) => p
-                  ..required = (it.isNamed &&
-                      it.type.nullabilitySuffix == NullabilitySuffix.none &&
-                      !it.hasDefaultValue)
-                  ..name = it.name
-                  ..named = it.isNamed
-                  ..defaultTo = it.defaultValueCode == null
-                      ? null
-                      : Code(it.defaultValueCode!),
-              ),
-            ),
-      );
+      mm.optionalParameters.addAll(m.parameters
+          .where((i) => i.isOptional || i.isRequiredNamed)
+          .map((it) => Parameter((p) => p
+        ..required = (it.isNamed &&
+            it.type.nullabilitySuffix == NullabilitySuffix.none &&
+            !it.hasDefaultValue)
+        ..name = it.name
+        ..named = it.isNamed
+        ..defaultTo = it.defaultValueCode == null
+            ? null
+            : Code(it.defaultValueCode!))));
       mm.body = _generateRequest(m, httpMehod);
     });
   }
@@ -385,17 +349,15 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     String? definePath = method.peek("path")?.stringValue;
     paths.forEach((k, v) {
       final value = v.peek("value")?.stringValue ?? k.displayName;
-      definePath = definePath?.replaceFirst(
-        "{$value}",
-        "\${${k.displayName}${k.type.element2?.kind == ElementKind.ENUM ? '.name' : ''}}",
-      );
+      definePath = definePath?.replaceFirst("{$value}",
+          "\${${k.displayName}${k.type.element2?.kind == ElementKind.ENUM ? '.name' : ''}}");
     });
     return literal(definePath);
   }
 
   Code _generateRequest(MethodElement m, ConstantReader httpMethod) {
     final returnAsyncWrapper =
-        m.returnType.isDartAsyncFuture ? 'return' : 'yield';
+    m.returnType.isDartAsyncFuture ? 'return' : 'yield';
     final path = _generatePath(m, httpMethod);
     final blocks = <Code>[];
 
@@ -403,17 +365,12 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     _generateQueries(m, blocks, _queryParamsVar);
     Map<String, Expression> headers = _generateHeaders(m);
-    blocks.add(
-      declareFinal(_localHeadersVar)
-          .assign(
-            literalMap(
-              headers.map((k, v) => MapEntry(literalString(k, raw: true), v)),
-              refer("String"),
-              refer("dynamic"),
-            ),
-          )
-          .statement,
-    );
+    blocks.add(declareFinal(_localHeadersVar)
+        .assign(literalMap(
+        headers.map((k, v) => MapEntry(literalString(k, raw: true), v)),
+        refer("String"),
+        refer("dynamic")))
+        .statement);
 
     if (headers.isNotEmpty) {
       blocks.add(Code("${_localHeadersVar}.removeWhere((k, v) => v == null);"));
@@ -429,8 +386,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final contentTypeInHeader = headers.entries
         .firstWhereOrNull(
-          (i) => "Content-Type".toLowerCase() == i.key.toLowerCase(),
-        )
+            (i) => "Content-Type".toLowerCase() == i.key.toLowerCase())
         ?.value;
     if (contentTypeInHeader != null) {
       extraOptions[_contentType] = contentTypeInHeader;
@@ -448,20 +404,17 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     if (responseType != null) {
       final v = responseType.peek("responseType")?.objectValue;
       log.info("ResponseType  :  ${v?.getField("index")?.toIntValue()}");
-      final rsType = ResponseType.values.firstWhere(
-        (it) {
-          return responseType
-                  .peek("responseType")
-                  ?.objectValue
-                  .getField('index')
-                  ?.toIntValue() ==
-              it.index;
-        },
-        orElse: () {
-          log.warning("responseType cast error!!!!");
-          return ResponseType.json;
-        },
-      );
+      final rsType = ResponseType.values.firstWhere((it) {
+        return responseType
+            .peek("responseType")
+            ?.objectValue
+            .getField('index')
+            ?.toIntValue() ==
+            it.index;
+      }, orElse: () {
+        log.warning("responseType cast error!!!!");
+        return ResponseType.json;
+      });
 
       extraOptions["responseType"] = refer(rsType.toString());
     }
@@ -508,7 +461,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     }
 
     final bool isWrappered =
-        _typeChecker(retrofit.HttpResponse).isExactlyType(wrapperedReturnType);
+    _typeChecker(retrofit.HttpResponse).isExactlyType(wrapperedReturnType);
     final returnType = isWrappered
         ? _getResponseType(wrapperedReturnType)
         : wrapperedReturnType;
@@ -518,12 +471,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           refer("final $_resultVar = await $_dioVar.fetch")
               .call([options], {}, [refer("void")]).statement,
         );
-        blocks.add(
-          Code("""
+        blocks.add(Code("""
       final httpResponse = HttpResponse(null, $_resultVar);
       $returnAsyncWrapper httpResponse;
-      """),
-        );
+      """));
       } else {
         blocks.add(
           refer("await $_dioVar.fetch")
@@ -536,106 +487,74 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       if (_typeChecker(List).isExactlyType(returnType) ||
           _typeChecker(BuiltList).isExactlyType(returnType)) {
         if (_isBasicType(innerReturnType)) {
-          blocks.add(
-            declareFinal(_resultVar)
-                .assign(
-                  refer("await $_dioVar.fetch<List<dynamic>>").call([options]),
-                )
-                .statement,
-          );
+          blocks.add(declareFinal(_resultVar)
+              .assign(
+              refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
+              .statement);
 
-          blocks.add(
-            declareFinal('value')
-                .assign(
-                  refer('$_resultVar.data')
-                      .propertyIf(
-                          thisNullable: returnType.isNullable, name: 'cast')
-                      .call([], {}, [
-                    refer(
-                      '${_displayString(innerReturnType, withNullability: innerReturnType?.isNullable ?? false)}',
-                    )
-                  ]),
-                )
-                .statement,
-          );
+          blocks.add(declareFinal('value')
+              .assign(refer('$_resultVar.data')
+              .propertyIf(thisNullable: returnType.isNullable, name: 'cast')
+              .call([], {}, [
+            refer(
+                '${_displayString(innerReturnType, withNullability: innerReturnType?.isNullable ?? false)}')
+          ]))
+              .statement);
         } else {
-          blocks.add(
-            declareFinal(_resultVar)
-                .assign(
-                  refer("await $_dioVar.fetch<List<dynamic>>").call([options]),
-                )
-                .statement,
-          );
+          blocks.add(declareFinal(_resultVar)
+              .assign(
+              refer("await $_dioVar.fetch<List<dynamic>>").call([options]))
+              .statement);
           if (clientAnnotation.parser == retrofit.Parser.FlutterCompute) {
-            blocks.add(
-              declareVar('value')
-                  .assign(
-                    refer('$_resultVar.data').conditionalIsNullIf(
-                      thisNullable: returnType.isNullable,
-                      whenFalse: refer('await compute').call([
-                        refer(
-                          'deserialize${_displayString(innerReturnType)}List',
-                        ),
-                        refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
-                      ]),
-                    ),
-                  )
-                  .statement,
-            );
+            blocks.add(declareVar('value')
+                .assign(refer('$_resultVar.data').conditionalIsNullIf(
+                thisNullable: returnType.isNullable,
+                whenFalse: refer('await compute').call([
+                  refer(
+                      'deserialize${_displayString(innerReturnType)}List'),
+                  refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
+                ])))
+                .statement);
           } else {
             final Reference mapperCode;
             switch (clientAnnotation.parser) {
               case retrofit.Parser.MapSerializable:
                 mapperCode = refer(
-                  '(dynamic i) => ${_displayString(innerReturnType)}.fromMap(i as Map<String,dynamic>)',
-                );
+                    '(dynamic i) => ${_displayString(innerReturnType)}.fromMap(i as Map<String,dynamic>)');
                 break;
               case retrofit.Parser.JsonSerializable:
                 if (innerReturnType?.isNullable == true) {
                   mapperCode = refer(
-                    '(dynamic i) => i == null ? null : ${_displayString(innerReturnType)}.fromJson(i as Map<String,dynamic>)',
-                  );
+                      '(dynamic i) => i == null ? null : ${_displayString(innerReturnType)}.fromJson(i as Map<String,dynamic>)');
                 } else {
                   mapperCode = refer(
-                    '(dynamic i) => ${_displayString(innerReturnType)}.fromJson(i as Map<String,dynamic>)',
-                  );
+                      '(dynamic i) => ${_displayString(innerReturnType)}.fromJson(i as Map<String,dynamic>)');
                 }
                 break;
               case retrofit.Parser.DartJsonMapper:
                 mapperCode = refer(
-                  '(dynamic i) => JsonMapper.fromMap<${_displayString(innerReturnType)}>(i as Map<String,dynamic>)!',
-                );
+                    '(dynamic i) => JsonMapper.fromMap<${_displayString(innerReturnType)}>(i as Map<String,dynamic>)!');
                 break;
               case retrofit.Parser.FlutterCompute:
                 throw Exception('Unreachable code');
             }
-            blocks.add(
-              declareVar('value')
-                  .assign(
-                    refer('$_resultVar.data')
-                        .propertyIf(
-                          thisNullable: returnType.isNullable,
-                          name: 'map',
-                        )
-                        .call([mapperCode])
-                        .property('toList')
-                        .call([]),
-                  )
-                  .statement,
-            );
+            blocks.add(declareVar('value')
+                .assign(refer('$_resultVar.data')
+                .propertyIf(
+                thisNullable: returnType.isNullable, name: 'map')
+                .call([mapperCode])
+                .property('toList')
+                .call([]))
+                .statement);
           }
         }
       } else if (_typeChecker(Map).isExactlyType(returnType) ||
           _typeChecker(BuiltMap).isExactlyType(returnType)) {
         final types = _getResponseInnerTypes(returnType)!;
-        blocks.add(
-          declareFinal(_resultVar)
-              .assign(
-                refer("await $_dioVar.fetch<Map<String,dynamic>>")
-                    .call([options]),
-              )
-              .statement,
-        );
+        blocks.add(declareFinal(_resultVar)
+            .assign(refer("await $_dioVar.fetch<Map<String,dynamic>>")
+            .call([options]))
+            .statement);
 
         /// assume the first type is a basic type
         if (types.length > 1) {
@@ -692,31 +611,20 @@ You should create a new class to encapsulate the response.
                 break;
             }
             if (future) {
-              blocks.add(
-                declareVar('value')
-                    .assign(
-                      refer('Map.fromEntries').call([
-                        refer('await Future.wait').call([
-                          refer('$_resultVar.data!.entries.map')
-                              .call([mapperCode])
-                        ])
-                      ]),
-                    )
-                    .statement,
-              );
+              blocks.add(declareVar('value')
+                  .assign(refer('Map.fromEntries').call([
+                refer('await Future.wait').call([
+                  refer('$_resultVar.data!.entries.map').call([mapperCode])
+                ])
+              ]))
+                  .statement);
             } else {
-              blocks.add(
-                declareVar('value')
-                    .assign(
-                      refer('$_resultVar.data')
-                          .propertyIf(
-                        thisNullable: returnType.isNullable,
-                        name: 'map',
-                      )
-                          .call([mapperCode]),
-                    )
-                    .statement,
-              );
+              blocks.add(declareVar('value')
+                  .assign(refer('$_resultVar.data')
+                  .propertyIf(
+                  thisNullable: returnType.isNullable, name: 'map')
+                  .call([mapperCode]))
+                  .statement);
             }
           } else if (!_isBasicType(secondType)) {
             final Reference mapperCode;
@@ -724,19 +632,16 @@ You should create a new class to encapsulate the response.
             switch (clientAnnotation.parser) {
               case retrofit.Parser.MapSerializable:
                 mapperCode = refer(
-                  '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromMap(v as Map<String, dynamic>))',
-                );
+                    '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromMap(v as Map<String, dynamic>))');
                 break;
               case retrofit.Parser.JsonSerializable:
                 mapperCode = refer(
-                  '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromJson(v as Map<String, dynamic>))',
-                );
+                    '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromJson(v as Map<String, dynamic>))');
 
                 break;
               case retrofit.Parser.DartJsonMapper:
                 mapperCode = refer(
-                  '(k, dynamic v) => MapEntry(k, JsonMapper.fromMap<${_displayString(secondType)}>(v as Map<String, dynamic>)!)',
-                );
+                    '(k, dynamic v) => MapEntry(k, JsonMapper.fromMap<${_displayString(secondType)}>(v as Map<String, dynamic>)!)');
                 break;
               case retrofit.Parser.FlutterCompute:
                 log.warning('''
@@ -751,103 +656,72 @@ You should create a new class to encapsulate the response.
                 break;
             }
             if (future) {
-              blocks.add(
-                declareVar('value')
-                    .assign(
-                      refer('$_resultVar.data').conditionalIsNullIf(
-                        thisNullable: returnType.isNullable,
-                        whenFalse: refer('Map.fromEntries').call([
-                          refer('await Future.wait').call([
-                            refer('$_resultVar.data!.entries.map')
-                                .call([mapperCode])
-                          ])
-                        ]),
-                      ),
-                    )
-                    .statement,
-              );
+              blocks.add(declareVar('value')
+                  .assign(refer('$_resultVar.data').conditionalIsNullIf(
+                  thisNullable: returnType.isNullable,
+                  whenFalse: refer('Map.fromEntries').call([
+                    refer('await Future.wait').call([
+                      refer('$_resultVar.data!.entries.map')
+                          .call([mapperCode])
+                    ])
+                  ])))
+                  .statement);
             } else {
-              blocks.add(
-                declareVar('value')
-                    .assign(
-                      refer('$_resultVar.data')
-                          .propertyIf(
-                        thisNullable: returnType.isNullable,
-                        name: 'map',
-                      )
-                          .call([mapperCode]),
-                    )
-                    .statement,
-              );
+              blocks.add(declareVar('value')
+                  .assign(refer('$_resultVar.data')
+                  .propertyIf(
+                  thisNullable: returnType.isNullable, name: 'map')
+                  .call([mapperCode]))
+                  .statement);
             }
           } else {
-            blocks.add(
-              declareFinal('value')
-                  .assign(
-                    refer('$_resultVar.data')
-                        .propertyIf(
-                      thisNullable: returnType.isNullable,
-                      name: 'cast',
-                    )
-                        .call([], {}, [
-                      refer('${_displayString(firstType)}'),
-                      refer('${_displayString(secondType)}'),
-                    ]),
-                  )
-                  .statement,
-            );
+            blocks.add(declareFinal('value')
+                .assign(refer('$_resultVar.data')
+                .propertyIf(
+                thisNullable: returnType.isNullable, name: 'cast')
+                .call([], {}, [
+              refer('${_displayString(firstType)}'),
+              refer('${_displayString(secondType)}'),
+            ]))
+                .statement);
           }
         } else {
           blocks.add(Code("final value = $_resultVar.data!;"));
         }
       } else {
         if (_isBasicType(returnType)) {
-          blocks.add(
-            declareFinal(_resultVar)
-                .assign(
-                  refer("await $_dioVar.fetch<${_displayString(returnType)}>")
-                      .call([options]),
-                )
-                .statement,
-          );
-          blocks.add(
-            declareFinal('value')
-                .assign(
-                  refer('$_resultVar.data')
-                      .asNoNullIf(returnNullable: returnType.isNullable),
-                )
-                .statement,
-          );
+          blocks.add(declareFinal(_resultVar)
+              .assign(
+              refer("await $_dioVar.fetch<${_displayString(returnType)}>")
+                  .call([options]))
+              .statement);
+          blocks.add(declareFinal('value')
+              .assign(refer('$_resultVar.data')
+              .asNoNullIf(returnNullable: returnType.isNullable))
+              .statement);
         } else if (returnType.toString() == 'dynamic') {
-          blocks.add(
-            declareFinal(_resultVar)
-                .assign(refer("await $_dioVar.fetch").call([options]))
-                .statement,
-          );
+          blocks.add(declareFinal(_resultVar)
+              .assign(refer("await $_dioVar.fetch").call([options]))
+              .statement);
           blocks.add(Code("final value = $_resultVar.data;"));
         } else {
           final fetchType = returnType.isNullable
               ? "Map<String,dynamic>?"
               : "Map<String,dynamic>";
-          blocks.add(
-            declareFinal(_resultVar)
-                .assign(
-                  refer("await $_dioVar"
-                          ".fetch<$fetchType>")
-                      .call([options]),
-                )
-                .statement,
-          );
+          blocks.add(declareFinal(_resultVar)
+              .assign(refer("await $_dioVar"
+              ".fetch<$fetchType>")
+              .call([options]))
+              .statement);
           Expression mapperCode;
           switch (clientAnnotation.parser) {
             case retrofit.Parser.MapSerializable:
               mapperCode = refer(
-                '${_displayString(returnType)}.fromMap($_resultVar.data!)',
-              );
+                  '${_displayString(returnType)}.fromMap($_resultVar.data!)');
               break;
             case retrofit.Parser.JsonSerializable:
               final genericArgumentFactories =
-                  isGenericArgumentFactories(returnType);
+              isGenericArgumentFactories(returnType);
 
               var typeArgs = returnType is ParameterizedType
                   ? returnType.typeArguments
@@ -856,52 +730,40 @@ You should create a new class to encapsulate the response.
               if (typeArgs.length > 0 && genericArgumentFactories) {
                 //Remove the outermost nullable modifier
                 //see NullableDynamicNullableInnerGenericTypeShouldBeCastedAsMap from generator/test/src/generator_test_src.dart:1529
-                var displayString = _displayString(
-                  returnType,
-                  withNullability: innerReturnType?.isNullable ?? false,
-                );
+                var displayString = _displayString(returnType,
+                    withNullability: innerReturnType?.isNullable ?? false);
                 displayString = displayString.endsWith("?")
                     ? displayString.substring(0, displayString.length - 1)
                     : displayString;
                 mapperCode = refer(
-                  '${displayString}.fromJson($_resultVar.data!,${_getInnerJsonSerializableMapperFn(returnType)})',
-                );
+                    '${displayString}.fromJson($_resultVar.data!,${_getInnerJsonSerializableMapperFn(returnType)})');
               } else {
                 mapperCode = refer(
-                  '${_displayString(returnType)}.fromJson($_resultVar.data!)',
-                );
+                    '${_displayString(returnType)}.fromJson($_resultVar.data!)');
               }
               break;
             case retrofit.Parser.DartJsonMapper:
               mapperCode = refer(
-                'JsonMapper.fromMap<${_displayString(returnType)}>($_resultVar.data!)!',
-              );
+                  'JsonMapper.fromMap<${_displayString(returnType)}>($_resultVar.data!)!');
               break;
             case retrofit.Parser.FlutterCompute:
               mapperCode = refer(
-                'await compute(deserialize${_displayString(returnType)}, $_resultVar.data!)',
-              );
+                  'await compute(deserialize${_displayString(returnType)}, $_resultVar.data!)');
               break;
           }
-          blocks.add(
-            declareFinal('value')
-                .assign(
-                  refer('$_resultVar.data').conditionalIsNullIf(
-                    thisNullable: returnType.isNullable,
-                    whenFalse: mapperCode,
-                  ),
-                )
-                .statement,
-          );
+          blocks.add(declareFinal('value')
+              .assign(refer('$_resultVar.data').conditionalIsNullIf(
+            thisNullable: returnType.isNullable,
+            whenFalse: mapperCode,
+          ))
+              .statement);
         }
       }
       if (isWrappered) {
-        blocks.add(
-          Code("""
+        blocks.add(Code("""
       final httpResponse = HttpResponse(value, $_resultVar);
       $returnAsyncWrapper httpResponse;
-      """),
-        );
+      """));
       } else {
         blocks.add(Code("$returnAsyncWrapper value;"));
       }
@@ -916,7 +778,7 @@ You should create a new class to encapsulate the response.
       return false;
     }
     final constDartObj =
-        metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
+    metaData.isNotEmpty ? metaData.first.computeConstantValue() : null;
     var genericArgumentFactories = false;
     if (constDartObj != null &&
         (!_typeChecker(List).isExactlyType(dartType) &&
@@ -939,7 +801,7 @@ You should create a new class to encapsulate the response.
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
         var typeArgs =
-            genericType is ParameterizedType ? genericType.typeArguments : [];
+        genericType is ParameterizedType ? genericType.typeArguments : [];
         var mapperVal;
 
         var genericTypeString = "${_displayString(genericType)}";
@@ -985,10 +847,10 @@ You should create a new class to encapsulate the response.
           } else {
             if (isGenericArgumentFactories(arg))
               mappedVal +=
-                  "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(arg)}),";
+              "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(arg)}),";
             else
               mappedVal +=
-                  "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
+              "(json)=>${_displayString(arg)}.fromJson(json as Map<String, dynamic>),";
           }
           else {
             mappedVal += "${_getInnerJsonSerializableMapperFn(arg)}";
@@ -1016,20 +878,20 @@ You should create a new class to encapsulate the response.
           _typeChecker(BuiltList).isExactlyType(dartType)) {
         var genericType = _getResponseType(dartType);
         var typeArgs =
-            genericType is ParameterizedType ? genericType.typeArguments : [];
+        genericType is ParameterizedType ? genericType.typeArguments : [];
         var mapperVal;
 
         if (typeArgs.length > 0 &&
             isGenericArgumentFactories(genericType) &&
             genericType != null) {
           mapperVal =
-              '(value) => value.map((value) => ${_getInnerJsonDeSerializableMapperFn(genericType)}).toList()';
+          '(value) => value.map((value) => ${_getInnerJsonDeSerializableMapperFn(genericType)}).toList()';
         } else {
           if (_isBasicType(genericType)) {
             mapperVal = '(value) => value';
           } else {
             mapperVal =
-                '(value) => value.map((value) => value.toJson()).toList()';
+            '(value) => value.map((value) => value.toJson()).toList()';
           }
         }
         return mapperVal;
@@ -1043,7 +905,7 @@ You should create a new class to encapsulate the response.
           } else {
             if (isGenericArgumentFactories(arg))
               mappedVal =
-                  '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
+              '(value) => value.toJson(${_getInnerJsonDeSerializableMapperFn(arg)})';
             else {
               mappedVal = "(value) => value";
             }
@@ -1064,11 +926,10 @@ You should create a new class to encapsulate the response.
   }
 
   Expression _parseOptions(
-    MethodElement m,
-    Map<String, Expression> namedArguments,
-    List<Code> blocks,
-    Map<String, Expression> extraOptions,
-  ) {
+      MethodElement m,
+      Map<String, Expression> namedArguments,
+      List<Code> blocks,
+      Map<String, Expression> extraOptions) {
     final annoOptions = _getAnnotation(m, retrofit.DioOptions);
     if (annoOptions == null) {
       final args = Map<String, Expression>.from(extraOptions)
@@ -1102,57 +963,43 @@ You should create a new class to encapsulate the response.
             .newInstance([], args)
             .property('compose')
             .call(
-              [refer(_dioVar).property('options'), path],
-              composeArguments,
-            )
+          [refer(_dioVar).property('options'), path],
+          composeArguments,
+        )
             .property('copyWith')
             .call([], {
-              _baseUrlVar: baseUrl.ifNullThen(
-                refer(_dioVar).property('options').property('baseUrl'),
-              )
-            })
+          _baseUrlVar: baseUrl.ifNullThen(
+              refer(_dioVar).property('options').property('baseUrl'))
+        })
       ], {}, [
         type
       ]);
     } else {
       hasCustomOptions = true;
-      blocks.add(
-        declareFinal("newOptions")
-            .assign(
-              refer("newRequestOptions")
-                  .call([refer(annoOptions.item1.displayName)]),
-            )
-            .statement,
-      );
+      blocks.add(declareFinal("newOptions")
+          .assign(refer("newRequestOptions")
+          .call([refer(annoOptions.item1.displayName)]))
+          .statement);
       final newOptions = refer("newOptions");
-      blocks.add(
-        newOptions
-            .property(_extraVar)
-            .property('addAll')
-            .call([extraOptions.remove(_extraVar)!]).statement,
-      );
-      blocks.add(
-        newOptions.property('headers').property('addAll').call(
-          [refer(_dioVar).property('options').property('headers')],
-        ).statement,
-      );
-      blocks.add(
-        newOptions
-            .property('headers')
-            .property('addAll')
-            .call([extraOptions.remove('headers')!]).statement,
-      );
+      blocks.add(newOptions
+          .property(_extraVar)
+          .property('addAll')
+          .call([extraOptions.remove(_extraVar)!]).statement);
+      blocks.add(newOptions.property('headers').property('addAll').call(
+          [refer(_dioVar).property('options').property('headers')]).statement);
+      blocks.add(newOptions
+          .property('headers')
+          .property('addAll')
+          .call([extraOptions.remove('headers')!]).statement);
       return newOptions
           .property('copyWith')
           .call(
-            [],
-            Map.from(extraOptions)
-              ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
-              ..[_path] = namedArguments[_path]!
-              ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
-                    refer(_dioVar).property('options').property('baseUrl'),
-                  ),
-          )
+          [],
+          Map.from(extraOptions)
+            ..[_queryParamsVar] = namedArguments[_queryParamsVar]!
+            ..[_path] = namedArguments[_path]!
+            ..[_baseUrlVar] = extraOptions.remove(_baseUrlVar)!.ifNullThen(
+                refer(_dioVar).property('options').property('baseUrl')))
           .cascade('data')
           .assign(namedArguments[_dataVar]!);
     }
@@ -1164,15 +1011,13 @@ You should create a new class to encapsulate the response.
         ..name = "newRequestOptions"
         ..returns = refer("RequestOptions")
 
-        /// required parameters
-        ..requiredParameters.add(
-          Parameter((p) {
-            p.name = "options";
-            p.type = refer("Object?").type;
-          }),
-        )
+      /// required parameters
+        ..requiredParameters.add(Parameter((p) {
+          p.name = "options";
+          p.type = refer("Object?").type;
+        }))
 
-        /// add method body
+      /// add method body
         ..body = Code('''
          if (options is RequestOptions) {
             return options as RequestOptions;
@@ -1245,10 +1090,7 @@ You should create a new class to encapsulate the response.
   }
 
   void _generateQueries(
-    MethodElement m,
-    List<Code> blocks,
-    String _queryParamsVar,
-  ) {
+      MethodElement m, List<Code> blocks, String _queryParamsVar) {
     final queries = _getAnnotations(m, retrofit.Query);
     final queryParameters = queries.map((p, ConstantReader r) {
       final key = r.peek("value")?.stringValue ?? p.displayName;
@@ -1274,8 +1116,7 @@ You should create a new class to encapsulate the response.
             break;
           case retrofit.Parser.FlutterCompute:
             value = refer(
-              'await compute(serialize${_displayString(p.type)}, ${p.displayName})',
-            );
+                'await compute(serialize${_displayString(p.type)}, ${p.displayName})');
             break;
         }
       }
@@ -1283,12 +1124,9 @@ You should create a new class to encapsulate the response.
     });
 
     final queryMap = _getAnnotations(m, retrofit.Queries);
-    blocks.add(
-      declareFinal(_queryParamsVar)
-          .assign(
-              literalMap(queryParameters, refer("String"), refer("dynamic")))
-          .statement,
-    );
+    blocks.add(declareFinal(_queryParamsVar)
+        .assign(literalMap(queryParameters, refer("String"), refer("dynamic")))
+        .statement);
     for (final p in queryMap.keys) {
       final type = p.type;
       final displayName = p.displayName;
@@ -1312,8 +1150,7 @@ You should create a new class to encapsulate the response.
             break;
           case retrofit.Parser.FlutterCompute:
             value = refer(
-              'await compute(serialize${_displayString(p.type)}, ${p.displayName})',
-            );
+                'await compute(serialize${_displayString(p.type)}, ${p.displayName})');
             break;
         }
       }
@@ -1338,17 +1175,12 @@ You should create a new class to encapsulate the response.
   }
 
   void _generateRequestBody(
-    List<Code> blocks,
-    String _dataVar,
-    MethodElement m,
-  ) {
+      List<Code> blocks, String _dataVar, MethodElement m) {
     final _noBody = _getMethodAnnotationByType(m, retrofit.NoBody);
     if (_noBody != null) {
-      blocks.add(
-        declareFinal(_dataVar, type: refer('String?'))
-            .assign(refer('null'))
-            .statement,
-      );
+      blocks.add(declareFinal(_dataVar, type: refer('String?'))
+          .assign(refer('null'))
+          .statement);
       return;
     }
 
@@ -1359,73 +1191,45 @@ You should create a new class to encapsulate the response.
           annotation!.item2.peek('nullToAbsent')?.boolValue ?? false;
       final bodyTypeElement = _bodyName.type.element2;
       if (TypeChecker.fromRuntime(Map).isAssignableFromType(_bodyName.type)) {
-        blocks.add(
-          declareFinal(_dataVar)
-              .assign(literalMap({}, refer("String"), refer("dynamic")))
-              .statement,
-        );
+        blocks.add(declareFinal(_dataVar)
+            .assign(literalMap({}, refer("String"), refer("dynamic")))
+            .statement);
 
-        blocks.add(
-          refer("$_dataVar.addAll").call([
-            refer(
-              "${_bodyName.displayName}${m.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''}",
-            )
-          ]).statement,
-        );
+        blocks.add(refer("$_dataVar.addAll").call([
+          refer(
+              "${_bodyName.displayName}${m.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''}")
+        ]).statement);
         if (nullToAbsent)
           blocks.add(Code("$_dataVar.removeWhere((k, v) => v == null);"));
       } else if (bodyTypeElement != null &&
           ((_typeChecker(List).isExactly(bodyTypeElement) ||
-                  _typeChecker(BuiltList).isExactly(bodyTypeElement)) &&
+              _typeChecker(BuiltList).isExactly(bodyTypeElement)) &&
               !_isBasicInnerType(_bodyName.type))) {
         switch (clientAnnotation.parser) {
           case retrofit.Parser.JsonSerializable:
           case retrofit.Parser.DartJsonMapper:
-            blocks.add(
-              declareFinal(_dataVar)
-                  .assign(
-                    refer('''
+            blocks.add(declareFinal(_dataVar).assign(refer('''
             ${_bodyName.displayName}.map((e) => e.toJson()).toList()
-            '''),
-                  )
-                  .statement,
-            );
+            ''')).statement);
             break;
           case retrofit.Parser.MapSerializable:
-            blocks.add(
-              declareFinal(_dataVar)
-                  .assign(
-                    refer('''
+            blocks.add(declareFinal(_dataVar).assign(refer('''
             ${_bodyName.displayName}.map((e) => e.toMap()).toList()
-            '''),
-                  )
-                  .statement,
-            );
+            ''')).statement);
             break;
           case retrofit.Parser.FlutterCompute:
-            blocks.add(
-              declareFinal(_dataVar)
-                  .assign(
-                    refer('''
+            blocks.add(declareFinal(_dataVar).assign(refer('''
             await compute(serialize${_displayString(_genericOf(_bodyName.type))}List, ${_bodyName.displayName})
-            '''),
-                  )
-                  .statement,
-            );
+            ''')).statement);
             break;
         }
       } else if (bodyTypeElement != null &&
           _typeChecker(File).isExactly(bodyTypeElement)) {
-        blocks.add(
-          declareFinal(_dataVar)
-              .assign(
-                refer("Stream").property("fromIterable").call([
-                  refer(
-                      "${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])")
-                ]),
-              )
-              .statement,
-        );
+        blocks.add(declareFinal(_dataVar)
+            .assign(refer("Stream").property("fromIterable").call([
+          refer("${_bodyName.displayName}.readAsBytesSync().map((i)=>[i])")
+        ]))
+            .statement);
       } else if (_bodyName.type.element2 is ClassElement) {
         final ele = _bodyName.type.element2 as ClassElement;
         if (clientAnnotation.parser == retrofit.Parser.MapSerializable) {
@@ -1433,56 +1237,44 @@ You should create a new class to encapsulate the response.
           if (toMap == null) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toMap()` method which return a Map.\n"
-                "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
-            blocks.add(
-              declareFinal(_dataVar)
-                  .assign(refer(_bodyName.displayName))
-                  .statement,
-            );
+                    "It is programmer's responsibility to make sure the ${_bodyName.type} is properly serialized");
+            blocks.add(declareFinal(_dataVar)
+                .assign(refer(_bodyName.displayName))
+                .statement);
           } else {
-            blocks.add(
-              declareFinal(_dataVar)
-                  .assign(literalMap({}, refer("String"), refer("dynamic")))
-                  .statement,
-            );
-            blocks.add(
-              refer("$_dataVar.addAll").call([
-                refer("${_bodyName.displayName}?.toMap() ?? <String,dynamic>{}")
-              ]).statement,
-            );
+            blocks.add(declareFinal(_dataVar)
+                .assign(literalMap({}, refer("String"), refer("dynamic")))
+                .statement);
+            blocks.add(refer("$_dataVar.addAll").call([
+              refer("${_bodyName.displayName}?.toMap() ?? <String,dynamic>{}")
+            ]).statement);
           }
         } else {
           if (_missingToJson(ele)) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `toJson()` method which return a Map.\n"
-                "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
-            blocks.add(
-              declareFinal(_dataVar)
-                  .assign(refer(_bodyName.displayName))
-                  .statement,
-            );
+                    "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
+            blocks.add(declareFinal(_dataVar)
+                .assign(refer(_bodyName.displayName))
+                .statement);
           } else if (_missingSerialize(ele.enclosingElement3, _bodyName.type)) {
             log.warning(
                 "${_displayString(_bodyName.type)} must provide a `serialize${_displayString(_bodyName.type)}()` method which returns a Map.\n"
-                "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
-            blocks.add(
-              declareFinal(_dataVar)
-                  .assign(refer(_bodyName.displayName))
-                  .statement,
-            );
+                    "It is programmer's responsibility to make sure the ${_displayString(_bodyName.type)} is properly serialized");
+            blocks.add(declareFinal(_dataVar)
+                .assign(refer(_bodyName.displayName))
+                .statement);
           } else {
-            blocks.add(
-              declareFinal(_dataVar)
-                  .assign(literalMap({}, refer("String"), refer("dynamic")))
-                  .statement,
-            );
+            blocks.add(declareFinal(_dataVar)
+                .assign(literalMap({}, refer("String"), refer("dynamic")))
+                .statement);
 
             final _bodyType = _bodyName.type;
             final genericArgumentFactories =
-                isGenericArgumentFactories(_bodyType);
+            isGenericArgumentFactories(_bodyType);
 
             var typeArgs =
-                _bodyType is ParameterizedType ? _bodyType.typeArguments : [];
+            _bodyType is ParameterizedType ? _bodyType.typeArguments : [];
 
             String toJsonCode = '';
             if (typeArgs.length > 0 && genericArgumentFactories) {
@@ -1494,44 +1286,34 @@ You should create a new class to encapsulate the response.
               case retrofit.Parser.DartJsonMapper:
                 if (_bodyName.type.nullabilitySuffix !=
                     NullabilitySuffix.question) {
-                  blocks.add(
-                    refer("$_dataVar.addAll").call([
-                      refer('${_bodyName.displayName}.toJson($toJsonCode)')
-                    ]).statement,
-                  );
+                  blocks.add(refer("$_dataVar.addAll").call([
+                    refer('${_bodyName.displayName}.toJson($toJsonCode)')
+                  ]).statement);
                 } else {
-                  blocks.add(
-                    refer("$_dataVar.addAll").call([
-                      refer(
-                        '${_bodyName.displayName}?.toJson($toJsonCode) ?? <String,dynamic>{}',
-                      )
-                    ]).statement,
-                  );
+                  blocks.add(refer("$_dataVar.addAll").call([
+                    refer(
+                        '${_bodyName.displayName}?.toJson($toJsonCode) ?? <String,dynamic>{}')
+                  ]).statement);
                 }
                 break;
               case retrofit.Parser.FlutterCompute:
                 if (_bodyName.type.nullabilitySuffix !=
                     NullabilitySuffix.question) {
-                  blocks.add(
-                    refer("$_dataVar.addAll").call([
-                      refer(
-                        'await compute(serialize${_displayString(_bodyName.type)}, ${_bodyName.displayName})',
-                      )
-                    ]).statement,
-                  );
+                  blocks.add(refer("$_dataVar.addAll").call([
+                    refer(
+                        'await compute(serialize${_displayString(_bodyName.type)}, ${_bodyName.displayName})')
+                  ]).statement);
                 } else {
-                  blocks.add(
-                    refer("$_dataVar.addAll").call([
-                      refer('''${_bodyName.displayName} == null
+                  blocks.add(refer("$_dataVar.addAll").call([
+                    refer('''${_bodyName.displayName} == null
                       ? <String, dynamic>{}
                       : await compute(serialize${_displayString(_bodyName.type)}, ${_bodyName.displayName})
                   ''')
-                    ]).statement,
-                  );
+                  ]).statement);
                 }
                 break;
               case retrofit.Parser.MapSerializable:
-                // Unreachable code
+              // Unreachable code
                 break;
             }
 
@@ -1541,9 +1323,9 @@ You should create a new class to encapsulate the response.
         }
       } else {
         /// @Body annotations with no type are assinged as is
-        blocks.add(
-          declareFinal(_dataVar).assign(refer(_bodyName.displayName)).statement,
-        );
+        blocks.add(declareFinal(_dataVar)
+            .assign(refer(_bodyName.displayName))
+            .statement);
       }
 
       return;
@@ -1556,8 +1338,7 @@ You should create a new class to encapsulate the response.
       final isFileField = _typeChecker(File).isAssignableFromType(p.type);
       if (isFileField) {
         log.severe(
-          'File is not support by @Field(). Please use @Part() instead.',
-        );
+            'File is not support by @Field(). Please use @Part() instead.');
       }
       return MapEntry(literal(fieldName), refer(p.displayName));
     });
@@ -1573,36 +1354,22 @@ You should create a new class to encapsulate the response.
     final parts = _getAnnotations(m, retrofit.Part);
     if (parts.isNotEmpty) {
       if (m.parameters.length == 1 && m.parameters.first.type.isDartCoreMap) {
-        blocks.add(
-          declareFinal(_dataVar)
-              .assign(
-                refer('FormData').newInstanceNamed(
-                  'fromMap',
-                  [CodeExpression(Code(m.parameters.first.displayName))],
-                ),
-              )
-              .statement,
-        );
+        blocks.add(declareFinal(_dataVar)
+            .assign(refer('FormData').newInstanceNamed('fromMap',
+            [CodeExpression(Code(m.parameters.first.displayName))]))
+            .statement);
         return;
       } else if (m.parameters.length == 2 &&
           m.parameters[1].type.isDartCoreMap) {
-        blocks.add(
-          declareFinal(_dataVar)
-              .assign(
-                refer('FormData').newInstanceNamed(
-                  'fromMap',
-                  [CodeExpression(Code(m.parameters[1].displayName))],
-                ),
-              )
-              .statement,
-        );
+        blocks.add(declareFinal(_dataVar)
+            .assign(refer('FormData').newInstanceNamed(
+            'fromMap', [CodeExpression(Code(m.parameters[1].displayName))]))
+            .statement);
         return;
       }
-      blocks.add(
-        declareFinal(_dataVar)
-            .assign(refer('FormData').newInstance([]))
-            .statement,
-      );
+      blocks.add(declareFinal(_dataVar)
+          .assign(refer('FormData').newInstance([]))
+          .statement);
 
       parts.forEach((p, r) {
         final fieldName = r.peek("name")?.stringValue ??
@@ -1616,7 +1383,7 @@ You should create a new class to encapsulate the response.
           final fileName = fileNameValue != null
               ? literalString(fileNameValue)
               : refer(p.displayName)
-                  .property('path.split(Platform.pathSeparator).last');
+              .property('path.split(Platform.pathSeparator).last');
 
           final uploadFileInfo = refer('$MultipartFile.fromFileSync').call([
             refer(p.displayName).property('path')
@@ -1624,33 +1391,32 @@ You should create a new class to encapsulate the response.
             'filename': fileName,
             if (contentType != null)
               'contentType':
-                  refer("MediaType", 'package:http_parser/http_parser.dart')
-                      .property('parse')
-                      .call([literal(contentType)])
+              refer("MediaType", 'package:http_parser/http_parser.dart')
+                  .property('parse')
+                  .call([literal(contentType)])
           });
 
           final optinalFile = m.parameters
-                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
-                  ?.isOptional ??
+              .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+              ?.isOptional ??
               false;
 
           final returnCode =
               refer(_dataVar).property('files').property("add").call([
-            refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
-          ]).statement;
+                refer("MapEntry").newInstance([literal(fieldName), uploadFileInfo])
+              ]).statement;
           if (optinalFile) {
             final condication =
                 refer(p.displayName).notEqualTo(literalNull).code;
             blocks.addAll(
-              [Code("if("), condication, Code(") {"), returnCode, Code("}")],
-            );
+                [Code("if("), condication, Code(") {"), returnCode, Code("}")]);
           } else {
             blocks.add(returnCode);
           }
         } else if (_displayString(p.type) == "List<int>") {
           final optionalFile = m.parameters
-                  .firstWhereOrNull((pp) => pp.displayName == p.displayName)
-                  ?.isOptional ??
+              .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+              ?.isOptional ??
               false;
           final fileName = r.peek("fileName")?.stringValue;
           final conType = contentType == null
@@ -1658,7 +1424,7 @@ You should create a new class to encapsulate the response.
               : 'contentType: MediaType.parse(${literal(contentType)}),';
           final returnCode =
               refer(_dataVar).property('files').property("add").call([
-            refer(''' 
+                refer(''' 
                   MapEntry(
                 '${fieldName}',
                 MultipartFile.fromBytes(${p.displayName},
@@ -1667,12 +1433,11 @@ You should create a new class to encapsulate the response.
                     ${conType}
                     ))
                   ''')
-          ]).statement;
+              ]).statement;
           if (optionalFile) {
             final condition = refer(p.displayName).notEqualTo(literalNull).code;
             blocks.addAll(
-              [Code("if("), condition, Code(") {"), returnCode, Code("}")],
-            );
+                [Code("if("), condition, Code(") {"), returnCode, Code("}")]);
           } else {
             blocks.add(returnCode);
           }
@@ -1685,9 +1450,9 @@ You should create a new class to encapsulate the response.
             final conType = contentType == null
                 ? ""
                 : 'contentType: MediaType.parse(${literal(contentType)}),';
-            blocks.add(
-              refer(_dataVar).property('files').property("addAll").call([
-                refer(''' 
+            blocks
+                .add(refer(_dataVar).property('files').property("addAll").call([
+              refer(''' 
                   ${p.displayName}.map((i) => MapEntry(
                 '${fieldName}',
                 MultipartFile.fromBytes(i,
@@ -1695,8 +1460,7 @@ You should create a new class to encapsulate the response.
                     ${conType}
                     )))
                   ''')
-              ]).statement,
-            );
+            ]).statement);
           } else if (_isBasicType(innerType) ||
               ((innerType != null) &&
                   (_typeChecker(Map).isExactlyType(innerType) ||
@@ -1705,16 +1469,14 @@ You should create a new class to encapsulate the response.
                       _typeChecker(BuiltList).isExactlyType(innerType)))) {
             var value = _isBasicType(innerType) ? 'i' : 'jsonEncode(i)';
             var nullableInfix =
-                (p.type.nullabilitySuffix == NullabilitySuffix.question)
-                    ? '?'
-                    : '';
-            blocks.add(
-              refer('''
+            (p.type.nullabilitySuffix == NullabilitySuffix.question)
+                ? '?'
+                : '';
+            blocks.add(refer('''
             ${p.displayName}$nullableInfix.forEach((i){
               ${_dataVar}.fields.add(MapEntry(${literal(fieldName)},${value}));
             })
-            ''').statement,
-            );
+            ''').statement);
           } else if (innerType != null &&
               _typeChecker(File).isExactlyType(innerType)) {
             final conType = contentType == null
@@ -1723,9 +1485,9 @@ You should create a new class to encapsulate the response.
             if (p.type.isNullable) {
               blocks.add(Code("if (${p.displayName} != null) {"));
             }
-            blocks.add(
-              refer(_dataVar).property('files').property("addAll").call([
-                refer(''' 
+            blocks
+                .add(refer(_dataVar).property('files').property("addAll").call([
+              refer(''' 
                   ${p.displayName}.map((i) => MapEntry(
                 '${fieldName}',
                 MultipartFile.fromFileSync(i.path,
@@ -1733,8 +1495,7 @@ You should create a new class to encapsulate the response.
                     ${conType}
                     )))
                   ''')
-              ]).statement,
-            );
+            ]).statement);
             if (p.type.isNullable) {
               blocks.add(Code("}"));
             }
@@ -1743,15 +1504,14 @@ You should create a new class to encapsulate the response.
             if (p.type.isNullable) {
               blocks.add(Code("if (${p.displayName} != null) {"));
             }
-            blocks.add(
-              refer(_dataVar).property('files').property("addAll").call([
-                refer(''' 
+            blocks
+                .add(refer(_dataVar).property('files').property("addAll").call([
+              refer(''' 
                   ${p.displayName}.map((i) => MapEntry(
                 '${fieldName}',
                 i))
                   ''')
-              ]).statement,
-            );
+            ]).statement);
             if (p.type.isNullable) {
               blocks.add(Code("}"));
             }
@@ -1760,13 +1520,11 @@ You should create a new class to encapsulate the response.
             if (_missingToJson(ele)) {
               throw Exception("toJson() method have to add to ${p.type}");
             } else {
-              blocks.add(
-                refer(_dataVar).property('fields').property("add").call([
-                  refer("MapEntry").newInstance(
-                    [literal(fieldName), refer("jsonEncode(${p.displayName})")],
-                  )
-                ]).statement,
-              );
+              blocks
+                  .add(refer(_dataVar).property('fields').property("add").call([
+                refer("MapEntry").newInstance(
+                    [literal(fieldName), refer("jsonEncode(${p.displayName})")])
+              ]).statement);
             }
           } else {
             throw Exception("Unknown error!");
@@ -1775,76 +1533,62 @@ You should create a new class to encapsulate the response.
           if (p.type.nullabilitySuffix == NullabilitySuffix.question) {
             blocks.add(Code("if (${p.displayName} != null) {"));
           }
-          blocks.add(
-            refer(_dataVar).property('fields').property("add").call([
-              refer("MapEntry").newInstance([
-                literal(fieldName),
-                if (_typeChecker(String).isExactlyType(p.type))
-                  refer(p.displayName)
-                else
-                  refer(p.displayName).property('toString').call([])
-              ])
-            ]).statement,
-          );
+          blocks.add(refer(_dataVar).property('fields').property("add").call([
+            refer("MapEntry").newInstance([
+              literal(fieldName),
+              if (_typeChecker(String).isExactlyType(p.type))
+                refer(p.displayName)
+              else
+                refer(p.displayName).property('toString').call([])
+            ])
+          ]).statement);
           if (p.type.nullabilitySuffix == NullabilitySuffix.question) {
             blocks.add(Code("}"));
           }
         } else if (_typeChecker(Map).isExactlyType(p.type) ||
             _typeChecker(BuiltMap).isExactlyType(p.type)) {
-          blocks.add(
-            refer(_dataVar).property('fields').property("add").call([
-              refer("MapEntry").newInstance(
-                [literal(fieldName), refer("jsonEncode(${p.displayName})")],
-              )
-            ]).statement,
-          );
+          blocks.add(refer(_dataVar).property('fields').property("add").call([
+            refer("MapEntry").newInstance(
+                [literal(fieldName), refer("jsonEncode(${p.displayName})")])
+          ]).statement);
         } else if (p.type.element2 is ClassElement) {
           final ele = p.type.element2 as ClassElement;
           if (_missingToJson(ele)) {
             throw Exception("toJson() method have to add to ${p.type}");
           } else {
-            blocks.add(
-              refer(_dataVar).property('fields').property("add").call([
-                refer("MapEntry").newInstance([
-                  literal(fieldName),
-                  refer(
-                    "jsonEncode(${p.displayName}${p.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''})",
-                  )
-                ])
-              ]).statement,
-            );
+            blocks.add(refer(_dataVar).property('fields').property("add").call([
+              refer("MapEntry").newInstance([
+                literal(fieldName),
+                refer(
+                    "jsonEncode(${p.displayName}${p.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''})")
+              ])
+            ]).statement);
           }
         } else {
-          blocks.add(
-            refer(_dataVar).property('fields').property("add").call([
-              refer("MapEntry")
-                  .newInstance([literal(fieldName), refer(p.displayName)])
-            ]).statement,
-          );
+          blocks.add(refer(_dataVar).property('fields').property("add").call([
+            refer("MapEntry")
+                .newInstance([literal(fieldName), refer(p.displayName)])
+          ]).statement);
         }
       });
       return;
     }
 
     /// There is no body
-    blocks.add(
-      declareFinal(_dataVar)
-          .assign(literalMap({}, refer("String"), refer("dynamic")))
-          .statement,
-    );
+    blocks.add(declareFinal(_dataVar)
+        .assign(literalMap({}, refer("String"), refer("dynamic")))
+        .statement);
   }
 
   Map<String, Expression> _generateHeaders(MethodElement m) {
     final headers = _getMethodAnnotations(m, retrofit.Headers)
         .map((e) => e.peek('value'))
-        .map(
-          (value) => value?.mapValue.map((k, v) {
-            return MapEntry(
-              k?.toStringValue() ?? 'null',
-              literal(v?.toStringValue()),
-            );
-          }),
-        )
+        .map((value) => value?.mapValue.map((k, v) {
+      return MapEntry(
+        k?.toStringValue() ?? 'null',
+        literal(v?.toStringValue()),
+      );
+    }))
         .fold<Map<String, Expression>>({}, (p, e) => p..addAll(e ?? {}));
 
     final annosInParam = _getAnnotations(m, retrofit.Header);
@@ -1900,47 +1644,38 @@ You should create a new class to encapsulate the response.
   }
 
   void _generateExtra(
-    MethodElement m,
-    List<Code> blocks,
-    String localExtraVar,
-  ) {
-    blocks.add(
-      declareConst(localExtraVar)
-          .assign(
-            literalMap(
-              _getMethodAnnotations(m, retrofit.Extra)
-                  .map((e) => e.peek('data'))
-                  .map(
-                    (data) => data?.mapValue.map((k, v) {
-                      return MapEntry(
-                        k?.toStringValue() ??
-                            (throw InvalidGenerationSourceError(
-                              'Invalid key for extra Map, only `String` keys are supported',
-                              element: m,
-                              todo: 'Make sure all keys are of string type',
-                            )),
-                        v?.toBoolValue() ??
-                            v?.toDoubleValue() ??
-                            v?.toIntValue() ??
-                            v?.toStringValue() ??
-                            v?.toListValue() ??
-                            v?.toMapValue() ??
-                            v?.toSetValue() ??
-                            v?.toSymbolValue() ??
-                            (v?.toTypeValue() ??
-                                (v != null
-                                    ? Code(revivedLiteral(v))
-                                    : Code('null'))),
-                      );
-                    }),
-                  )
-                  .fold<Map<String, Object>>({}, (p, e) => p..addAll(e ?? {})),
-              refer('String'),
-              refer('dynamic'),
-            ),
-          )
-          .statement,
-    );
+      MethodElement m, List<Code> blocks, String localExtraVar) {
+    blocks.add(declareConst(localExtraVar)
+        .assign(literalMap(
+      _getMethodAnnotations(m, retrofit.Extra)
+          .map((e) => e.peek('data'))
+          .map((data) => data?.mapValue.map((k, v) {
+        return MapEntry(
+          k?.toStringValue() ??
+              (throw InvalidGenerationSourceError(
+                'Invalid key for extra Map, only `String` keys are supported',
+                element: m,
+                todo: 'Make sure all keys are of string type',
+              )),
+          v?.toBoolValue() ??
+              v?.toDoubleValue() ??
+              v?.toIntValue() ??
+              v?.toStringValue() ??
+              v?.toListValue() ??
+              v?.toMapValue() ??
+              v?.toSetValue() ??
+              v?.toSymbolValue() ??
+              (v?.toTypeValue() ??
+                  (v != null
+                      ? Code(revivedLiteral(v))
+                      : Code('null'))),
+        );
+      }))
+          .fold<Map<String, Object>>({}, (p, e) => p..addAll(e ?? {})),
+      refer('String'),
+      refer('dynamic'),
+    ))
+        .statement);
   }
 
   bool _missingToJson(ClassElement ele) {
@@ -1962,29 +1697,24 @@ You should create a new class to encapsulate the response.
       case retrofit.Parser.MapSerializable:
         return false;
       case retrofit.Parser.FlutterCompute:
-        return !ele.functions.any(
-          (element) =>
-              element.name == 'serialize${_displayString(type)}' &&
-              element.parameters.length == 1 &&
-              _displayString(element.parameters[0].type) ==
-                  _displayString(type),
-        );
+        return !ele.functions.any((element) =>
+        element.name == 'serialize${_displayString(type)}' &&
+            element.parameters.length == 1 &&
+            _displayString(element.parameters[0].type) == _displayString(type));
     }
   }
 }
 
 Builder generatorFactoryBuilder(BuilderOptions options) => SharedPartBuilder(
-      [RetrofitGenerator(RetrofitOptions.fromOptions(options))],
-      "retrofit",
-    );
+    [RetrofitGenerator(RetrofitOptions.fromOptions(options))], "retrofit");
 
 /// Returns `$revived($args $kwargs)`, this won't have ending semi-colon (`;`).
 /// [object] must not be null.
 /// [object] is assumed to be a constant.
 String revivedLiteral(
-  Object object, {
-  DartEmitter? dartEmitter,
-}) {
+    Object object, {
+      DartEmitter? dartEmitter,
+    }) {
   dartEmitter ??= DartEmitter();
 
   ArgumentError.checkNotNull(object, 'object');
@@ -2000,11 +1730,8 @@ String revivedLiteral(
     revived = object.revive();
   }
   if (revived == null) {
-    throw ArgumentError.value(
-      object,
-      'object',
-      'Only `Revivable`, `DartObject`, `ConstantReader` are supported values',
-    );
+    throw ArgumentError.value(object, 'object',
+        'Only `Revivable`, `DartObject`, `ConstantReader` are supported values');
   }
 
   String instantiation = '';
@@ -2053,12 +1780,9 @@ String revivedLiteral(
     }
 
     if (constant.isMap) {
-      return literalMap(
-        Map.fromIterables(
+      return literalMap(Map.fromIterables(
           constant.mapValue.keys.map(objectToSpec),
-          constant.mapValue.values.map(objectToSpec),
-        ),
-      );
+          constant.mapValue.values.map(objectToSpec)));
       // return literal(constant.mapValue);
     }
 
@@ -2104,7 +1828,7 @@ String revivedLiteral(
 extension DartTypeStreamAnnotation on DartType {
   bool get isDartAsyncStream {
     final element =
-        this.element2 != null ? null : this.element2 as ClassElement;
+    this.element2 != null ? null : this.element2 as ClassElement;
     if (element == null) {
       return false;
     }
@@ -2117,7 +1841,7 @@ String _displayString(dynamic e, {bool withNullability = false}) {
     return e.getDisplayString(withNullability: withNullability);
   } catch (error) {
     if (error is TypeError) {
-      return e.getDisplayString(withNullability: withNullability);
+      return e.getDisplayString();
     } else {
       rethrow;
     }

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -1,12 +1,12 @@
 name: retrofit_generator
 description: retrofit generator is an dio client generator using source_gen and inspired by Chopper and Retrofit.
-version: 4.0.1
+version: 4.0.4
 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   dio: ^4.0.1
@@ -14,8 +14,8 @@ dependencies:
   built_collection: ^5.0.0
   code_builder: ^4.0.0
   tuple: ^2.0.0
-  retrofit: ^3.0.1
-  analyzer: '>=3.0.0 <5.0.0'
+  retrofit: ^3.0.1+1
+  analyzer: ^4.6.0
   dart_style: ^2.0.1
   build: ^2.0.1
 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -12,10 +12,10 @@ dependencies:
   analyzer: '>=4.6.0 <6.0.0'
   build: ^2.3.1
   built_collection: ^5.1.1
-  code_builder: 4.2.0
+  code_builder: '>=4.0.0 <4.3.0'
   dart_style: ^2.2.4
   dio: ^4.0.6
-  retrofit: ^3.0.2
+  retrofit: ^3.0.1
   source_gen: ^1.2.5
   tuple: ^2.0.0
 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   built_collection: ^5.1.1
   code_builder: 4.2.0
   dart_style: ^2.2.4
-  dio: ^4.0.1
-  retrofit: ^3.0.1
+  dio: ^4.0.6
+  retrofit: ^3.0.2
   source_gen: ^1.2.5
   tuple: ^2.0.0
 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: retrofit_generator
 description: retrofit generator is an dio client generator using source_gen and inspired by Chopper and Retrofit.
-version: 4.0.4
+version: 4.1.0
 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
@@ -9,16 +9,16 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
+  analyzer: '>=4.6.0 <6.0.0'
+  build: ^2.3.1
+  built_collection: ^5.1.1
+  code_builder: 4.2.0
+  dart_style: ^2.2.4
   dio: ^4.0.1
-  source_gen: ^1.0.1
-  built_collection: ^5.0.0
-  code_builder: ^4.0.0
+  retrofit: ^3.0.1
+  source_gen: ^1.2.5
   tuple: ^2.0.0
-  retrofit: ^3.0.1+1
-  analyzer: ^4.6.0
-  dart_style: ^2.0.1
-  build: ^2.0.1
 
 dev_dependencies:
-  test: ^1.17.10
-  source_gen_test: ^1.0.0
+  source_gen_test: ^1.0.4
+  test: ^1.21.4

--- a/generator/test/generator_test.dart
+++ b/generator/test/generator_test.dart
@@ -9,7 +9,9 @@ import 'package:source_gen_test/src/test_annotated_classes.dart';
 
 Future<void> main() async {
   final reader = await initializeLibraryReaderForDirectory(
-      'test/src', 'generator_test_src.dart');
+    'test/src',
+    'generator_test_src.dart',
+  );
   initializeBuildLogTracking();
   testAnnotatedElements<http.RestApi>(
     reader,

--- a/generator/test/generator_test.dart
+++ b/generator/test/generator_test.dart
@@ -1,16 +1,18 @@
 // @dart=2.9
 import 'dart:async';
+
+import 'package:retrofit/http.dart' as http;
 import 'package:retrofit_generator/src/generator.dart';
 import 'package:source_gen_test/src/build_log_tracking.dart';
 import 'package:source_gen_test/src/init_library_reader.dart';
 import 'package:source_gen_test/src/test_annotated_classes.dart';
-
-import 'package:retrofit/http.dart' as http;
 
 Future<void> main() async {
   final reader = await initializeLibraryReaderForDirectory(
       'test/src', 'generator_test_src.dart');
   initializeBuildLogTracking();
   testAnnotatedElements<http.RestApi>(
-      reader, RetrofitGenerator(RetrofitOptions()));
+    reader,
+    RetrofitGenerator(RetrofitOptions()),
+  );
 }

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -10,3 +10,4 @@ environment:
 
 dependencies:
   dio: ^4.0.1
+  meta: ^1.8.0

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -1,12 +1,12 @@
 name: retrofit
-version: 3.0.2
+version: 3.0.1+1
 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
 description: retrofit.dart is an dio client generator using source_gen and inspired by Chopper and Retrofit.
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   dio: ^4.0.1

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -1,13 +1,12 @@
 name: retrofit
-version: 3.0.1+1
+version: 3.0.2
 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
 description: retrofit.dart is an dio client generator using source_gen and inspired by Chopper and Retrofit.
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   dio: ^4.0.1
-  meta: ^1.3.0

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -1,12 +1,12 @@
 name: retrofit
-version: 3.0.1+1
+version: 3.0.2
 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
 description: retrofit.dart is an dio client generator using source_gen and inspired by Chopper and Retrofit.
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   dio: ^4.0.1

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -9,5 +9,5 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  dio: ^4.0.1
+  dio: ^4.0.6
   meta: ^1.8.0


### PR DESCRIPTION
In my project I use freezed and also analyzer version 5(#499).  So I removed deprecated methods to their alternative.

- assertFinal -> declareFinal
- assertVar -> declareVar
- assertConst -> declareConst
- element -> element2
- enclosingElement -> enclosingElement3

Also, to use analyzer 4.6.0 and higher, need Dart 2.17