### PR TITLE
For constant null, declareFinal is replaced by declareConst

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2052,7 +2052,7 @@ ${bodyName.displayName} == null
       );
     } else {
       blocks.add(
-        declareFinal(dataVar, type: refer('Map<String, dynamic>?'))
+        declareConst(dataVar, type: refer('Map<String, dynamic>?'))
             .assign(literalNull)
             .statement,
       );


### PR DESCRIPTION
Use 'const' for final variables initialized to a constant value. Try replacing 'final' with 'const'. #652