### PR TITLE
feat: Add support @Extras()

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 8.1.0
+
+- Added `@Extras` to pass extra options to dio requests, response, transformer and interceptors.
+
+  Example :
+  ```dart
+  @http.POST('/path/')
+  Future<String> myMethod(@Extras() Map<String, dynamic> extras);
+  ```
+
 ## 8.0.6
 
 - @useResult

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -17,8 +17,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit:
-    path: ../retrofit
+  retrofit: ^4.1.0
   source_gen: ^1.3.0
   tuple: ^2.0.1
   protobuf: ^3.1.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -6,7 +6,7 @@ topics:
   - build-runner
   - codegen
   - api
-version: 8.0.3
+version: 8.1.0
 environment:
   sdk: '>=2.19.0 <4.0.0'
 
@@ -17,7 +17,8 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit: ^4.1.0
+  retrofit:
+    path: ../retrofit
   source_gen: ^1.3.0
   tuple: ^2.0.1
   protobuf: ^3.1.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit: ^4.0.2
+  retrofit: ^4.1.0
   source_gen: ^1.3.0
   tuple: ^2.0.1
   protobuf: ^3.1.0

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -46,7 +46,7 @@ abstract class BaseUrl {}
 
 @ShouldGenerate(
   '''
-    const _extra = <String, dynamic>{};
+    final _extra = <String, dynamic>{};
 ''',
   contains: true,
 )
@@ -59,7 +59,7 @@ abstract class EmptyExtras {
 
 @ShouldGenerate(
   '''
-    const _extra = <String, dynamic>{'key': 'value'};
+    final _extra = <String, dynamic>{'key': 'value'};
   ''',
   contains: true,
 )
@@ -72,7 +72,7 @@ abstract class ExtrasWithPrimitiveValues {
 
 @ShouldGenerate(
   '''
-    const _extra = <String, dynamic>{
+    final _extra = <String, dynamic>{
       'key': 'value',
       'key2': 'value2',
     };
@@ -89,7 +89,7 @@ abstract class MultipleExtrasWithPrimitiveValues {
 
 @ShouldGenerate(
   '''
-    const _extra = <String, dynamic>{'key': CustomConstant()};
+    final _extra = <String, dynamic>{'key': CustomConstant()};
 ''',
   contains: true,
 )
@@ -98,6 +98,50 @@ abstract class ExtrasWithCustomConstant {
   @GET('/list/')
   @Extra({'key': CustomConstant()})
   Future<void> list();
+}
+
+@ShouldGenerate(
+  '''
+    final _extra = <String, dynamic>{};
+    _extra.addAll(extras ?? <String, dynamic>{});
+''',
+  contains: true,
+)
+@RestApi()
+abstract class TestExtrasWithNullable {
+  @GET('/list/')
+  Future<void> list(@Extras() Map<String, dynamic>? extras);
+}
+
+@ShouldGenerate(
+  '''
+    final _extra = <String, dynamic>{'key': 'value'};
+    _extra.addAll(extras);
+  ''',
+  contains: true,
+)
+@RestApi()
+abstract class TestExtrasWithMap {
+  @GET('/list/')
+  @Extra({'key': 'value'})
+  Future<void> list(
+      @Extras() Map<String, dynamic> extras,
+      );
+}
+
+@ShouldGenerate(
+  '''
+    final _extra = <String, dynamic>{};
+    _extra.addAll(u.toJson());
+  ''',
+  contains: true,
+)
+@RestApi()
+abstract class TestExtrasWithObject {
+  @GET('/list/')
+  Future<void> list(
+      @Extras() User u,
+  );
 }
 
 class CustomConstant {

--- a/retrofit/CHANGELOG.md
+++ b/retrofit/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.1.0
+
+- Added `@Extras` to pass extra options to dio requests, response, transformer and interceptors.
+
+  Example :
+
+  ```dart
+  @http.POST('/path/')
+  Future<String> myMethod(@Extras() Map<String, dynamic> extras);
+  ```
+
 ## 4.0.0
 
 - Update dio to ^5.0.0

--- a/retrofit/lib/dio.dart
+++ b/retrofit/lib/dio.dart
@@ -10,6 +10,18 @@ class Extra {
   const Extra(this.data);
 }
 
+/// Extra data that will be passed to dio's request, response, transformer and interceptors.
+/// Simple Example:
+///
+///```
+/// @GET("/get")
+/// Future<String> foo(@Extras() Map<String, dynamic> extras)
+///```
+@immutable
+class Extras {
+  const Extras();
+}
+
 @immutable
 class CancelRequest {
   const CancelRequest();

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -2,7 +2,7 @@ name: retrofit
 description: retrofit.dart is an dio client generator using source_gen and inspired by Chopper and Retrofit.
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
-version: 4.0.2
+version: 4.1.0
 
 environment:
   sdk: '>=2.17.0 <4.0.0'


### PR DESCRIPTION
Add @Extras() to pass extra options to dio interceptors for each request as parameters.
The code is mostly copy-pasted from the @Queries implementation.
Fix https://github.com/trevorwang/retrofit.dart/issues/445

Usage is the same as @Queries

```
   @GET("/get")
   Future<String> foo(@Extras() Map<String, dynamic> extras)
```