### PR TITLE
Extend when there is a default constructor

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -87,7 +87,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     );
     final baseUrl = clientAnnotation.baseUrl;
     final annotClassConsts = element.constructors
-        .where((c) => !c.isFactory && !c.isDefaultConstructor);
+        .where((c) => !c.isFactory);
     final classBuilder = Class((c) {
       c
         ..name = '_$className'


### PR DESCRIPTION
Sometimes we need implemented logic in `RestClient ` itself: 

```
@RestApi(baseUrl: URL)
abstract class RestClient {
  RestClient();

  factory RestClient.fac(Dio dio,{String baseUrl}) = _RestClient;

  @GET('/$KAL')
  Future<Kal> _getKal();

  @GET('/$GPC')
  Future<Gpc> _getGpc();

  Future<T> get<T>() => (T == Kal ? _getKal() : T==Gpc ? _getGpc() : throw 'not impl' ) as Future<T>;
}
```