### PR TITLE
Add json_annotation dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Add the generator to your dev dependencies
 dependencies:
   retrofit: '>=4.0.0 <5.0.0'
   logger: any  #for logging purpose
+  json_annotation: ^4.8.0
 
 dev_dependencies:
   retrofit_generator: '>=6.0.0 <7.0.0'   // only support dart >=2.18


### PR DESCRIPTION
I received the following warning message from Flutter version 3.7.10 with Dart version 2.18:
```
[WARNING] json_serializable on lib/screens/example/example.dart:
You are missing a required dependency on json_annotation in the "dependencies" section of your pubspec with a lower bound of at least "4.8.0”
```