### PR TITLE
Use `toJson()` instead of .name if `@Path` enums have `toJson()`

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -406,7 +406,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       final value = v.peek(_valueVar)?.stringValue ?? k.displayName;
       definePath = definePath?.replaceFirst(
         '{$value}',
-        "\${${k.displayName}${k.type.element?.kind == ElementKind.ENUM ? '.name' : ''}}",
+        "\${${k.displayName}${k.type.element?.kind == ElementKind.ENUM ? _hasToJson(k.type) ? '.toJson()' : '.name' : ''}}",
       );
     });
     return literal(definePath);


### PR DESCRIPTION
this is the fix for https://github.com/trevorwang/retrofit.dart/issues/559
and it's a patch continued from https://github.com/trevorwang/retrofit.dart/pull/596