### PR TITLE
fix: pb support error on MapSerializable、DartJsonMapper、FlutterCompute

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1571,6 +1571,14 @@ if (T != dynamic &&
             );
             break;
         }
+      } else if (_typeChecker(GeneratedMessage).isSuperTypeOf(bodyName.type)) {
+        if (bodyName.type.nullabilitySuffix != NullabilitySuffix.none) {
+          log.warning(
+              "GeneratedMessage body ${_displayString(bodyName.type)} can not be nullable.");
+        }
+        blocks.add(declareFinal(dataVar)
+            .assign(refer("${bodyName.displayName}.writeToBuffer()"))
+            .statement);
       } else if (bodyTypeElement != null &&
           _typeChecker(File).isExactly(bodyTypeElement)) {
         blocks.add(
@@ -1614,15 +1622,6 @@ if (T != dynamic &&
                 ).statement,
               );
           }
-        } else if (_typeChecker(GeneratedMessage)
-            .isSuperTypeOf(bodyName.type)) {
-          if (bodyName.type.nullabilitySuffix != NullabilitySuffix.none) {
-            log.warning(
-                "GeneratedMessage body ${_displayString(bodyName.type)} can not be nullable.");
-          }
-          blocks.add(declareFinal(dataVar)
-              .assign(refer("${bodyName.displayName}.writeToBuffer()"))
-              .statement);
         } else {
           if (_missingToJson(ele)) {
             log.warning(

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1952,8 +1952,93 @@ abstract class CombineBaseUrls {
           'application/x-protobuf; \${params.info_.qualifiedMessageName == "" ? "" : "messageType=\${params.info_.qualifiedMessageName}"}\'''',
   contains: true,
 )
+@ShouldGenerate(
+  '''await compute(Result.fromBuffer, _result.data!);''',
+  contains: true,
+)
 @RestApi()
-abstract class ProtoSupport {
+abstract class ProtoSupportParserJsonSerializable {
+  @GET('/')
+  Future<Result> get(@Body() Params params);
+}
+
+@ShouldGenerate(
+  '''final _data = params.writeToBuffer();''',
+  contains: true,
+)
+@ShouldGenerate(
+  '''
+      r'accept':
+          'application/x-protobuf; \${Result.getDefault().info_.qualifiedMessageName == "" ? "" : "messageType=\${Result.getDefault().info_.qualifiedMessageName}"}'
+  ''',
+  contains: true,
+)
+@ShouldGenerate(
+  '''
+      contentType:
+          'application/x-protobuf; \${params.info_.qualifiedMessageName == "" ? "" : "messageType=\${params.info_.qualifiedMessageName}"}\'''',
+  contains: true,
+)
+@ShouldGenerate(
+  '''await compute(Result.fromBuffer, _result.data!);''',
+  contains: true,
+)
+@RestApi(parser: Parser.DartJsonMapper)
+abstract class ProtoSupportParserDartJsonMapper {
+  @GET('/')
+  Future<Result> get(@Body() Params params);
+}
+
+@ShouldGenerate(
+  '''final _data = params.writeToBuffer();''',
+  contains: true,
+)
+@ShouldGenerate(
+  '''
+      r'accept':
+          'application/x-protobuf; \${Result.getDefault().info_.qualifiedMessageName == "" ? "" : "messageType=\${Result.getDefault().info_.qualifiedMessageName}"}'
+  ''',
+  contains: true,
+)
+@ShouldGenerate(
+  '''
+      contentType:
+          'application/x-protobuf; \${params.info_.qualifiedMessageName == "" ? "" : "messageType=\${params.info_.qualifiedMessageName}"}\'''',
+  contains: true,
+)
+@ShouldGenerate(
+  '''await compute(Result.fromBuffer, _result.data!);''',
+  contains: true,
+)
+@RestApi(parser: Parser.MapSerializable)
+abstract class ProtoSupportParserMapSerializable {
+  @GET('/')
+  Future<Result> get(@Body() Params params);
+}
+
+@ShouldGenerate(
+  '''final _data = params.writeToBuffer();''',
+  contains: true,
+)
+@ShouldGenerate(
+  '''
+      r'accept':
+          'application/x-protobuf; \${Result.getDefault().info_.qualifiedMessageName == "" ? "" : "messageType=\${Result.getDefault().info_.qualifiedMessageName}"}'
+  ''',
+  contains: true,
+)
+@ShouldGenerate(
+  '''
+      contentType:
+          'application/x-protobuf; \${params.info_.qualifiedMessageName == "" ? "" : "messageType=\${params.info_.qualifiedMessageName}"}\'''',
+  contains: true,
+)
+@ShouldGenerate(
+  '''await compute(Result.fromBuffer, _result.data!);''',
+  contains: true,
+)
+@RestApi(parser: Parser.FlutterCompute)
+abstract class ProtoSupportParserFlutterCompute {
   @GET('/')
   Future<Result> get(@Body() Params params);
 }


### PR DESCRIPTION
1、fix gen code error on  MapSerializable、DartJsonMapper、FlutterCompute with pb support
2、add test for every Parse for PB support