### PR TITLE
PROPOSAL: Improve experience when retrying MultiPart request with Files

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1726,7 +1726,9 @@ ${bodyName.displayName} == null
                   .property('path.split(Platform.pathSeparator).last');
           final filePath = refer(p.displayName).property('path');
           final headers = keepFilePath
-              ? literalMap({'original_file_path': filePath})
+              ? literalMap({
+                  'original_file_path': [filePath]
+                })
               : literalMap({});
 
           final uploadFileInfo = refer('$MultipartFile.fromFileSync').call([
@@ -1846,7 +1848,9 @@ ${bodyName.displayName} == null
             final keepFilePath = r.peek('keepFilePath')?.boolValue ?? false;
             final filePath = refer(p.displayName).property('path');
             final headers = keepFilePath
-                ? literalMap({'original_file_path': filePath})
+                ? literalMap({
+                    'original_file_path': [filePath]
+                  })
                 : '{}';
             if (p.type.isNullable) {
               blocks.add(Code('if (${p.displayName} != null) {'));

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1741,7 +1741,7 @@ ${bodyName.displayName} == null
           final filePath = refer(p.displayName).property('path');
           final headers = keepFilePath
               ? literalMap({
-                  'original_file_path': [filePath]
+                  'original_file_path': literalList([filePath])
                 })
               : literalMap({});
 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -1,6 +1,5 @@
 name: retrofit_generator
 description: retrofit generator is an dio client generator using source_gen and inspired by Chopper and Retrofit.
-publish_to: none
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
 topics:
@@ -18,7 +17,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit:
+  retrofit:  ## update this dependency once a new version is released with keepOriginalPath change
     path: ../retrofit
   source_gen: ^1.3.0
   tuple: ^2.0.1

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -1,5 +1,6 @@
 name: retrofit_generator
 description: retrofit generator is an dio client generator using source_gen and inspired by Chopper and Retrofit.
+publish_to: none
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
 topics:
@@ -17,7 +18,8 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit: ^4.0.1
+  retrofit:
+    path: ../retrofit
   source_gen: ^1.3.0
   tuple: ^2.0.1
 

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -263,7 +263,9 @@ enum ImageType { icon, large }
       MultipartFile.fromFileSync(
         image.path,
         filename: image.path.split(Platform.pathSeparator).last,
-        headers: {},
+        headers: {
+          'original_file_path': [image.path]
+        },
       ),
     ));
 ''',
@@ -283,7 +285,7 @@ abstract class FilePartTest {
       MultipartFile.fromFileSync(
         image.path,
         filename: 'my_profile_image.jpg',
-        headers: {'original_file_path': [image.path]},
+        headers: {},
       ),
     ));
 ''',
@@ -334,7 +336,9 @@ abstract class FilePartWithNullableMultipartListTest {
       MultipartFile.fromFileSync(
         image.path,
         filename: image.path.split(Platform.pathSeparator).last,
-        headers: {'original_file_path': [image.path]},
+        headers: {
+          'original_file_path': [image.path]
+        },
       ),
     ));
   ''',

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -263,6 +263,7 @@ enum ImageType { icon, large }
       MultipartFile.fromFileSync(
         image.path,
         filename: image.path.split(Platform.pathSeparator).last,
+        headers: {},
       ),
     ));
 ''',
@@ -271,7 +272,7 @@ enum ImageType { icon, large }
 @RestApi(baseUrl: 'https://httpbin.org/')
 abstract class FilePartTest {
   @POST('/profile')
-  Future<String> setProfile(@Part() File image);
+  Future<String> setProfile(@Part(keepFilePath: true) File image);
 }
 
 @ShouldGenerate(
@@ -282,6 +283,7 @@ abstract class FilePartTest {
       MultipartFile.fromFileSync(
         image.path,
         filename: 'my_profile_image.jpg',
+        headers: {'original_file_path': image.path},
       ),
     ));
 ''',
@@ -320,7 +322,8 @@ abstract class FilePartWithMultipartListTest {
 @RestApi(baseUrl: 'https://httpbin.org/')
 abstract class FilePartWithNullableMultipartListTest {
   @POST('/profile')
-  Future<String> setProfile(@Part() List<MultipartFile>? images);
+  Future<String> setProfile(
+      @Part(keepFilePath: true) List<MultipartFile>? images);
 }
 
 @ShouldGenerate(
@@ -331,6 +334,7 @@ abstract class FilePartWithNullableMultipartListTest {
       MultipartFile.fromFileSync(
         image.path,
         filename: image.path.split(Platform.pathSeparator).last,
+        headers: {'original_file_path': image.path},
       ),
     ));
   ''',
@@ -339,7 +343,7 @@ abstract class FilePartWithNullableMultipartListTest {
 @RestApi(baseUrl: 'https://httpbin.org/')
 abstract class UploadFileInfoPartTest {
   @POST('/profile')
-  Future<String> setProfile(@Part() File image);
+  Future<String> setProfile(@Part(keepFilePath: true) File image);
 }
 
 @ShouldGenerate(
@@ -401,7 +405,8 @@ abstract class EnumReturnType {
 }
 
 enum EnumParam {
-  enabled, disabled,
+  enabled,
+  disabled,
 }
 
 @ShouldGenerate(
@@ -894,6 +899,7 @@ abstract class TestHttpResponseArray {
         MultipartFile.fromFileSync(
           i.path,
           filename: i.path.split(Platform.pathSeparator).last,
+          headers: {},
         ))));
 ''',
   contains: true,
@@ -907,6 +913,7 @@ abstract class TestHttpResponseArray {
           MultipartFile.fromFileSync(
             i.path,
             filename: i.path.split(Platform.pathSeparator).last,
+            headers: {},
           ))));
     }
 ''',
@@ -920,6 +927,7 @@ abstract class TestHttpResponseArray {
         MultipartFile.fromFileSync(
           file.path,
           filename: file.path.split(Platform.pathSeparator).last,
+          headers: {},
         ),
       ));
     }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -283,7 +283,7 @@ abstract class FilePartTest {
       MultipartFile.fromFileSync(
         image.path,
         filename: 'my_profile_image.jpg',
-        headers: {'original_file_path': image.path},
+        headers: {'original_file_path': [image.path]},
       ),
     ));
 ''',
@@ -334,7 +334,7 @@ abstract class FilePartWithNullableMultipartListTest {
       MultipartFile.fromFileSync(
         image.path,
         filename: image.path.split(Platform.pathSeparator).last,
-        headers: {'original_file_path': image.path},
+        headers: {'original_file_path': [image.path]},
       ),
     ));
   ''',

--- a/retrofit/lib/http.dart
+++ b/retrofit/lib/http.dart
@@ -301,6 +301,7 @@ class Part {
     this.name,
     this.fileName,
     this.contentType,
+    this.keepFilePath = false,
   });
 
   @Deprecated('future release')
@@ -313,6 +314,9 @@ class Part {
 
   // To identify the content type of a file
   final String? contentType;
+
+  /// If this field is a file, optionally specify whether to keep the file path for retrying requests
+  final bool? keepFilePath;
 }
 
 @immutable


### PR DESCRIPTION
Hello there!

We at Revelo use Retrofit and its generator for all of our http requests. We also use MultiPart a lot and have gotten a significant amount of errors when retrying to send a MultiPart File because the stream has already been listened to. 

 exception: Bad state: The FormData has already been finalized. This typically means you are using the same FormData in repeated requests.. Error thrown .

I thought of a possible way to make retrying these requests possible and it involves including the [original file path] in the multipart file. At first I thought about inserting it in the file's headers, but I don't know if this could be a security breach or interfere in any other processes. And well, even though it would require us to rebuild the [files] field of the FormData, it's already better than having to implement another class just to deal with the paths of all of the files we're inserting and managing this in local storage.

To make this change, we would ideally add a new parameter in the Part() class, like [keepOriginalPath], which would be a bool. We could then use this bool in the generator to insert the path in the [headers] field's map when generating the code, if this field is given as true.

With this, we could retrieve the path in the RequestOptions object, and would not need to mess with Dio's structures as well.

WDYT? Would this ideia be ok? I was able to make it work properly but the tests got me confused, I would love some help from the team if I could have it and the idea makes sense to you.

Thanks a lot, best regards!

|Usage example|Generated Code example|
|:-:|:-:|
|![Screenshot 2023-07-04 at 14 51 23](https://github.com/trevorwang/retrofit.dart/assets/20102814/f451e05e-4532-45c9-b9bf-eb1fd81c48ae)|![Screenshot 2023-07-04 at 14 51 42](https://github.com/trevorwang/retrofit.dart/assets/20102814/688841f3-c64a-49f5-8c6d-b9358bdf0140)|

