### PR TITLE
Allow to have 'value' as a parameter identifier in annotated methods

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -59,7 +59,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   static const _onSendProgress = 'onSendProgress';
   static const _onReceiveProgress = 'onReceiveProgress';
   static const _path = 'path';
-  static const _valueVar = 'value';
+  static const _valueVar = '_value';
   bool hasCustomOptions = false;
 
   /// Global options specified in the `build.yaml`
@@ -828,7 +828,7 @@ You should create a new class to encapsulate the response.
             );
           }
         } else {
-          blocks.add(const Code('final value = $_resultVar.data!;'));
+          blocks.add(const Code('final $_valueVar = $_resultVar.data!;'));
         }
       } else {
         if (_isBasicType(returnType)) {
@@ -856,7 +856,7 @@ You should create a new class to encapsulate the response.
                   .assign(refer('await $_dioVar.fetch').call([options]))
                   .statement,
             )
-            ..add(const Code('final value = $_resultVar.data;'));
+            ..add(const Code('final $_valueVar = $_resultVar.data;'));
         } else if (_typeChecker(GeneratedMessage).isSuperTypeOf(returnType)) {
           blocks.add(
             declareFinal(_resultVar)
@@ -865,7 +865,7 @@ You should create a new class to encapsulate the response.
                 .statement,
           );
           blocks.add(Code(
-              "final value = await compute(${_displayString(returnType)}.fromBuffer, $_resultVar.data!);"));
+              "final $_valueVar = await compute(${_displayString(returnType)}.fromBuffer, $_resultVar.data!);"));
         } else {
           final fetchType = returnType.isNullable
               ? 'Map<String,dynamic>?'
@@ -954,7 +954,7 @@ You should create a new class to encapsulate the response.
       '''),
         );
       } else {
-        blocks.add(Code('$returnAsyncWrapper value;'));
+        blocks.add(Code('$returnAsyncWrapper $_valueVar;'));
       }
     }
 

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -403,7 +403,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     final paths = _getAnnotations(m, retrofit.Path);
     var definePath = method.peek('path')?.stringValue;
     paths.forEach((k, v) {
-      final value = v.peek(_valueVar)?.stringValue ?? k.displayName;
+      final value = v.peek('value')?.stringValue ?? k.displayName;
       definePath = definePath?.replaceFirst(
         '{$value}',
         "\${${k.displayName}${k.type.element?.kind == ElementKind.ENUM ? _hasToJson(k.type) ? '.toJson()' : '.name' : ''}}",
@@ -1377,7 +1377,7 @@ if (T != dynamic &&
   ) {
     final queries = _getAnnotations(m, retrofit.Query);
     final queryParameters = queries.map((p, r) {
-      final key = r.peek(_valueVar)?.stringValue ?? p.displayName;
+      final key = r.peek('value')?.stringValue ?? p.displayName;
       final Expression value;
       if (_isBasicType(p.type) ||
           p.type.isDartCoreList ||
@@ -1726,7 +1726,7 @@ ${bodyName.displayName} == null
     var anyNullable = false;
     final fields = _getAnnotations(m, retrofit.Field).map((p, r) {
       anyNullable |= p.type.nullabilitySuffix == NullabilitySuffix.question;
-      final fieldName = r.peek(_valueVar)?.stringValue ?? p.displayName;
+      final fieldName = r.peek('value')?.stringValue ?? p.displayName;
       final isFileField = _typeChecker(File).isAssignableFromType(p.type);
       if (isFileField) {
         log.severe(
@@ -1768,7 +1768,7 @@ ${bodyName.displayName} == null
 
       parts.forEach((p, r) {
         final fieldName = r.peek('name')?.stringValue ??
-            r.peek(_valueVar)?.stringValue ??
+            r.peek('value')?.stringValue ??
             p.displayName;
         final isFileField = _typeChecker(File).isAssignableFromType(p.type);
         final contentType = r.peek('contentType')?.stringValue;
@@ -2018,7 +2018,7 @@ ${bodyName.displayName} == null
 
   Map<String, Expression> _generateHeaders(MethodElement m) {
     final headers = _getMethodAnnotations(m, retrofit.Headers)
-        .map((e) => e.peek(_valueVar))
+        .map((e) => e.peek('value'))
         .map(
           (value) => value?.mapValue.map(
             (k, v) {
@@ -2047,7 +2047,7 @@ ${bodyName.displayName} == null
 
     final annotationsInParam = _getAnnotations(m, retrofit.Header);
     final headersInParams = annotationsInParam.map((k, v) {
-      final value = v.peek(_valueVar)?.stringValue ?? k.displayName;
+      final value = v.peek('value')?.stringValue ?? k.displayName;
       return MapEntry(value, refer(k.displayName));
     });
     headers.addAll(headersInParams);

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -949,7 +949,7 @@ You should create a new class to encapsulate the response.
       if (isWrapped) {
         blocks.add(
           Code('''
-      final httpResponse = HttpResponse(value, $_resultVar);
+      final httpResponse = HttpResponse($_valueVar, $_resultVar);
       $returnAsyncWrapper httpResponse;
       '''),
         );

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -125,8 +125,8 @@ abstract class TestExtrasWithMap {
   @GET('/list/')
   @Extra({'key': 'value'})
   Future<void> list(
-      @Extras() Map<String, dynamic> extras,
-      );
+    @Extras() Map<String, dynamic> extras,
+  );
 }
 
 @ShouldGenerate(
@@ -140,7 +140,7 @@ abstract class TestExtrasWithMap {
 abstract class TestExtrasWithObject {
   @GET('/list/')
   Future<void> list(
-      @Extras() User u,
+    @Extras() User u,
   );
 }
 
@@ -390,8 +390,8 @@ abstract class UploadFileInfoPartTest {
 
 @ShouldGenerate(
   '''
-    final value = User.fromJson(_result.data!);
-    return value;
+    final _value = User.fromJson(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -403,8 +403,8 @@ abstract class GenericCast {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null ? null : User.fromJson(_result.data!);
-    return value;
+    final _value = _result.data == null ? null : User.fromJson(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -416,7 +416,7 @@ abstract class NullableGenericCast {
 
 @ShouldGenerate(
   '''
-    yield value;
+    yield _value;
 ''',
   contains: true,
 )
@@ -430,13 +430,13 @@ enum TestEnum { A, B }
 
 @ShouldGenerate(
   '''
-    final value = TestEnum.values.firstWhere(
+    final _value = TestEnum.values.firstWhere(
       (e) => e.name == _result.data,
       orElse: () => throw ArgumentError(
         'TestEnum does not contain value \${_result.data}',
       ),
     );
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -473,8 +473,8 @@ enum FromJsonEnum {
 
 @ShouldGenerate(
   '''
-    final value = FromJsonEnum.fromJson(_result.data!);
-    return value;
+    final _value = FromJsonEnum.fromJson(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -571,8 +571,8 @@ Map<String, dynamic> serializeUser(User object) => object.toJson();
 
 @ShouldGenerate(
   '''
-    final value = _result.data!;
-    return value;
+    final _value = _result.data!;
+    return _value;
 ''',
   contains: true,
 )
@@ -584,8 +584,8 @@ abstract class GenericCastBasicType {
 
 @ShouldGenerate(
   '''
-    final value = _result.data;
-    return value;
+    final _value = _result.data;
+    return _value;
 ''',
   contains: true,
 )
@@ -715,12 +715,12 @@ abstract class TestCustomObjectBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) => MapEntry(
+    var _value = _result.data!.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => User.fromJson(i as Map<String, dynamic>))
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -732,12 +732,12 @@ abstract class TestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map((k, dynamic v) => MapEntry(
+    var _value = _result.data?.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => User.fromJson(i as Map<String, dynamic>))
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -749,9 +749,9 @@ abstract class NullableTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) =>
+    var _value = _result.data!.map((k, dynamic v) =>
         MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -763,9 +763,9 @@ abstract class TestMapBody2 {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map((k, dynamic v) =>
+    var _value = _result.data?.map((k, dynamic v) =>
         MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -777,8 +777,8 @@ abstract class NullableTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<String>();
-    return value;
+    final _value = _result.data!.cast<String>();
+    return _value;
 ''',
   contains: true,
 )
@@ -790,8 +790,8 @@ abstract class TestBasicListString {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<String>();
-    return value;
+    final _value = _result.data?.cast<String>();
+    return _value;
 ''',
   contains: true,
 )
@@ -803,8 +803,8 @@ abstract class NullableTestBasicListString {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<bool>();
-    return value;
+    final _value = _result.data!.cast<bool>();
+    return _value;
 ''',
   contains: true,
 )
@@ -816,8 +816,8 @@ abstract class TestBasicListBool {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<bool>();
-    return value;
+    final _value = _result.data?.cast<bool>();
+    return _value;
 ''',
   contains: true,
 )
@@ -829,8 +829,8 @@ abstract class NullableTestBasicListBool {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<int>();
-    return value;
+    final _value = _result.data!.cast<int>();
+    return _value;
 ''',
   contains: true,
 )
@@ -842,8 +842,8 @@ abstract class TestBasicListInt {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<int>();
-    return value;
+    final _value = _result.data?.cast<int>();
+    return _value;
 ''',
   contains: true,
 )
@@ -855,8 +855,8 @@ abstract class NullableTestBasicListInt {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<double>();
-    return value;
+    final _value = _result.data!.cast<double>();
+    return _value;
 ''',
   contains: true,
 )
@@ -868,8 +868,8 @@ abstract class TestBasicListDouble {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<double>();
-    return value;
+    final _value = _result.data?.cast<double>();
+    return _value;
 ''',
   contains: true,
 )
@@ -956,7 +956,7 @@ abstract class TestHttpResponseVoid {
 
 @ShouldGenerate(
   '''
-    final httpResponse = HttpResponse(value, _result);
+    final httpResponse = HttpResponse(_value, _result);
 ''',
   contains: true,
 )
@@ -968,7 +968,7 @@ abstract class TestHttpResponseObject {
 
 @ShouldGenerate(
   '''
-    final httpResponse = HttpResponse(value, _result);
+    final httpResponse = HttpResponse(_value, _result);
 ''',
   contains: true,
 )
@@ -1162,8 +1162,8 @@ abstract class CustomOptions {
 
 @ShouldGenerate(
   '''
-    final value = JsonMapper.fromMap<User>(_result.data!)!;
-    return value;
+    final _value = JsonMapper.fromMap<User>(_result.data!)!;
+    return _value;
 ''',
   contains: true,
 )
@@ -1178,9 +1178,9 @@ abstract class JsonMapperGenericCast {
 
 @ShouldGenerate(
   '''
-    final value =
+    final _value =
         _result.data == null ? null : JsonMapper.fromMap<User>(_result.data!)!;
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1195,11 +1195,11 @@ abstract class NullableJsonMapperGenericCast {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!
+    var _value = _result.data!
         .map(
             (dynamic i) => JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
         .toList();
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1214,12 +1214,12 @@ abstract class JsonMapperTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) => MapEntry(
+    var _value = _result.data!.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1234,9 +1234,9 @@ abstract class JsonMapperTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) =>
+    var _value = _result.data!.map((k, dynamic v) =>
         MapEntry(k, JsonMapper.fromMap<User>(v as Map<String, dynamic>)!));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1251,8 +1251,8 @@ abstract class JsonMapperTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    final value = User.fromMap(_result.data!);
-    return value;
+    final _value = User.fromMap(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -1267,8 +1267,8 @@ abstract class MapSerializableGenericCast {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null ? null : User.fromMap(_result.data!);
-    return value;
+    final _value = _result.data == null ? null : User.fromMap(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -1283,10 +1283,10 @@ abstract class NullableMapSerializableGenericCast {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!
+    var _value = _result.data!
         .map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
         .toList();
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1301,10 +1301,10 @@ abstract class MapSerializableTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data
+    var _value = _result.data
         ?.map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
         .toList();
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1319,12 +1319,12 @@ abstract class NullableMapSerializableTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) => MapEntry(
+    var _value = _result.data!.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => User.fromMap(i as Map<String, dynamic>))
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1339,12 +1339,12 @@ abstract class MapSerializableTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map((k, dynamic v) => MapEntry(
+    var _value = _result.data?.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => User.fromMap(i as Map<String, dynamic>))
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1359,9 +1359,9 @@ abstract class NullableMapSerializableTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map(
+    var _value = _result.data!.map(
         (k, dynamic v) => MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1376,9 +1376,9 @@ abstract class MapSerializableTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map(
+    var _value = _result.data?.map(
         (k, dynamic v) => MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1393,8 +1393,8 @@ abstract class NullableMapSerializableTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    final value = await compute(deserializeUser, _result.data!);
-    return value;
+    final _value = await compute(deserializeUser, _result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -1409,10 +1409,10 @@ abstract class ComputeGenericCast {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : await compute(deserializeUser, _result.data!);
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1427,11 +1427,11 @@ abstract class NullableComputeGenericCast {
 
 @ShouldGenerate(
   '''
-    var value = await compute(
+    var _value = await compute(
       deserializeUserList,
       _result.data!.cast<Map<String, dynamic>>(),
     );
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1446,13 +1446,13 @@ abstract class ComputeTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data == null
+    var _value = _result.data == null
         ? null
         : await compute(
             deserializeUserList,
             _result.data!.cast<Map<String, dynamic>>(),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1467,12 +1467,12 @@ abstract class NullableComputeTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
+    var _value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
         (e) async => MapEntry(
             e.key,
             await compute(deserializeUserList,
                 (e.value as List).cast<Map<String, dynamic>>())))));
-    return value;
+    return _value;
 ''',
   contains: true,
   expectedLogItems: [
@@ -1493,12 +1493,12 @@ abstract class ComputeTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
+    var _value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
         (e) async => MapEntry(
             e.key,
             await compute(deserializeUserList,
                 (e.value as List).cast<Map<String, dynamic>>())))));
-    return value;
+    return _value;
 ''',
   contains: true,
   expectedLogItems: [
@@ -1519,10 +1519,10 @@ abstract class NullableComputeTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
+    var _value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
         (e) async => MapEntry(e.key,
             await compute(deserializeUser, e.value as Map<String, dynamic>)))));
-    return value;
+    return _value;
 ''',
   contains: true,
   expectedLogItems: [
@@ -1543,14 +1543,14 @@ abstract class ComputeTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    var value = _result.data == null
+    var _value = _result.data == null
         ? null
         : Map.fromEntries(await Future.wait(_result.data!.entries.map(
             (e) async => MapEntry(
                 e.key,
                 await compute(
                     deserializeUser, e.value as Map<String, dynamic>)))));
-    return value;
+    return _value;
 ''',
   contains: true,
   expectedLogItems: [
@@ -1701,11 +1701,11 @@ abstract class ListBodyShouldNotBeCleanTest {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<dynamic>.fromJson(
+    final _value = GenericUser<dynamic>.fromJson(
       _result.data!,
       (json) => json as dynamic,
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1717,7 +1717,7 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsDynamic {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<List<User>>.fromJson(
+    final _value = GenericUser<List<User>>.fromJson(
       _result.data!,
       (json) => json is List<dynamic>
           ? json
@@ -1725,7 +1725,7 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsDynamic {
               .toList()
           : List.empty(),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1737,7 +1737,7 @@ abstract class DynamicInnerListGenericTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUser<List<User>>.fromJson(
             _result.data!,
@@ -1747,7 +1747,7 @@ abstract class DynamicInnerListGenericTypeShouldBeCastedRecursively {
                     .toList()
                 : List.empty(),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1759,11 +1759,11 @@ abstract class NullableDynamicInnerListGenericTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<User>.fromJson(
+    final _value = GenericUser<User>.fromJson(
       _result.data!,
       (json) => User.fromJson(json as Map<String, dynamic>),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1775,14 +1775,14 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<GenericUser<User>>.fromJson(
+    final _value = GenericUser<GenericUser<User>>.fromJson(
       _result.data!,
       (json) => GenericUser<User>.fromJson(
         json as Map<String, dynamic>,
         (json) => User.fromJson(json as Map<String, dynamic>),
       ),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1794,13 +1794,13 @@ abstract class NestGenericTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUser<User>.fromJson(
             _result.data!,
             (json) => User.fromJson(json as Map<String, dynamic>),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1812,12 +1812,12 @@ abstract class NullableDynamicInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<User?>.fromJson(
+    final _value = GenericUser<User?>.fromJson(
       _result.data!,
       (json) =>
           json == null ? null : User.fromJson(json as Map<String, dynamic>),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1829,7 +1829,7 @@ abstract class DynamicNullableInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUser<User?>.fromJson(
             _result.data!,
@@ -1837,7 +1837,7 @@ abstract class DynamicNullableInnerGenericTypeShouldBeCastedAsMap {
                 ? null
                 : User.fromJson(json as Map<String, dynamic>),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1849,13 +1849,13 @@ abstract class NullableDynamicNullableInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<List<double>>.fromJson(
+    final _value = GenericUser<List<double>>.fromJson(
       _result.data!,
       (json) => json is List<dynamic>
           ? json.map<double>((i) => i as double).toList()
           : List.empty(),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1867,7 +1867,7 @@ abstract class DynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUser<List<double>>.fromJson(
             _result.data!,
@@ -1875,7 +1875,7 @@ abstract class DynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursively {
                 ? json.map<double>((i) => i as double).toList()
                 : List.empty(),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1887,9 +1887,9 @@ abstract class NullableDynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursi
 
 @ShouldGenerate(
   '''
-    final value = GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
+    final _value = GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
         _result.data!);
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1901,11 +1901,11 @@ abstract class DynamicInnerGenericTypeShouldBeWithoutGenericArgumentType {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
             _result.data!);
-    return value;
+    return _value;
   ''',
   contains: true,
 )

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -346,8 +346,8 @@ abstract class UploadFileInfoPartTest {
 
 @ShouldGenerate(
   '''
-    final value = User.fromJson(_result.data!);
-    return value;
+    final _value = User.fromJson(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -359,8 +359,8 @@ abstract class GenericCast {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null ? null : User.fromJson(_result.data!);
-    return value;
+    final _value = _result.data == null ? null : User.fromJson(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -372,7 +372,7 @@ abstract class NullableGenericCast {
 
 @ShouldGenerate(
   '''
-    yield value;
+    yield _value;
 ''',
   contains: true,
 )
@@ -386,13 +386,13 @@ enum TestEnum { A, B }
 
 @ShouldGenerate(
   '''
-    final value = TestEnum.values.firstWhere(
+    final _value = TestEnum.values.firstWhere(
       (e) => e.name == _result.data,
       orElse: () => throw ArgumentError(
         'TestEnum does not contain value \${_result.data}',
       ),
     );
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -429,8 +429,8 @@ enum FromJsonEnum {
 
 @ShouldGenerate(
   '''
-    final value = FromJsonEnum.fromJson(_result.data!);
-    return value;
+    final _value = FromJsonEnum.fromJson(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -527,8 +527,8 @@ Map<String, dynamic> serializeUser(User object) => object.toJson();
 
 @ShouldGenerate(
   '''
-    final value = _result.data!;
-    return value;
+    final _value = _result.data!;
+    return _value;
 ''',
   contains: true,
 )
@@ -540,8 +540,8 @@ abstract class GenericCastBasicType {
 
 @ShouldGenerate(
   '''
-    final value = _result.data;
-    return value;
+    final _value = _result.data;
+    return _value;
 ''',
   contains: true,
 )
@@ -671,12 +671,12 @@ abstract class TestCustomObjectBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) => MapEntry(
+    var _value = _result.data!.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => User.fromJson(i as Map<String, dynamic>))
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -688,12 +688,12 @@ abstract class TestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map((k, dynamic v) => MapEntry(
+    var _value = _result.data?.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => User.fromJson(i as Map<String, dynamic>))
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -705,9 +705,9 @@ abstract class NullableTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) =>
+    var _value = _result.data!.map((k, dynamic v) =>
         MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -719,9 +719,9 @@ abstract class TestMapBody2 {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map((k, dynamic v) =>
+    var _value = _result.data?.map((k, dynamic v) =>
         MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -733,8 +733,8 @@ abstract class NullableTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<String>();
-    return value;
+    final _value = _result.data!.cast<String>();
+    return _value;
 ''',
   contains: true,
 )
@@ -746,8 +746,8 @@ abstract class TestBasicListString {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<String>();
-    return value;
+    final _value = _result.data?.cast<String>();
+    return _value;
 ''',
   contains: true,
 )
@@ -759,8 +759,8 @@ abstract class NullableTestBasicListString {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<bool>();
-    return value;
+    final _value = _result.data!.cast<bool>();
+    return _value;
 ''',
   contains: true,
 )
@@ -772,8 +772,8 @@ abstract class TestBasicListBool {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<bool>();
-    return value;
+    final _value = _result.data?.cast<bool>();
+    return _value;
 ''',
   contains: true,
 )
@@ -785,8 +785,8 @@ abstract class NullableTestBasicListBool {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<int>();
-    return value;
+    final _value = _result.data!.cast<int>();
+    return _value;
 ''',
   contains: true,
 )
@@ -798,8 +798,8 @@ abstract class TestBasicListInt {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<int>();
-    return value;
+    final _value = _result.data?.cast<int>();
+    return _value;
 ''',
   contains: true,
 )
@@ -811,8 +811,8 @@ abstract class NullableTestBasicListInt {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<double>();
-    return value;
+    final _value = _result.data!.cast<double>();
+    return _value;
 ''',
   contains: true,
 )
@@ -824,8 +824,8 @@ abstract class TestBasicListDouble {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<double>();
-    return value;
+    final _value = _result.data?.cast<double>();
+    return _value;
 ''',
   contains: true,
 )
@@ -912,7 +912,7 @@ abstract class TestHttpResponseVoid {
 
 @ShouldGenerate(
   '''
-    final httpResponse = HttpResponse(value, _result);
+    final httpResponse = HttpResponse(_value, _result);
 ''',
   contains: true,
 )
@@ -924,7 +924,7 @@ abstract class TestHttpResponseObject {
 
 @ShouldGenerate(
   '''
-    final httpResponse = HttpResponse(value, _result);
+    final httpResponse = HttpResponse(_value, _result);
 ''',
   contains: true,
 )
@@ -1118,8 +1118,8 @@ abstract class CustomOptions {
 
 @ShouldGenerate(
   '''
-    final value = JsonMapper.fromMap<User>(_result.data!)!;
-    return value;
+    final _value = JsonMapper.fromMap<User>(_result.data!)!;
+    return _value;
 ''',
   contains: true,
 )
@@ -1134,9 +1134,9 @@ abstract class JsonMapperGenericCast {
 
 @ShouldGenerate(
   '''
-    final value =
+    final _value =
         _result.data == null ? null : JsonMapper.fromMap<User>(_result.data!)!;
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1151,11 +1151,11 @@ abstract class NullableJsonMapperGenericCast {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!
+    var _value = _result.data!
         .map(
             (dynamic i) => JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
         .toList();
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1170,12 +1170,12 @@ abstract class JsonMapperTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) => MapEntry(
+    var _value = _result.data!.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1190,9 +1190,9 @@ abstract class JsonMapperTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) =>
+    var _value = _result.data!.map((k, dynamic v) =>
         MapEntry(k, JsonMapper.fromMap<User>(v as Map<String, dynamic>)!));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1207,8 +1207,8 @@ abstract class JsonMapperTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    final value = User.fromMap(_result.data!);
-    return value;
+    final _value = User.fromMap(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -1223,8 +1223,8 @@ abstract class MapSerializableGenericCast {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null ? null : User.fromMap(_result.data!);
-    return value;
+    final _value = _result.data == null ? null : User.fromMap(_result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -1239,10 +1239,10 @@ abstract class NullableMapSerializableGenericCast {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!
+    var _value = _result.data!
         .map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
         .toList();
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1257,10 +1257,10 @@ abstract class MapSerializableTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data
+    var _value = _result.data
         ?.map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
         .toList();
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1275,12 +1275,12 @@ abstract class NullableMapSerializableTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) => MapEntry(
+    var _value = _result.data!.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => User.fromMap(i as Map<String, dynamic>))
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1295,12 +1295,12 @@ abstract class MapSerializableTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map((k, dynamic v) => MapEntry(
+    var _value = _result.data?.map((k, dynamic v) => MapEntry(
         k,
         (v as List)
             .map((i) => User.fromMap(i as Map<String, dynamic>))
             .toList()));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1315,9 +1315,9 @@ abstract class NullableMapSerializableTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map(
+    var _value = _result.data!.map(
         (k, dynamic v) => MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1332,9 +1332,9 @@ abstract class MapSerializableTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map(
+    var _value = _result.data?.map(
         (k, dynamic v) => MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1349,8 +1349,8 @@ abstract class NullableMapSerializableTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    final value = await compute(deserializeUser, _result.data!);
-    return value;
+    final _value = await compute(deserializeUser, _result.data!);
+    return _value;
 ''',
   contains: true,
 )
@@ -1365,10 +1365,10 @@ abstract class ComputeGenericCast {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : await compute(deserializeUser, _result.data!);
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1383,11 +1383,11 @@ abstract class NullableComputeGenericCast {
 
 @ShouldGenerate(
   '''
-    var value = await compute(
+    var _value = await compute(
       deserializeUserList,
       _result.data!.cast<Map<String, dynamic>>(),
     );
-    return value;
+    return _value;
 ''',
   contains: true,
 )
@@ -1402,13 +1402,13 @@ abstract class ComputeTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data == null
+    var _value = _result.data == null
         ? null
         : await compute(
             deserializeUserList,
             _result.data!.cast<Map<String, dynamic>>(),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1423,12 +1423,12 @@ abstract class NullableComputeTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
+    var _value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
         (e) async => MapEntry(
             e.key,
             await compute(deserializeUserList,
                 (e.value as List).cast<Map<String, dynamic>>())))));
-    return value;
+    return _value;
 ''',
   contains: true,
   expectedLogItems: [
@@ -1449,12 +1449,12 @@ abstract class ComputeTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
+    var _value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
         (e) async => MapEntry(
             e.key,
             await compute(deserializeUserList,
                 (e.value as List).cast<Map<String, dynamic>>())))));
-    return value;
+    return _value;
 ''',
   contains: true,
   expectedLogItems: [
@@ -1475,10 +1475,10 @@ abstract class NullableComputeTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
+    var _value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
         (e) async => MapEntry(e.key,
             await compute(deserializeUser, e.value as Map<String, dynamic>)))));
-    return value;
+    return _value;
 ''',
   contains: true,
   expectedLogItems: [
@@ -1499,14 +1499,14 @@ abstract class ComputeTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    var value = _result.data == null
+    var _value = _result.data == null
         ? null
         : Map.fromEntries(await Future.wait(_result.data!.entries.map(
             (e) async => MapEntry(
                 e.key,
                 await compute(
                     deserializeUser, e.value as Map<String, dynamic>)))));
-    return value;
+    return _value;
 ''',
   contains: true,
   expectedLogItems: [
@@ -1657,11 +1657,11 @@ abstract class ListBodyShouldNotBeCleanTest {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<dynamic>.fromJson(
+    final _value = GenericUser<dynamic>.fromJson(
       _result.data!,
       (json) => json as dynamic,
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1673,7 +1673,7 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsDynamic {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<List<User>>.fromJson(
+    final _value = GenericUser<List<User>>.fromJson(
       _result.data!,
       (json) => json is List<dynamic>
           ? json
@@ -1681,7 +1681,7 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsDynamic {
               .toList()
           : List.empty(),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1693,7 +1693,7 @@ abstract class DynamicInnerListGenericTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUser<List<User>>.fromJson(
             _result.data!,
@@ -1703,7 +1703,7 @@ abstract class DynamicInnerListGenericTypeShouldBeCastedRecursively {
                     .toList()
                 : List.empty(),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1715,11 +1715,11 @@ abstract class NullableDynamicInnerListGenericTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<User>.fromJson(
+    final _value = GenericUser<User>.fromJson(
       _result.data!,
       (json) => User.fromJson(json as Map<String, dynamic>),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1731,14 +1731,14 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<GenericUser<User>>.fromJson(
+    final _value = GenericUser<GenericUser<User>>.fromJson(
       _result.data!,
       (json) => GenericUser<User>.fromJson(
         json as Map<String, dynamic>,
         (json) => User.fromJson(json as Map<String, dynamic>),
       ),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1750,13 +1750,13 @@ abstract class NestGenericTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUser<User>.fromJson(
             _result.data!,
             (json) => User.fromJson(json as Map<String, dynamic>),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1768,12 +1768,12 @@ abstract class NullableDynamicInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<User?>.fromJson(
+    final _value = GenericUser<User?>.fromJson(
       _result.data!,
       (json) =>
           json == null ? null : User.fromJson(json as Map<String, dynamic>),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1785,7 +1785,7 @@ abstract class DynamicNullableInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUser<User?>.fromJson(
             _result.data!,
@@ -1793,7 +1793,7 @@ abstract class DynamicNullableInnerGenericTypeShouldBeCastedAsMap {
                 ? null
                 : User.fromJson(json as Map<String, dynamic>),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1805,13 +1805,13 @@ abstract class NullableDynamicNullableInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<List<double>>.fromJson(
+    final _value = GenericUser<List<double>>.fromJson(
       _result.data!,
       (json) => json is List<dynamic>
           ? json.map<double>((i) => i as double).toList()
           : List.empty(),
     );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1823,7 +1823,7 @@ abstract class DynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUser<List<double>>.fromJson(
             _result.data!,
@@ -1831,7 +1831,7 @@ abstract class DynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursively {
                 ? json.map<double>((i) => i as double).toList()
                 : List.empty(),
           );
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1843,9 +1843,9 @@ abstract class NullableDynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursi
 
 @ShouldGenerate(
   '''
-    final value = GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
+    final _value = GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
         _result.data!);
-    return value;
+    return _value;
   ''',
   contains: true,
 )
@@ -1857,11 +1857,11 @@ abstract class DynamicInnerGenericTypeShouldBeWithoutGenericArgumentType {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
+    final _value = _result.data == null
         ? null
         : GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
             _result.data!);
-    return value;
+    return _value;
   ''',
   contains: true,
 )


### PR DESCRIPTION
Currently it is not possible to have a parameter named `value` in methods annotated with `@GET/POST/PUT...`

I'm in the complex process of setting up retrofit.dart to generate an API Client from an OpenAPI specification file, which itself is generated by [api-platform](https://github.com/api-platform/api-platform), the boilerplate code of which is also generated. (by a custom built code-generator based on [php-generator](https://github.com/nette/php-generator))

To make a long story shorter, this means that the method parameters in my RestClient have identifiers based on the column names of the underlying database. Here is an example of such a method : 
```dart
  /// Updates the ExampleEndpoint resource.
  @PATCH('/api/example_endpoint/{idExampleEndpoint}')
  Future<ExampleEndpoint> exampleEndpointPatch(
    @Path() String idExampleEndpoint, {
    @Field('idClient') int? idClient,
    @Field('value') String? value,
    @Field('description') String? description,
    @Field('createdAt') String? createdAt,
    @Field('updatedAt') String? updatedAt,
    @Field('deletedAt') String? deletedAt,
    @Field('client') String? client,
  });
```

The lack of control I have on the identifiers causes this of course. I could rename the parameter since I have an `@Field()` annotation anyway, but I want to limit the chance of runtime errors and special cases in my generation code. This happens mostly in PATCH methods, but also affects some filters for GET methods. Here's the generated code for this specific method : 
```dart
  @override
  Future<ExampleEndpoint> exampleEndpointPatch(
    String idExampleEndpoint, {
    int? idClient,
    String? value,
    String? description,
    String? createdAt,
    String? updatedAt,
    String? deletedAt,
    String? client,
  }) async {
    const _extra = <String, dynamic>{};
    final queryParameters = <String, dynamic>{};
    queryParameters.removeWhere((k, v) => v == null);
    final _headers = <String, dynamic>{};
    final _data = {
      'idClient': idClient,
      'value': value,
      'description': description,
      'createdAt': createdAt,
      'updatedAt': updatedAt,
      'deletedAt': deletedAt,
      'client': client,
    };
    _data.removeWhere((k, v) => v == null);
    final _result = await _dio
        .fetch<Map<String, dynamic>>(_setStreamType<ExampleEndpoint>(Options(
      method: 'PATCH',
      headers: _headers,
      extra: _extra,
    )
            .compose(
              _dio.options,
              '/api/example_endpoint/${idExampleEndpoint}',
              queryParameters: queryParameters,
              data: _data,
            )
            .copyWith(
                baseUrl: _combineBaseUrls(
              _dio.options.baseUrl,
              baseUrl,
            ))));
    final value = ExampleEndpoint.fromJson(_result.data!);
    return value;
  }
```

Which results in the `value` parameter clashing with the `final value` declaration.

I'm not yet super familiar with retrofit.dart, so this might not be ideal, but changing the value of `_valueVar` from `'value'` to `'_value'` in `generator/lib/src/generator.dart` seems to solve the issue for me, and would allow to use `value` as an identifier for method parameters in the package user's `RestClient` class.

It also seems to me like the current value of `_valueVar`, `'value'`, is hard-coded in some places, and should be using `_valueVar` or `$_valueVar` to lessen the risk of bugs in the generated code in case of edits. Again, I'm not quite familiar with the code, so I'd appreciate a look-over make sure the edits I've made are indeed correct.

Additionally, the local `queryParameter` variable in the generated code suffers from this as well. I haven't modified it in this branch yet, but I could if deemed necessary.