### PR TITLE
Unused baseUrl parameter warning fix

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -16,7 +16,7 @@ import 'package:source_gen/source_gen.dart';
 import 'package:tuple/tuple.dart';
 
 const _analyzerIgnores =
-    '// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers';
+    '// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element';
 
 class RetrofitOptions {
   RetrofitOptions({


### PR DESCRIPTION
#676 I am passing baseUrl through `@RestApi`, it is showing a warning that I am not using the baseUrl parameter from the Auto-generated(g.dart) file

With the following comment, this issue can be resolved 
`// ignore_for_file: unused_element`

Output after change:
```// GENERATED CODE - DO NOT MODIFY BY HAND

part of 'api_service.dart';

// **************************************************************************
// RetrofitGenerator
// **************************************************************************

// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element

class _ApiService implements ApiService {
  _ApiService(
    this._dio, {
    this.baseUrl,
  }) {
    baseUrl ??= 'https://fakestoreapi.com';
  }
```