### PR TITLE
fix(UploadFile): Improve File Opening Performance During Upload

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1627,12 +1627,10 @@ if (T != dynamic &&
         blocks.add(
           declareFinal(dataVar)
               .assign(
-                refer('Stream').property('fromIterable').call([
-                  refer(
-                    '${bodyName.displayName}.readAsBytesSync().map((i)=>[i])',
-                  )
-                ]),
-              )
+            refer(
+              '${bodyName.displayName}.openRead()',
+            ),
+          )
               .statement,
         );
       } else if (bodyName.type.element is ClassElement) {

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1627,9 +1627,9 @@ if (T != dynamic &&
         blocks.add(
           declareFinal(dataVar)
               .assign(
-            refer(
-              '${bodyName.displayName}.openRead()',
-            ),
+                refer(
+                  '${bodyName.displayName}.openRead()',
+                ),
           )
               .statement,
         );


### PR DESCRIPTION
# Context
During file upload, I noticed an abnormally long processing and opening time. This PR introduces a modification to improve the performance of file opening before the upload.

# Changes Made
Replaced the existing file opening method with a more efficient method.

# Test Details
I conducted tests by uploading a 2MB file. Here are the comparative results:

## Existing Code:
```dart
final _data = Stream.fromIterable(gpxFile.readAsBytesSync().map((i) => [i]));
```
File opening and processing time: between 1min30s to 2 minutes

## Modified Code:
```dart
final _data = gpx.openRead();
```
File opening and processing time: < 5 seconds

# How to Test
- Use the application to upload a test file, ideally 1MB or larger.
- Note the processing and opening times before and after applying the modifications.

# Notes
- This modification should significantly improve performance for large files
- No changes to the API are necessary
- If you have any suggestions or questions regarding this modification, please let me know