### PR TITLE
Fix Flutter Compute Generator to allow Multiple Functions for Generic Objects

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -930,7 +930,7 @@ You should create a new class to encapsulate the response.
               break;
             case retrofit.Parser.FlutterCompute:
               mapperCode = refer(
-                'await compute(deserialize${_displayString(returnType)}, $_resultVar.data!)',
+                'await compute(deserialize${_displayString(returnType).replaceFirst('<', '').replaceFirst('>', '')}, $_resultVar.data!)',
               );
               break;
           }


### PR DESCRIPTION
I have a Generic API Model that couldn't be used in a Computed Data Source(using retrofit.Parser.FlutterCompute) because I didn't have a way to pass the fromJson factory of the T.

I tried to extend T with an abstract class, but it doesn't work. I also tried passing the factory method as a parameter to the deserialization method, it didn't work as well.

I finally made it by changing the `_generateRequest` method to return a name that I could use to have a unique method for every T type in ApiModel<T> by removing the `<`and `>`.

```
PaginatedApiData<SampleApiData> deserializePaginatedApiDataSampleApiData(
  Map<String, dynamic> json,
) =>
    PaginatedApiData.fromJson(json, SampleApiData.fromJson);

PaginatedApiData<SampleTestApiData>
    deserializePaginatedApiDataSampleTestApiData(
  Map<String, dynamic> json,
) =>
        PaginatedApiData.fromJson(json, SampleTestApiData.fromJson);

```

I'd like to help to create a better solution for it. Let me know what you think and how it can be improved.