### PR TITLE
fix the crash while receiving nonstandard response

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -950,28 +950,34 @@ You should create a new class to encapsulate the response.
             isGenericArgumentFactories(genericType) &&
             genericType != null) {
           mapperVal = '''
-    (json)=> (json as List<dynamic>)
+    (json)=> json is List<dynamic>
+          ? json
             .map<$genericTypeString>((i) => $genericTypeString.fromJson(
                   i as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(genericType)}
                 ))
-            .toList(),
+            .toList()
+          : List.empty(),
     ''';
         } else {
           if (_isBasicType(genericType)) {
             mapperVal = '''
-    (json)=>(json as List<dynamic>)
+    (json)=> json is List<dynamic>
+          ? json
             .map<$genericTypeString>((i) => 
                   i as $genericTypeString
                 )
-            .toList(),
+            .toList()
+          : List.empty(),
     ''';
           } else {
             mapperVal = """
-    (json)=>(json as List<dynamic>)
+    (json)=> json is List<dynamic>
+          ? json
             .map<$genericTypeString>((i) =>
             ${genericTypeString == 'dynamic' ? ' i as Map<String, dynamic>' : '$genericTypeString.fromJson(  i as Map<String, dynamic> )  '}
     )
-            .toList(),
+            .toList()
+          : List.empty(),
     """;
           }
         }


### PR DESCRIPTION
如这样一个接口
Future<ApiResult<List<Task>>> getApiResultGenericsInnerTypeNullable();

当返回值不是一个List而是一个Object时：
{
	"code": 0,
	"data": {},
	"msg": ""
}

解析报错，同时开发者没办法去处理这个异常