### PR TITLE
fix the problem when deserialize an object to list

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -950,28 +950,34 @@ You should create a new class to encapsulate the response.
             isGenericArgumentFactories(genericType) &&
             genericType != null) {
           mapperVal = '''
-    (json)=> (json as List<dynamic>)
+    (json)=> json is List<dynamic>
+          ? json
             .map<$genericTypeString>((i) => $genericTypeString.fromJson(
                   i as Map<String, dynamic>,${_getInnerJsonSerializableMapperFn(genericType)}
                 ))
-            .toList(),
+            .toList()
+          : List.empty(),
     ''';
         } else {
           if (_isBasicType(genericType)) {
             mapperVal = '''
-    (json)=>(json as List<dynamic>)
+    (json)=> json is List<dynamic>
+          ? json
             .map<$genericTypeString>((i) => 
                   i as $genericTypeString
                 )
-            .toList(),
+            .toList()
+          : List.empty(),
     ''';
           } else {
             mapperVal = """
-    (json)=>(json as List<dynamic>)
+    (json)=> json is List<dynamic>
+          ? json
             .map<$genericTypeString>((i) =>
             ${genericTypeString == 'dynamic' ? ' i as Map<String, dynamic>' : '$genericTypeString.fromJson(  i as Map<String, dynamic> )  '}
     )
-            .toList(),
+            .toList()
+          : List.empty(),
     """;
           }
         }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1579,9 +1579,11 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsDynamic {
   '''
     final value = GenericUser<List<User>>.fromJson(
       _result.data!,
-      (json) => (json as List<dynamic>)
-          .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
-          .toList(),
+      (json) => json is List<dynamic>
+          ? json
+              .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
+              .toList()
+          : List.empty(),
     );
     return value;
   ''',
@@ -1599,9 +1601,11 @@ abstract class DynamicInnerListGenericTypeShouldBeCastedRecursively {
         ? null
         : GenericUser<List<User>>.fromJson(
             _result.data!,
-            (json) => (json as List<dynamic>)
-                .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
-                .toList(),
+            (json) => json is List<dynamic>
+                ? json
+                    .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
+                    .toList()
+                : List.empty(),
           );
     return value;
   ''',
@@ -1707,8 +1711,9 @@ abstract class NullableDynamicNullableInnerGenericTypeShouldBeCastedAsMap {
   '''
     final value = GenericUser<List<double>>.fromJson(
       _result.data!,
-      (json) =>
-          (json as List<dynamic>).map<double>((i) => i as double).toList(),
+      (json) => json is List<dynamic>
+          ? json.map<double>((i) => i as double).toList()
+          : List.empty(),
     );
     return value;
   ''',
@@ -1726,9 +1731,9 @@ abstract class DynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursively {
         ? null
         : GenericUser<List<double>>.fromJson(
             _result.data!,
-            (json) => (json as List<dynamic>)
-                .map<double>((i) => i as double)
-                .toList(),
+            (json) => json is List<dynamic>
+                ? json.map<double>((i) => i as double).toList()
+                : List.empty(),
           );
     return value;
   ''',


### PR DESCRIPTION
如这样一个接口
Future<ApiResult<List>> getApiResultGenericsInnerTypeNullable();

当返回值不是一个List而是一个Object时：
{
"code": 0,
"data": {},
"msg": ""
}

解析报错，同时开发者没办法去处理这个异常