### PR TITLE
Use `toJson()` instead of `.name` if enums have `toJson()`.

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,4 +24,4 @@ dependency_overrides:
     path: ../retrofit
   retrofit_generator:
     path: ../generator
-  source_gen: ^1.2.7
+  source_gen: ">=1.3.0 <1.4.0"

--- a/example_relative_base_url/pubspec.yaml
+++ b/example_relative_base_url/pubspec.yaml
@@ -25,4 +25,4 @@ dependency_overrides:
     path: ../retrofit
   retrofit_generator:
     path: ../generator
-  source_gen: ^1.2.7
+  source_gen: ">=1.3.0 <1.4.0"

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 7.0.8
+- Use `toJson()` instead of `.name` if enums have `toJson()`.
+
 ## 7.0.7
 
 - Enums return types generated iterating over the enum values instead of calling `.toJson()` method

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -6,7 +6,7 @@ topics:
   - build-runner
   - codegen
   - api
-version: 7.0.7
+version: 7.0.8
 environment:
   sdk: '>=2.19.0 <4.0.0'
 

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -401,7 +401,8 @@ abstract class EnumReturnType {
 }
 
 enum EnumParam {
-  enabled, disabled,
+  enabled,
+  disabled,
 }
 
 @ShouldGenerate(
@@ -414,6 +415,51 @@ enum EnumParam {
 abstract class TestQueryParamEnum {
   @GET('/test')
   Future<void> getTest(@Query('test') EnumParam? status);
+}
+
+enum FromJsonEnum {
+  a,
+  b,
+  ;
+
+  factory FromJsonEnum.fromJson(Map<String, dynamic> json) => FromJsonEnum.a;
+}
+
+@ShouldGenerate(
+  '''
+    final value = FromJsonEnum.fromJson(_result.data!);
+    return value;
+''',
+  contains: true,
+)
+@RestApi()
+abstract class EnumFromJsonReturnType {
+  @GET('/')
+  Future<FromJsonEnum> getTestEnum();
+}
+
+enum ToJsonEnum {
+  plus(1),
+  minus(-1),
+  ;
+
+  const ToJsonEnum(this.value);
+
+  final int value;
+
+  int toJson() => value;
+}
+
+@ShouldGenerate(
+  '''
+    final queryParameters = <String, dynamic>{r'test': status?.toJson()};
+''',
+  contains: true,
+)
+@RestApi()
+abstract class TestQueryParamEnumToJson {
+  @GET('/test')
+  Future<void> getTest(@Query('test') ToJsonEnum? status);
 }
 
 @ShouldGenerate(


### PR DESCRIPTION
Vesion 7.0.7 has breaking change.
I want to use `toJson()` if it exists.

-----

```dart
enum ToJsonEnum {
  plus(1),
  minus(-1),
  ;

  const ToJsonEnum(this.value);

  final int value;

  int toJson() => value;
}

@RestApi()
abstract class TestQueryParamEnumToJson {
  @GET('/test')
  Future<void> getTest(@Query('test') ToJsonEnum? status);
}
```

7.0.6 and 7.0.8 generates `final queryParameters = <String, dynamic>{r'test': status?.toJson()};`.
7.0.7 generates `final queryParameters = <String, dynamic>{r'test': status?.name};`.