### PR TITLE
feat: add protobuf mineType parameters messageType for proxy tools

### DIFF
--- a/example_protobuf/lib/example.dart
+++ b/example_protobuf/lib/example.dart
@@ -2,7 +2,8 @@ import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 import 'package:flutter/foundation.dart';
 
-import 'proto/query.pbserver.dart';
+import 'proto/params.pbserver.dart';
+import 'proto/result.pbserver.dart';
 
 part 'example.g.dart';
 
@@ -10,10 +11,9 @@ part 'example.g.dart';
 abstract class RestClient {
   factory RestClient(Dio dio, {String baseUrl}) = _RestClient;
 
-  @GET("/tags")
+  @POST("/tags")
   Future<Result> getProtoBufInt(@Body() Params message);
 
-  
-  @GET("/tags1")
+  @POST("/tags1")
   Future<List<int>> getMessage(@Body() Params message);
 }

--- a/example_protobuf/lib/proto/params.pb.dart
+++ b/example_protobuf/lib/proto/params.pb.dart
@@ -27,7 +27,7 @@ class Params extends $pb.GeneratedMessage {
   factory Params.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory Params.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Params', createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Params', package: const $pb.PackageName(_omitMessageNames ? '' : 'examples.enumerations'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'key')
     ..hasRequiredFields = false
   ;
@@ -61,56 +61,6 @@ class Params extends $pb.GeneratedMessage {
   $core.bool hasKey() => $_has(0);
   @$pb.TagNumber(1)
   void clearKey() => clearField(1);
-}
-
-class Result extends $pb.GeneratedMessage {
-  factory Result({
-    $core.String? value,
-  }) {
-    final $result = create();
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
-  }
-  Result._() : super();
-  factory Result.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Result.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Result', createEmptyInstance: create)
-    ..aOS(1, _omitFieldNames ? '' : 'value')
-    ..hasRequiredFields = false
-  ;
-
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  Result clone() => Result()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Result copyWith(void Function(Result) updates) => super.copyWith((message) => updates(message as Result)) as Result;
-
-  $pb.BuilderInfo get info_ => _i;
-
-  @$core.pragma('dart2js:noInline')
-  static Result create() => Result._();
-  Result createEmptyInstance() => create();
-  static $pb.PbList<Result> createRepeated() => $pb.PbList<Result>();
-  @$core.pragma('dart2js:noInline')
-  static Result getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Result>(create);
-  static Result? _defaultInstance;
-
-  @$pb.TagNumber(1)
-  $core.String get value => $_getSZ(0);
-  @$pb.TagNumber(1)
-  set value($core.String v) { $_setString(0, v); }
-  @$pb.TagNumber(1)
-  $core.bool hasValue() => $_has(0);
-  @$pb.TagNumber(1)
-  void clearValue() => clearField(1);
 }
 
 

--- a/example_protobuf/lib/proto/params.pbenum.dart
+++ b/example_protobuf/lib/proto/params.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: proto/params.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/example_protobuf/lib/proto/params.pbjson.dart
+++ b/example_protobuf/lib/proto/params.pbjson.dart
@@ -1,6 +1,6 @@
 //
 //  Generated code. Do not modify.
-//  source: proto/query.proto
+//  source: proto/params.proto
 //
 // @dart = 2.12
 
@@ -24,16 +24,4 @@ const Params$json = {
 /// Descriptor for `Params`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List paramsDescriptor = $convert.base64Decode(
     'CgZQYXJhbXMSEAoDa2V5GAEgASgJUgNrZXk=');
-
-@$core.Deprecated('Use resultDescriptor instead')
-const Result$json = {
-  '1': 'Result',
-  '2': [
-    {'1': 'value', '3': 1, '4': 1, '5': 9, '10': 'value'},
-  ],
-};
-
-/// Descriptor for `Result`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resultDescriptor = $convert.base64Decode(
-    'CgZSZXN1bHQSFAoFdmFsdWUYASABKAlSBXZhbHVl');
 

--- a/example_protobuf/lib/proto/params.pbserver.dart
+++ b/example_protobuf/lib/proto/params.pbserver.dart
@@ -1,11 +1,14 @@
 //
 //  Generated code. Do not modify.
-//  source: proto/query.proto
+//  source: proto/params.proto
 //
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'params.pb.dart';
 

--- a/example_protobuf/lib/proto/result.pb.dart
+++ b/example_protobuf/lib/proto/result.pb.dart
@@ -1,6 +1,6 @@
 //
 //  Generated code. Do not modify.
-//  source: proto/query.proto
+//  source: proto/result.proto
 //
 // @dart = 2.12
 
@@ -12,56 +12,6 @@
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
-
-class Params extends $pb.GeneratedMessage {
-  factory Params({
-    $core.String? key,
-  }) {
-    final $result = create();
-    if (key != null) {
-      $result.key = key;
-    }
-    return $result;
-  }
-  Params._() : super();
-  factory Params.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Params.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Params', createEmptyInstance: create)
-    ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..hasRequiredFields = false
-  ;
-
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  Params clone() => Params()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Params copyWith(void Function(Params) updates) => super.copyWith((message) => updates(message as Params)) as Params;
-
-  $pb.BuilderInfo get info_ => _i;
-
-  @$core.pragma('dart2js:noInline')
-  static Params create() => Params._();
-  Params createEmptyInstance() => create();
-  static $pb.PbList<Params> createRepeated() => $pb.PbList<Params>();
-  @$core.pragma('dart2js:noInline')
-  static Params getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Params>(create);
-  static Params? _defaultInstance;
-
-  @$pb.TagNumber(1)
-  $core.String get key => $_getSZ(0);
-  @$pb.TagNumber(1)
-  set key($core.String v) { $_setString(0, v); }
-  @$pb.TagNumber(1)
-  $core.bool hasKey() => $_has(0);
-  @$pb.TagNumber(1)
-  void clearKey() => clearField(1);
-}
 
 class Result extends $pb.GeneratedMessage {
   factory Result({

--- a/example_protobuf/lib/proto/result.pbenum.dart
+++ b/example_protobuf/lib/proto/result.pbenum.dart
@@ -1,14 +1,11 @@
 //
 //  Generated code. Do not modify.
-//  source: proto/query.proto
+//  source: proto/result.proto
 //
 // @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
-// ignore_for_file: constant_identifier_names
-// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-
-export 'query.pb.dart';
 

--- a/example_protobuf/lib/proto/result.pbjson.dart
+++ b/example_protobuf/lib/proto/result.pbjson.dart
@@ -1,0 +1,27 @@
+//
+//  Generated code. Do not modify.
+//  source: proto/result.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use resultDescriptor instead')
+const Result$json = {
+  '1': 'Result',
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 9, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `Result`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List resultDescriptor = $convert.base64Decode(
+    'CgZSZXN1bHQSFAoFdmFsdWUYASABKAlSBXZhbHVl');
+

--- a/example_protobuf/lib/proto/result.pbserver.dart
+++ b/example_protobuf/lib/proto/result.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: proto/result.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'result.pb.dart';
+

--- a/example_protobuf/proto/params.proto
+++ b/example_protobuf/proto/params.proto
@@ -1,9 +1,7 @@
 syntax = "proto3";
 
+package examples.enumerations;
+
 message Params {
   string key = 1;
-}
-
-message Result {
-  string value = 1;
 }

--- a/example_protobuf/proto/result.proto
+++ b/example_protobuf/proto/result.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Result {
+  string value = 1;
+}

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -459,6 +459,17 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           literal(contentType.peek('mime')?.stringValue);
     }
 
+    /// gen code for request body for content-type on Protobuf body
+    final annotation = _getAnnotation(m, retrofit.Body);
+    final bodyName = annotation?.item1;
+    if (bodyName != null) {
+      if (const TypeChecker.fromRuntime(GeneratedMessage)
+          .isAssignableFromType(bodyName.type)) {
+        extraOptions[_contentType] = literal(
+            "application/x-protobuf; \${${bodyName.displayName}.info_.qualifiedMessageName == \"\" ? \"\" :\"messageType=\${${bodyName.displayName}.info_.qualifiedMessageName}\"}");
+      }
+    }
+
     extraOptions[_baseUrlVar] = refer(_baseUrlVar);
 
     final responseType = _getResponseTypeAnnotation(m);
@@ -2055,19 +2066,10 @@ ${bodyName.displayName} == null
         _typeChecker(GeneratedMessage).isAssignableFromType(returnType)) {
       headers.removeWhere(
           (key, value) => "accept".toLowerCase() == key.toLowerCase());
-      headers.addAll({"accept": literal("application/x-protobuf")});
-    }
-
-    /// gen code for request body for content-type on Protobuf body
-    final annotation = _getAnnotation(m, retrofit.Body);
-    final bodyName = annotation?.item1;
-    if (bodyName != null) {
-      if (const TypeChecker.fromRuntime(GeneratedMessage)
-          .isAssignableFromType(bodyName.type)) {
-        headers.removeWhere(
-            (key, value) => "content-type".toLowerCase() == key.toLowerCase());
-        headers.addAll({"content-type": literal("application/x-protobuf")});
-      }
+      headers.addAll({
+        "accept": literal(
+            "application/x-protobuf; \${${_displayString(returnType)}.getDefault().info_.qualifiedMessageName == \"\" ? \"\" :\"messageType=\${${_displayString(returnType)}.getDefault().info_.qualifiedMessageName}\"}")
+      });
     }
 
     return headers;

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1940,15 +1940,16 @@ abstract class CombineBaseUrls {
   contains: true,
 )
 @ShouldGenerate(
-  '''r'accept': 'application/x-protobuf''',
+  '''
+      r'accept':
+          'application/x-protobuf; \${Result.getDefault().info_.qualifiedMessageName == "" ? "" : "messageType=\${Result.getDefault().info_.qualifiedMessageName}"}'
+  ''',
   contains: true,
 )
 @ShouldGenerate(
-  '''r'content-type': 'application/x-protobuf''',
-  contains: true,
-)
-@ShouldGenerate(
-  '''contentType: 'application/x-protobuf''',
+  '''
+      contentType:
+          'application/x-protobuf; \${params.info_.qualifiedMessageName == "" ? "" : "messageType=\${params.info_.qualifiedMessageName}"}\'''',
   contains: true,
 )
 @RestApi()


### PR DESCRIPTION
1、remove unused contentType in header and move gen code for requestBody contentType
2、add protobuf mineType parameters messageType for proxy tools (https://stackoverflow.com/questions/30505408/what-is-the-correct-protobuf-content-type,https://docs.proxyman.io/advanced-features/protobuf)