### PR TITLE
Fix/enum return types and query params

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 ## 7.0.7
 
-- Enums return types are now generated iterating over the enum values instead of calling `.toJson()` method
+- Enums return types generated iterating over the enum values instead of calling `.toJson()` method
+- Enums as query parameters generated with `.name` instead of `toJson()`
 
 ## 7.0.6
 

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 7.0.7
+
+- Enums return types are now generated iterating over the enum values instead of calling `.toJson()` method
+
 ## 7.0.6
 
 - Fix DateTime.toIso8601String() issue #586

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -878,9 +878,20 @@ You should create a new class to encapsulate the response.
                   '$displayString.fromJson($_resultVar.data!,${_getInnerJsonSerializableMapperFn(returnType)})',
                 );
               } else {
-                mapperCode = refer(
-                  '${_displayString(returnType)}.fromJson($_resultVar.data!)',
-                );
+                // check if returnType is an enum
+                if (returnType.element is EnumElement) {
+                  mapperCode = refer(
+                    '${_displayString(returnType)}.values.firstWhere((e) => e.toString() == \'${_displayString(returnType)}.\${_result.data}\','
+                    'orElse: () => throw ArgumentError('
+                    '\'${_displayString(returnType)} does not contain value \${_result.data}\','
+                    '),'
+                    ')',
+                  );
+                } else {
+                  mapperCode = refer(
+                    '${_displayString(returnType)}.fromJson($_resultVar.data!)',
+                  );
+                }
               }
               break;
             case retrofit.Parser.DartJsonMapper:

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -878,10 +878,9 @@ You should create a new class to encapsulate the response.
                   '$displayString.fromJson($_resultVar.data!,${_getInnerJsonSerializableMapperFn(returnType)})',
                 );
               } else {
-                // check if returnType is an enum
-                if (returnType.element is EnumElement) {
+                if (_isEnum(returnType)) {
                   mapperCode = refer(
-                    '${_displayString(returnType)}.values.firstWhere((e) => e.toString() == \'${_displayString(returnType)}.\${_result.data}\','
+                    '${_displayString(returnType)}.values.firstWhere((e) => e.name == _result.data,'
                     'orElse: () => throw ArgumentError('
                     '\'${_displayString(returnType)} does not contain value \${_result.data}\','
                     '),'
@@ -1308,6 +1307,12 @@ if (T != dynamic &&
         _typeChecker(Float).isExactlyType(returnType);
   }
 
+  bool _isEnum(DartType? dartType){
+    if (dartType == null || dartType.element == null){
+      return false;
+    }
+    return dartType.element is EnumElement;
+  }
   bool _isDateTime(DartType? dartType) {
     if (dartType == null) {
       return false;
@@ -1342,7 +1347,12 @@ if (T != dynamic &&
                       .nullSafeProperty('toIso8601String')
                       .call([])
                   : refer(p.displayName).property('toIso8601String').call([]);
-            } else {
+            } else if(_isEnum(p.type)) {
+              value = p.type.nullabilitySuffix == NullabilitySuffix.question
+                  ? refer(p.displayName)
+                      .nullSafeProperty('name')
+                  : refer(p.displayName).property('name');
+            }else{
               value = p.type.nullabilitySuffix == NullabilitySuffix.question
                   ? refer(p.displayName).nullSafeProperty('toJson').call([])
                   : refer(p.displayName).property('toJson').call([]);

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -6,7 +6,7 @@ topics:
   - build-runner
   - codegen
   - api
-version: 7.0.6
+version: 7.0.7
 environment:
   sdk: '>=2.19.0 <4.0.0'
 

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -380,6 +380,26 @@ abstract class StreamReturnType {
   Stream<User> getUser();
 }
 
+enum TestEnum { A, B }
+
+@ShouldGenerate(
+  '''
+    final value = TestEnum.values.firstWhere(
+      (e) => e.toString() == 'TestEnum.\$_result.data',
+      orElse: () => throw ArgumentError(
+        'TestEnum does not contain value \$_result.data',
+      ),
+    );
+    return value;
+''',
+  contains: true,
+)
+@RestApi()
+abstract class EnumReturnType {
+  @GET('/')
+  Future<TestEnum> getTestEnum();
+}
+
 @ShouldGenerate(
   '''
   Stream<User> getUser() async* {

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -385,9 +385,9 @@ enum TestEnum { A, B }
 @ShouldGenerate(
   '''
     final value = TestEnum.values.firstWhere(
-      (e) => e.toString() == 'TestEnum.\$_result.data',
+      (e) => e.name == _result.data,
       orElse: () => throw ArgumentError(
-        'TestEnum does not contain value \$_result.data',
+        'TestEnum does not contain value \${_result.data}',
       ),
     );
     return value;
@@ -398,6 +398,22 @@ enum TestEnum { A, B }
 abstract class EnumReturnType {
   @GET('/')
   Future<TestEnum> getTestEnum();
+}
+
+enum EnumParam {
+  enabled, disabled,
+}
+
+@ShouldGenerate(
+  '''
+    final queryParameters = <String, dynamic>{r'test': status?.name};
+''',
+  contains: true,
+)
+@RestApi()
+abstract class TestQueryParamEnum {
+  @GET('/test')
+  Future<void> getTest(@Query('test') EnumParam? status);
 }
 
 @ShouldGenerate(


### PR DESCRIPTION
fix #588 and #591
not 100% sure that `dartType.element is EnumElement` is the best way to check if a type is an enum (`dartType.isDartCoreEnum` does not work in this case). Just let me know if there's another way please.

edit: i also found the open issues  #559 and #536 that would be fixed by this pr