### PR TITLE
fix: Add Missing Mapping of DateTime in Multipart

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1974,7 +1974,20 @@ ${bodyName.displayName} == null
           } else if (innerType?.element is ClassElement) {
             final ele = innerType!.element! as ClassElement;
             if (_missingToJson(ele)) {
-              throw Exception('toJson() method have to add to ${p.type}');
+              if (_isDateTime(p.type)) {
+                final expr = [
+                  p.type.nullabilitySuffix == NullabilitySuffix.question
+                      ? refer(p.displayName)
+                          .nullSafeProperty('toIso8601String')
+                          .call([])
+                      : refer(p.displayName)
+                          .property('toIso8601String')
+                          .call([])
+                ];
+                refer(dataVar).property('fields').property('add').call(expr);
+              } else {
+                throw Exception('toJson() method have to add to ${p.type}');
+              }
             } else {
               blocks.add(
                 refer(dataVar).property('fields').property('add').call([
@@ -2018,7 +2031,18 @@ ${bodyName.displayName} == null
         } else if (p.type.element is ClassElement) {
           final ele = p.type.element! as ClassElement;
           if (_missingToJson(ele)) {
-            throw Exception('toJson() method have to add to ${p.type}');
+            if (_isDateTime(p.type)) {
+              final expr = [
+                p.type.nullabilitySuffix == NullabilitySuffix.question
+                    ? refer(p.displayName)
+                        .nullSafeProperty('toIso8601String')
+                        .call([])
+                    : refer(p.displayName).property('toIso8601String').call([])
+              ];
+              refer(dataVar).property('fields').property('add').call(expr);
+            } else {
+              throw Exception('toJson() method have to add to ${p.type}');
+            }
           } else {
             blocks.add(
               refer(dataVar).property('fields').property('add').call([


### PR DESCRIPTION
## Problem

If we have a request like this:
```dart
  @MultiPart()
  @POST('/api/some/path/')
  Future<SomeResponse> requestName({
    @Part(name: 'full_name') required String fullName,
    @Part(name: 'birth_date') required DateTime birthDate,
```
we'll get a `toJson() method have to add to DateTime` Exception.

## Solution

If part param doesn't have the `toJson()` method, we have to check whether this is DateTime. If so, we use a`toIso8601String` method.
