### PR TITLE
Add support for relative base path in @RestApi

### DIFF
--- a/example_relative_base_url/analysis_options.yaml
+++ b/example_relative_base_url/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:lints/recommended.yaml
+analyzer:
+  exclude:
+    - lib/**/*.reflectable.dart
+    - lib/**/*.g.dart

--- a/example_relative_base_url/build.yaml
+++ b/example_relative_base_url/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      reflectable:
+        generate_for:
+          - lib/json_mapper_example.dart

--- a/example_relative_base_url/lib/api_result.dart
+++ b/example_relative_base_url/lib/api_result.dart
@@ -1,0 +1,32 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'api_result.g.dart';
+
+@JsonSerializable(genericArgumentFactories: true)
+class ApiResult<T> {
+  const ApiResult({
+    required this.code,
+    required this.data,
+    this.msg,
+  });
+
+  factory ApiResult.fromJson(
+          Map<String, dynamic> json, T Function(Object?) fromJsonT) =>
+      _$ApiResultFromJson(json, fromJsonT);
+
+  ///接口调用成功的code码
+  static const success = 0;
+  static const unknown = -1;
+  final int code;
+  final T data;
+  final String? msg;
+
+  ///业务接口执行成功
+  bool get isSuccess => code == success;
+
+  Map<String, dynamic> toJson(Object? Function(T) toJsonT) =>
+      _$ApiResultToJson(this, toJsonT);
+
+  @override
+  String toString() => 'ApiResult{code: $code, data: $data, msg: $msg}';
+}

--- a/example_relative_base_url/lib/example.dart
+++ b/example_relative_base_url/lib/example.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart' hide Headers;
+import 'package:http_parser/http_parser.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:retrofit/retrofit.dart';
+import 'package:retrofit_example/api_result.dart';
+
+part 'example.g.dart';
+
+@RestApi(baseUrl: 'tasks')
+abstract class TasksRestClient {
+  factory TasksRestClient(Dio dio, {String baseUrl}) = _TasksRestClient;
+
+  @GET('/tasks/{id}')
+  Future<List<Task?>> getTaskById();
+
+  @GET('/')
+  Future<List<Task>> getTasks();
+
+  @GET('/{id}')
+  Future<Task> getTask(@Path('id') String id);
+
+  @PATCH('/tasks/{id}')
+  Future<Task> updateTaskPart(
+    @Path() String id,
+    @Body() Map<String, dynamic> map,
+  );
+
+  @PUT('/tasks/{id}')
+  Future<Task> updateTask(@Path() String id, @Body() Task task);
+
+  @DELETE('/tasks/{id}')
+  Future<void> deleteTask(@Path() String id);
+
+  @POST('/tasks')
+  Future<Task> createTask(@Body() Task task);
+
+  @POST('/tasks')
+  Future<List<Task>> createTasks(@Body() List<Task> tasks);
+}
+
+@JsonSerializable()
+class Task {
+  const Task({
+    required this.id,
+    required this.name,
+    required this.avatar,
+    required this.createdAt,
+  });
+
+  factory Task.fromJson(Map<String, dynamic> json) => _$TaskFromJson(json);
+
+  final String id;
+  final String name;
+  final String avatar;
+  final String createdAt;
+
+  Map<String, dynamic> toJson() => _$TaskToJson(this);
+}
+
+// ignore_for_file: constant_identifier_names
+enum Status {
+  @JsonValue('new')
+  New,
+  @JsonValue('on_going')
+  OnGoing,
+  @JsonValue('closed')
+  Closed,
+}
+
+@JsonSerializable()
+class TaskQuery {
+  const TaskQuery(this.statuses);
+
+  factory TaskQuery.fromJson(Map<String, dynamic> json) =>
+      _$TaskQueryFromJson(json);
+
+  final List<Status> statuses;
+
+  Map<String, dynamic> toJson() => _$TaskQueryToJson(this);
+}
+
+@JsonSerializable()
+class TaskGroup {
+  const TaskGroup({
+    required this.date,
+    required this.todos,
+    required this.completed,
+    required this.inProgress,
+  });
+
+  factory TaskGroup.fromJson(Map<String, dynamic> json) =>
+      _$TaskGroupFromJson(json);
+
+  final DateTime date;
+  final List<Task> todos;
+  final List<Task> completed;
+  final List<Task> inProgress;
+
+  Map<String, dynamic> toJson() => _$TaskGroupToJson(this);
+}
+
+@JsonSerializable(genericArgumentFactories: true)
+class ValueWrapper<T> {
+  const ValueWrapper({required this.value});
+
+  factory ValueWrapper.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object? json) fromJsonT,
+  ) =>
+      _$ValueWrapperFromJson(json, fromJsonT);
+
+  final T value;
+
+  Map<String, dynamic> toJson(Object? Function(T value) toJsonT) =>
+      _$ValueWrapperToJson(this, toJsonT);
+}

--- a/example_relative_base_url/mono_pkg.yaml
+++ b/example_relative_base_url/mono_pkg.yaml
@@ -1,0 +1,7 @@
+dart:
+ - dev
+
+stages:
+  # Register two jobs to run under the `analyze` stage.
+  - analyze:
+    - dartanalyzer

--- a/example_relative_base_url/pubspec.yaml
+++ b/example_relative_base_url/pubspec.yaml
@@ -1,0 +1,28 @@
+name: retrofit_example
+description: Retrofit generator
+version: 1.0.0
+
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+
+dependencies:
+  retrofit:
+  json_annotation:
+  logger: ^1.2.2
+  dio: ^5.0.1
+  http_parser:
+
+dev_dependencies:
+  test: ^1.23.1
+  retrofit_generator:
+  build_runner: ^2.3.3
+  json_serializable: ^6.6.1
+  mock_web_server: ^5.0.0-nullsafety.1
+  lints: ^2.0.1
+
+dependency_overrides:
+  retrofit:
+    path: ../retrofit
+  retrofit_generator:
+    path: ../generator
+  source_gen: ^1.2.7

--- a/example_relative_base_url/test/example_test.dart
+++ b/example_relative_base_url/test/example_test.dart
@@ -1,0 +1,104 @@
+import 'package:dio/dio.dart';
+import 'package:mock_web_server/mock_web_server.dart';
+import 'package:retrofit_example/example.dart';
+import 'package:test/test.dart';
+
+import 'task_data.dart';
+
+late MockWebServer _server;
+late TasksRestClient _client;
+final _headers = {'Content-Type': 'application/json'};
+final dispatcherMap = <String, MockResponse>{};
+
+void main() {
+  setUp(() async {
+    _server = MockWebServer();
+    await _server.start();
+    final dio = Dio(BaseOptions(baseUrl: _server.url));
+    dio.interceptors.add(LogInterceptor(responseBody: true));
+    dio.interceptors.add(DateTimeInterceptor());
+    _client = TasksRestClient(dio);
+  });
+
+  tearDown(() {
+    _server.shutdown();
+  });
+
+  test('test empty task list', () async {
+    _server.enqueue(
+        body: demoEmptyListJson, headers: {'Content-Type': 'application/json'});
+    final tasks = await _client.getTasks();
+    expect(tasks, isNotNull);
+    expect(tasks.length, 0);
+  });
+
+  test('test task list', () async {
+    _server.enqueue(body: demoTaskListJson, headers: _headers);
+    final tasks = await _client.getTasks();
+    expect(tasks, isNotNull);
+    expect(tasks.length, 1);
+  });
+
+  test('test task detail', () async {
+    _server.enqueue(headers: _headers, body: demoTaskJson);
+    final task = await _client.getTask('id');
+    expect(task, isNotNull);
+    expect(task.id, demoTask.id);
+    expect(task.avatar, demoTask.avatar);
+    expect(task.name, demoTask.name);
+    expect(task.createdAt, demoTask.createdAt);
+  });
+
+  test('create new task', () async {
+    _server.enqueue(headers: _headers, body: demoTaskJson);
+    final task = await _client.createTask(demoTask);
+    expect(task, isNotNull);
+    expect(task.id, demoTask.id);
+    expect(task.avatar, demoTask.avatar);
+    expect(task.name, demoTask.name);
+    expect(task.createdAt, demoTask.createdAt);
+  });
+
+  test('update task all content', () async {
+    _server.enqueue(headers: _headers, body: demoTaskJson);
+    final task = await _client.updateTask('id', demoTask);
+    expect(task, isNotNull);
+    expect(task.id, demoTask.id);
+    expect(task.avatar, demoTask.avatar);
+    expect(task.name, demoTask.name);
+    expect(task.createdAt, demoTask.createdAt);
+  });
+
+  test('update task part content', () async {
+    _server.enqueue(headers: _headers, body: demoTaskJson);
+    final task = await _client
+        .updateTaskPart('id', <String, String>{'name': 'demo name 2'});
+    expect(task, isNotNull);
+    expect(task.id, demoTask.id);
+    expect(task.avatar, demoTask.avatar);
+    expect(task.name, demoTask.name);
+    expect(task.createdAt, demoTask.createdAt);
+  });
+
+  test('delete a task', () async {
+    _server.enqueue();
+    await _client.deleteTask('id').then((it) {
+      expect(null, null);
+    });
+  });
+}
+
+class DateTimeInterceptor extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    options.queryParameters = options.queryParameters.map((key, value) {
+      if (value is DateTime) {
+        //may be change to string from any you use object
+        return MapEntry(key, value.toString());
+      } else {
+        return MapEntry(key, value);
+      }
+    });
+    handler.next(options);
+  }
+}

--- a/example_relative_base_url/test/task_data.dart
+++ b/example_relative_base_url/test/task_data.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:retrofit_example/example.dart';
+
+final demoTask = Task(
+  id: '123455151',
+  name: 'demo task',
+  avatar:
+      'https://p7.hiclipart.com/preview/312/283/679/avatar-computer-icons-user-profile-business-user-avatar.jpg',
+  createdAt: '2017/09/08 21:35:19',
+);
+
+final demoTaskJson = jsonEncode(demoTask);
+final List<Task> demoTaskList = [demoTask];
+final demoTaskListJson = jsonEncode(demoTaskList);
+final List<Task> demoEmptyList = [];
+final demoEmptyListJson = jsonEncode(demoEmptyList);
+
+final groupTask = TaskGroup(
+  date: DateTime.now(),
+  todos: demoTaskList,
+  completed: demoTaskList,
+  inProgress: demoEmptyList,
+);
+
+final groupTaskList = [groupTask];
+final groupTaskListJson = jsonEncode(groupTaskList);

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1822,3 +1822,19 @@ abstract class GenericCastFetch {
   @GET('/')
   Future<User> get();
 }
+
+@ShouldGenerate(
+  '''
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+  ''',
+  contains: true,
+)
+@RestApi()
+abstract class CombineBaseUrls {
+  @GET('/')
+  Future<User> get();
+}

--- a/retrofit/lib/http.dart
+++ b/retrofit/lib/http.dart
@@ -84,6 +84,7 @@ class RestApi {
   /// * Endpoint: `foo/bar/`
   /// * Result: `http://example.com/foo/bar/`
   ///
+  /// When you specify a relative [baseUrl]. The [Dio] instance passed to the constructor should have it defined.
   /// When you don't specify the [baseUrl]. The [Dio] instance passed to the constructor should have it defined.
   /// Otherwise the `path` field of any [HttpMethod] like [POST] should have the full URL.
 


### PR DESCRIPTION
This pull request introduces the feature of supporting a relative base path in the @RestApi annotation. Now it's possible to specify a relative base path for the client, allowing greater flexibility in route configuration.

```dart
@RestApi(baseUrl: 'tasks')
abstract class TasksRestClient {
  @GET('/{id}')
  Future<List<Task?>> getTaskById();

  @GET('/')
  Future<List<Task>> getTasks();

  ....
}
```

This update has been implemented by incorporating a mechanism to correctly interpret and combine the relative base path with the configured baseUrl in the dio instance. A new test has been added to ensure proper handling of the base path. This enhancement provides a more convenient way to organize and structure routes within our clients, enabling a more modular and scalable implementation.