### PR TITLE
Use the available content type part annotation field for objects

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2020,16 +2020,55 @@ ${bodyName.displayName} == null
           if (_missingToJson(ele)) {
             throw Exception('toJson() method have to add to ${p.type}');
           } else {
-            blocks.add(
-              refer(dataVar).property('fields').property('add').call([
-                refer('MapEntry').newInstance([
-                  literal(fieldName),
-                  refer(
-                    "jsonEncode(${p.displayName}${p.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''})",
-                  )
-                ])
-              ]).statement,
-            );
+            if (contentType != null) {
+              final uploadFileInfo = refer('$MultipartFile.fromString').call([
+                refer(
+                  "jsonEncode(${p.displayName}${p.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''})",
+                )
+              ], {
+                'contentType':
+                    refer('MediaType', 'package:http_parser/http_parser.dart')
+                        .property('parse')
+                        .call([literal(contentType)])
+              });
+
+              final optionalFile = m.parameters
+                      .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+                      ?.isOptional ??
+                  false;
+
+              final returnCode =
+                  refer(dataVar).property('files').property('add').call([
+                refer('MapEntry')
+                    .newInstance([literal(fieldName), uploadFileInfo])
+              ]).statement;
+              if (optionalFile) {
+                final condition =
+                    refer(p.displayName).notEqualTo(literalNull).code;
+                blocks.addAll(
+                  [
+                    const Code('if('),
+                    condition,
+                    const Code(') {'),
+                    returnCode,
+                    const Code('}')
+                  ],
+                );
+              } else {
+                blocks.add(returnCode);
+              }
+            } else {
+              blocks.add(
+                refer(dataVar).property('fields').property('add').call([
+                  refer('MapEntry').newInstance([
+                    literal(fieldName),
+                    refer(
+                      "jsonEncode(${p.displayName}${p.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''})",
+                    )
+                  ])
+                ]).statement,
+              );
+            }
           }
         } else {
           blocks.add(


### PR DESCRIPTION
Hello,
This is my first contribution to retrofit or any other dart open-source project so sorry for any inconvenience.

In my use case we are sending several different content-types in multipart request. So the use of the content-type header for each part is very important. 
The way I got around this so far is  using `List<MultipartFile>` and building out my own objects with content type as that seems to have worked.
I thought others might find this useful so I tweaked the generator a bit. 
When content type is present instead of serializing into a simple map entry I create a MultipartFile from string and add the content-type.
This is just a PR to gauge the possibility of this being merged. I know I still have to handle the other types.

I await your input.