### PR TITLE
Make data `null` when there is no body

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1860,8 +1860,8 @@ ${bodyName.displayName} == null
 
     /// There is no body
     blocks.add(
-      declareFinal(dataVar)
-          .assign(literalMap({}, refer('String'), refer('dynamic')))
+      declareFinal(dataVar, type: refer('Map<String, dynamic>?'))
+          .assign(literalNull)
           .statement,
     );
   }


### PR DESCRIPTION
It will fix this issue. https://github.com/trevorwang/retrofit.dart/issues/547

I made the generator to make the data null when there is no body.