### PR TITLE
feat(generator): Add ParseErrorLogger

### DIFF
--- a/example/lib/auth_client.dart
+++ b/example/lib/auth_client.dart
@@ -5,7 +5,7 @@ part 'auth_client.g.dart';
 
 @RestApi()
 abstract class AuthClient {
-  factory AuthClient(Dio dio, {String? baseUrl}) = RestClientYmlp;
+  factory AuthClient(Dio dio, {String? baseUrl, ParseErrorLogger errorLogger}) = RestClientYmlp;
 
   @POST('/api/auth/mqttClient/authentication')
   Future<Object?> authenticationUsingPost({

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -11,7 +11,7 @@ part 'example.g.dart';
 
 @RestApi(baseUrl: 'https://5d42a6e2bc64f90014a56ca0.mockapi.io/api/v1/')
 abstract class RestClient {
-  factory RestClient(Dio dio, {String baseUrl}) = RestClientYmlp;
+  factory RestClient(Dio dio, {String baseUrl, ParseErrorLogger errorLogger}) = RestClientYmlp;
 
   @GET('/tasks/{id}')
   Future<ApiResult<Task?>> getNestApiResultGenericsInnerTypeNullable();

--- a/example_dartmapper/lib/example.dart
+++ b/example_dartmapper/lib/example.dart
@@ -10,7 +10,7 @@ part 'example.g.dart';
 
 @RestApi(baseUrl: "https://5d42a6e2bc64f90014a56ca0.mockapi.io/api/v1/")
 abstract class RestClient {
-  factory RestClient(Dio dio, {String baseUrl}) = _RestClient;
+  factory RestClient(Dio dio, {String baseUrl, ParseErrorLogger errorLogger}) = _RestClient;
 
   @GET("/tags")
   Future<List<String>> getTags();

--- a/example_dartmapper/lib/json_mapper_example.dart
+++ b/example_dartmapper/lib/json_mapper_example.dart
@@ -10,7 +10,7 @@ part 'json_mapper_example.g.dart';
   parser: Parser.DartJsonMapper,
 )
 abstract class ApiService {
-  factory ApiService(Dio dio, {String baseUrl}) = _ApiService;
+  factory ApiService(Dio dio, {String baseUrl, ParseErrorLogger errorLogger}) = _ApiService;
 
   @GET("/tasks")
   Future<List<Task>> getTasks(@Query("dateTime") DateTime dateTime);

--- a/example_protobuf/lib/example.dart
+++ b/example_protobuf/lib/example.dart
@@ -9,7 +9,7 @@ part 'example.g.dart';
 
 @RestApi(baseUrl: "https://5d42a6e2bc64f90014a56ca0.mockapi.io/api/v1/")
 abstract class RestClient {
-  factory RestClient(Dio dio, {String baseUrl}) = _RestClient;
+  factory RestClient(Dio dio, {String baseUrl, ParseErrorLogger errorLogger}) = _RestClient;
 
   @POST("/tags")
   Future<Result> getProtoBufInt(@Body() Params message);

--- a/example_relative_base_url/lib/example.dart
+++ b/example_relative_base_url/lib/example.dart
@@ -11,7 +11,7 @@ part 'example.g.dart';
 
 @RestApi(baseUrl: 'tasks')
 abstract class TasksRestClient {
-  factory TasksRestClient(Dio dio, {String baseUrl}) = _TasksRestClient;
+  factory TasksRestClient(Dio dio, {String baseUrl, ParseErrorLogger errorLogger}) = _TasksRestClient;
 
   @GET('/tasks/{id}')
   Future<List<Task?>> getTaskById();

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -51,7 +51,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   static const String _baseUrlVar = 'baseUrl';
   static const String _errorLoggerVar = 'errorLogger';
   static const _queryParamsVar = 'queryParameters';
-  static const _optionsVar = 'options';
+  static const _optionsVar = '_options';
   static const _localHeadersVar = '_headers';
   static const _headersVar = 'headers';
   static const _dataVar = 'data';
@@ -2397,7 +2397,7 @@ ${bodyName.displayName} == null
         Code('try {'),
         child,
         Code('} on Object catch (e, s) {'),
-        Code('$_errorLoggerVar?.logError(e, s, options);'),
+        Code('$_errorLoggerVar?.logError(e, s, $_optionsVar);'),
         Code('rethrow;'),
         Code('}'),
       ],

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -49,7 +49,9 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   final RetrofitOptions globalOptions;
 
   static const String _baseUrlVar = 'baseUrl';
+  static const String _errorLoggerVar = 'errorLogger';
   static const _queryParamsVar = 'queryParameters';
+  static const _optionsVar = 'options';
   static const _localHeadersVar = '_headers';
   static const _headersVar = 'headers';
   static const _dataVar = 'data';
@@ -103,7 +105,11 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       c
         ..name = className
         ..types.addAll(element.typeParameters.map((e) => refer(e.name)))
-        ..fields.addAll([_buildDioFiled(), _buildBaseUrlFiled(baseUrl)])
+        ..fields.addAll([
+          _buildDioFiled(),
+          _buildBaseUrlFiled(baseUrl),
+          _buildErrorLoggerFiled(),
+        ])
         ..constructors.addAll(
           annotateClassConsts.map(
             (e) => _generateConstructor(baseUrl, superClassConst: e),
@@ -144,6 +150,13 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           ..modifier = FieldModifier.var$;
       });
 
+  Field _buildErrorLoggerFiled() => Field((m) {
+        m
+          ..name = _errorLoggerVar
+          ..type = refer('ParseErrorLogger?')
+          ..modifier = FieldModifier.final$;
+      });
+
   Constructor _generateConstructor(
     String? url, {
     ConstructorElement? superClassConst,
@@ -156,14 +169,20 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               ..toThis = true,
           ),
         );
-        c.optionalParameters.add(
+        c.optionalParameters.addAll([
           Parameter(
             (p) => p
               ..named = true
               ..name = _baseUrlVar
               ..toThis = true,
           ),
-        );
+          Parameter(
+            (p) => p
+              ..named = true
+              ..name = _errorLoggerVar
+              ..toThis = true,
+          ),
+        ]);
         if (superClassConst != null) {
           var superConstName = 'super';
           if (superClassConst.name.isNotEmpty) {
@@ -534,7 +553,11 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final wrappedReturnType = _getResponseType(m.returnType);
 
-    final options = _parseOptions(m, namedArguments, blocks, extraOptions);
+    blocks.add(declareFinal(_optionsVar)
+        .assign(_parseOptions(m, namedArguments, blocks, extraOptions))
+        .statement);
+
+    final options = refer(_optionsVar).expression;
 
     if (wrappedReturnType == null || 'void' == wrappedReturnType.toString()) {
       blocks.add(
@@ -572,34 +595,36 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       if (_typeChecker(List).isExactlyType(returnType) ||
           _typeChecker(BuiltList).isExactlyType(returnType)) {
         if (_isBasicType(innerReturnType)) {
-          blocks
-            ..add(
-              declareFinal(_resultVar)
-                  .assign(
-                    refer('await $_dioVar.fetch<List<dynamic>>')
-                        .call([options]),
+          blocks.add(
+            declareFinal(_resultVar)
+                .assign(
+                  refer('await $_dioVar.fetch<List<dynamic>>').call([options]),
+                )
+                .statement,
+          );
+
+          _wrapInTryCatch(
+            blocks,
+            options,
+            returnType,
+            refer(_valueVar)
+                .assign(
+                  refer('$_resultVar.data')
+                      .propertyIf(
+                    thisNullable: returnType.isNullable,
+                    name: 'cast',
                   )
-                  .statement,
-            )
-            ..add(
-              declareFinal(_valueVar)
-                  .assign(
-                    refer('$_resultVar.data')
-                        .propertyIf(
-                      thisNullable: returnType.isNullable,
-                      name: 'cast',
+                      .call([], {}, [
+                    refer(
+                      _displayString(
+                        innerReturnType,
+                        withNullability: innerReturnType?.isNullable ?? false,
+                      ),
                     )
-                        .call([], {}, [
-                      refer(
-                        _displayString(
-                          innerReturnType,
-                          withNullability: innerReturnType?.isNullable ?? false,
-                        ),
-                      )
-                    ]),
-                  )
-                  .statement,
-            );
+                  ]),
+                )
+                .statement,
+          );
         } else {
           blocks.add(
             declareFinal(_resultVar)
@@ -609,8 +634,11 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                 .statement,
           );
           if (clientAnnotation.parser == retrofit.Parser.FlutterCompute) {
-            blocks.add(
-              declareVar(_valueVar)
+            _wrapInTryCatch(
+              blocks,
+              options,
+              returnType,
+              refer(_valueVar)
                   .assign(
                     refer('$_resultVar.data').conditionalIsNullIf(
                       thisNullable: returnType.isNullable,
@@ -651,8 +679,12 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               case retrofit.Parser.FlutterCompute:
                 throw Exception('Unreachable code');
             }
-            blocks.add(
-              declareVar(_valueVar)
+
+            _wrapInTryCatch(
+              blocks,
+              options,
+              returnType,
+              refer(_valueVar)
                   .assign(
                     refer('$_resultVar.data')
                         .propertyIf(
@@ -734,8 +766,11 @@ You should create a new class to encapsulate the response.
                 break;
             }
             if (future) {
-              blocks.add(
-                declareVar(_valueVar)
+              _wrapInTryCatch(
+                blocks,
+                options,
+                returnType,
+                refer(_valueVar)
                     .assign(
                       refer('Map.fromEntries').call([
                         refer('await Future.wait').call([
@@ -747,8 +782,11 @@ You should create a new class to encapsulate the response.
                     .statement,
               );
             } else {
-              blocks.add(
-                declareVar(_valueVar)
+              _wrapInTryCatch(
+                blocks,
+                options,
+                returnType,
+                refer(_valueVar)
                     .assign(
                       refer('$_resultVar.data')
                           .propertyIf(
@@ -793,8 +831,11 @@ You should create a new class to encapsulate the response.
                 break;
             }
             if (future) {
-              blocks.add(
-                declareVar(_valueVar)
+              _wrapInTryCatch(
+                blocks,
+                options,
+                returnType,
+                refer(_valueVar)
                     .assign(
                       refer('$_resultVar.data').conditionalIsNullIf(
                         thisNullable: returnType.isNullable,
@@ -809,8 +850,11 @@ You should create a new class to encapsulate the response.
                     .statement,
               );
             } else {
-              blocks.add(
-                declareVar(_valueVar)
+              _wrapInTryCatch(
+                blocks,
+                options,
+                returnType,
+                refer(_valueVar)
                     .assign(
                       refer('$_resultVar.data')
                           .propertyIf(
@@ -823,8 +867,11 @@ You should create a new class to encapsulate the response.
               );
             }
           } else {
-            blocks.add(
-              declareFinal(_valueVar)
+            _wrapInTryCatch(
+              blocks,
+              options,
+              returnType,
+              refer(_valueVar)
                   .assign(
                     refer('$_resultVar.data')
                         .propertyIf(
@@ -844,23 +891,26 @@ You should create a new class to encapsulate the response.
         }
       } else {
         if (_isBasicType(returnType)) {
-          blocks
-            ..add(
-              declareFinal(_resultVar)
-                  .assign(
-                    refer('await $_dioVar.fetch<${_displayString(returnType)}>')
-                        .call([options]),
-                  )
-                  .statement,
-            )
-            ..add(
-              declareFinal(_valueVar)
-                  .assign(
-                    refer('$_resultVar.data')
-                        .asNoNullIf(returnNullable: returnType.isNullable),
-                  )
-                  .statement,
-            );
+          blocks.add(
+            declareFinal(_resultVar)
+                .assign(
+                  refer('await $_dioVar.fetch<${_displayString(returnType)}>')
+                      .call([options]),
+                )
+                .statement,
+          );
+
+          _wrapInTryCatch(
+            blocks,
+            options,
+            returnType,
+            refer(_valueVar)
+                .assign(
+                  refer('$_resultVar.data')
+                      .asNoNullIf(returnNullable: returnType.isNullable),
+                )
+                .statement,
+          );
         } else if (returnType is DynamicType || returnType.isDartCoreObject) {
           blocks
             ..add(
@@ -946,8 +996,11 @@ You should create a new class to encapsulate the response.
               );
               break;
           }
-          blocks.add(
-            declareFinal(_valueVar)
+          _wrapInTryCatch(
+            blocks,
+            options,
+            returnType,
+            refer(_valueVar)
                 .assign(
                   refer('$_resultVar.data').conditionalIsNullIf(
                     thisNullable: returnType.isNullable,
@@ -2269,6 +2322,25 @@ ${bodyName.displayName} == null
                   _displayString(type),
         );
     }
+  }
+
+  void _wrapInTryCatch(
+      List<Code> blocks, Expression options, DartType? returnType, Code child) {
+    blocks.addAll(
+      [
+        declareVar(
+          _valueVar,
+          type: refer(_displayString(returnType, withNullability: true)),
+          late: true,
+        ).statement,
+        Code('try {'),
+        child,
+        Code('} on Object catch (e, s) {'),
+        Code('$_errorLoggerVar?.logError(e, s, options);'),
+        Code('rethrow;'),
+        Code('}'),
+      ],
+    );
   }
 }
 

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -400,7 +400,7 @@ abstract class UploadFileInfoPartTest {
     try {
       _value = User.fromJson(_result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -419,7 +419,7 @@ abstract class GenericCast {
     try {
       _value = _result.data == null ? null : User.fromJson(_result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -438,7 +438,7 @@ abstract class NullableGenericCast {
     try {
       _value = User.fromJson(_result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     yield _value;
@@ -464,7 +464,7 @@ enum TestEnum { A, B }
         ),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -508,7 +508,7 @@ enum FromJsonEnum {
     try {
       _value = FromJsonEnum.fromJson(_result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -612,7 +612,7 @@ Map<String, dynamic> serializeUser(User object) => object.toJson();
     try {
       _value = _result.data!;
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -631,7 +631,7 @@ abstract class GenericCastBasicType {
     try {
       _value = _result.data;
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -772,7 +772,7 @@ abstract class TestCustomObjectBody {
               .map((i) => User.fromJson(i as Map<String, dynamic>))
               .toList()));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -795,7 +795,7 @@ abstract class TestMapBody {
               .map((i) => User.fromJson(i as Map<String, dynamic>))
               .toList()));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -815,7 +815,7 @@ abstract class NullableTestMapBody {
       _value = _result.data!.map((k, dynamic v) =>
           MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -835,7 +835,7 @@ abstract class TestMapBody2 {
       _value = _result.data?.map((k, dynamic v) =>
           MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -854,7 +854,7 @@ abstract class NullableTestMapBody2 {
     try {
       _value = _result.data!.cast<String>();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -873,7 +873,7 @@ abstract class TestBasicListString {
     try {
       _value = _result.data?.cast<String>();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -892,7 +892,7 @@ abstract class NullableTestBasicListString {
     try {
       _value = _result.data!.cast<bool>();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -911,7 +911,7 @@ abstract class TestBasicListBool {
     try {
       _value = _result.data?.cast<bool>();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -930,7 +930,7 @@ abstract class NullableTestBasicListBool {
     try {
       _value = _result.data!.cast<int>();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -949,7 +949,7 @@ abstract class TestBasicListInt {
     try {
       _value = _result.data?.cast<int>();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -968,7 +968,7 @@ abstract class NullableTestBasicListInt {
     try {
       _value = _result.data!.cast<double>();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -987,7 +987,7 @@ abstract class TestBasicListDouble {
     try {
       _value = _result.data?.cast<double>();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1093,7 +1093,7 @@ abstract class TestHttpResponseObject {
     try {
       _value = _result.data!.cast<String>();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     final httpResponse = HttpResponse(_value, _result);
@@ -1274,13 +1274,13 @@ abstract class TestModelList {
     newOptions.extra.addAll(_extra);
     newOptions.headers.addAll(_dio.options.headers);
     newOptions.headers.addAll(_headers);
-    final options = newOptions.copyWith(
+    final _options = newOptions.copyWith(
       method: 'GET',
       baseUrl: baseUrl ?? _dio.options.baseUrl,
       queryParameters: queryParameters,
       path: '',
     )..data = _data;
-    await _dio.fetch<void>(options);
+    await _dio.fetch<void>(_options);
   ''',
   contains: true,
 )
@@ -1296,7 +1296,7 @@ abstract class CustomOptions {
     try {
       _value = JsonMapper.fromMap<User>(_result.data!)!;
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1320,7 +1320,7 @@ abstract class JsonMapperGenericCast {
           ? null
           : JsonMapper.fromMap<User>(_result.data!)!;
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1345,7 +1345,7 @@ abstract class NullableJsonMapperGenericCast {
               JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
           .toList();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1371,7 +1371,7 @@ abstract class JsonMapperTestListBody {
               .map((i) => JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
               .toList()));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1394,7 +1394,7 @@ abstract class JsonMapperTestMapBody {
       _value = _result.data!.map((k, dynamic v) =>
           MapEntry(k, JsonMapper.fromMap<User>(v as Map<String, dynamic>)!));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1416,7 +1416,7 @@ abstract class JsonMapperTestMapBody2 {
     try {
       _value = User.fromMap(_result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1438,7 +1438,7 @@ abstract class MapSerializableGenericCast {
     try {
       _value = _result.data == null ? null : User.fromMap(_result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1462,7 +1462,7 @@ abstract class NullableMapSerializableGenericCast {
           .map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
           .toList();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1486,7 +1486,7 @@ abstract class MapSerializableTestListBody {
           ?.map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
           .toList();
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1512,7 +1512,7 @@ abstract class NullableMapSerializableTestListBody {
               .map((i) => User.fromMap(i as Map<String, dynamic>))
               .toList()));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1538,7 +1538,7 @@ abstract class MapSerializableTestMapBody {
               .map((i) => User.fromMap(i as Map<String, dynamic>))
               .toList()));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1561,7 +1561,7 @@ abstract class NullableMapSerializableTestMapBody {
       _value = _result.data!.map((k, dynamic v) =>
           MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1584,7 +1584,7 @@ abstract class MapSerializableTestMapBody2 {
       _value = _result.data?.map((k, dynamic v) =>
           MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1605,7 +1605,7 @@ abstract class NullableMapSerializableTestMapBody2 {
     try {
       _value = await compute(deserializeUser, _result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1629,7 +1629,7 @@ abstract class ComputeGenericCast {
           ? null
           : await compute(deserializeUser, _result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1653,7 +1653,7 @@ abstract class NullableComputeGenericCast {
         _result.data!.cast<Map<String, dynamic>>(),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1680,7 +1680,7 @@ abstract class ComputeTestListBody {
               _result.data!.cast<Map<String, dynamic>>(),
             );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1705,7 +1705,7 @@ abstract class NullableComputeTestListBody {
               await compute(deserializeUserList,
                   (e.value as List).cast<Map<String, dynamic>>())))));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1737,7 +1737,7 @@ abstract class ComputeTestMapBody {
               await compute(deserializeUserList,
                   (e.value as List).cast<Map<String, dynamic>>())))));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1769,7 +1769,7 @@ abstract class NullableComputeTestMapBody {
               await compute(
                   deserializeUser, e.value as Map<String, dynamic>)))));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1803,7 +1803,7 @@ abstract class ComputeTestMapBody2 {
                   await compute(
                       deserializeUser, e.value as Map<String, dynamic>)))));
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -1930,7 +1930,7 @@ abstract class JsonSerializableBodyShouldBeCleanTest {
 @ShouldGenerate(
   '''
     final _data = str;
-    final options = _setStreamType<void>(Options(''',
+    final _options = _setStreamType<void>(Options(''',
   contains: true,
   expectedLogItems: [
     "String must provide a `toJson()` method which return a Map.\nIt is programmer's responsibility to make sure the String is properly serialized"
@@ -1945,7 +1945,7 @@ abstract class NonJsonSerializableBodyShouldNotBeCleanTest {
 @ShouldGenerate(
   '''
     final _data = users.map((e) => e.toJson()).toList();
-    final options = _setStreamType<void>(Options(
+    final _options = _setStreamType<void>(Options(
       method: 'PUT',
       headers: _headers,
       extra: _extra,
@@ -1961,7 +1961,7 @@ abstract class NonJsonSerializableBodyShouldNotBeCleanTest {
           _dio.options.baseUrl,
           baseUrl,
         )));
-    await _dio.fetch<void>(options);
+    await _dio.fetch<void>(_options);
   ''',
   contains: true,
 )
@@ -1980,7 +1980,7 @@ abstract class ListBodyShouldNotBeCleanTest {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2006,7 +2006,7 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsDynamic {
             : List.empty(),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2035,7 +2035,7 @@ abstract class DynamicInnerListGenericTypeShouldBeCastedRecursively {
                   : List.empty(),
             );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2057,7 +2057,7 @@ late GenericUser<User> _value;
         (json) => User.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2082,7 +2082,7 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsMap {
         ),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2106,7 +2106,7 @@ abstract class NestGenericTypeShouldBeCastedRecursively {
               (json) => User.fromJson(json as Map<String, dynamic>),
             );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2129,7 +2129,7 @@ late GenericUser<User?> _value;
             json == null ? null : User.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2155,7 +2155,7 @@ abstract class DynamicNullableInnerGenericTypeShouldBeCastedAsMap {
                   : User.fromJson(json as Map<String, dynamic>),
             );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2179,7 +2179,7 @@ abstract class NullableDynamicNullableInnerGenericTypeShouldBeCastedAsMap {
             : List.empty(),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2205,7 +2205,7 @@ abstract class DynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursively {
                   : List.empty(),
             );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2225,7 +2225,7 @@ abstract class NullableDynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursi
       _value = GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
           _result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;
@@ -2247,7 +2247,7 @@ abstract class DynamicInnerGenericTypeShouldBeWithoutGenericArgumentType {
           : GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
               _result.data!);
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, options);
+      errorLogger?.logError(e, s, _options);
       rethrow;
     }
     return _value;

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -131,8 +131,8 @@ abstract class TestExtrasWithMap {
   @GET('/list/')
   @Extra({'key': 'value'})
   Future<void> list(
-      @Extras() Map<String, dynamic> extras,
-      );
+    @Extras() Map<String, dynamic> extras,
+  );
 }
 
 @ShouldGenerate(
@@ -146,7 +146,7 @@ abstract class TestExtrasWithMap {
 abstract class TestExtrasWithObject {
   @GET('/list/')
   Future<void> list(
-      @Extras() User u,
+    @Extras() User u,
   );
 }
 
@@ -434,6 +434,13 @@ abstract class NullableGenericCast {
 
 @ShouldGenerate(
   '''
+    late User value;
+    try {
+      value = User.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     yield value;
 ''',
   contains: true,
@@ -1082,7 +1089,15 @@ abstract class TestHttpResponseObject {
 
 @ShouldGenerate(
   '''
+    late List<String> value;
+    try {
+      value = _result.data!.cast<String>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     final httpResponse = HttpResponse(value, _result);
+    return httpResponse;
 ''',
   contains: true,
 )

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -14,11 +14,14 @@ class _RestClient implements RestClient {
   _RestClient(
     this._dio, {
     this.baseUrl,
+    this.errorLogger,
   });
 
   final Dio _dio;
 
   String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
 ''',
   contains: true,
 )
@@ -31,6 +34,7 @@ class _BaseUrl implements BaseUrl {
   _BaseUrl(
     this._dio, {
     this.baseUrl,
+    this.errorLogger,
   }) {
     baseUrl ??= 'http://httpbin.org/';
   }
@@ -38,6 +42,8 @@ class _BaseUrl implements BaseUrl {
   final Dio _dio;
 
   String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
 ''',
   contains: true,
 )
@@ -390,7 +396,13 @@ abstract class UploadFileInfoPartTest {
 
 @ShouldGenerate(
   '''
-    final value = User.fromJson(_result.data!);
+    late User value;
+    try {
+      value = User.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -403,7 +415,13 @@ abstract class GenericCast {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null ? null : User.fromJson(_result.data!);
+    late User? value;
+    try {
+      value = _result.data == null ? null : User.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -430,12 +448,18 @@ enum TestEnum { A, B }
 
 @ShouldGenerate(
   '''
-    final value = TestEnum.values.firstWhere(
-      (e) => e.name == _result.data,
-      orElse: () => throw ArgumentError(
-        'TestEnum does not contain value \${_result.data}',
-      ),
-    );
+    late TestEnum value;
+    try {
+      value = TestEnum.values.firstWhere(
+        (e) => e.name == _result.data,
+        orElse: () => throw ArgumentError(
+          'TestEnum does not contain value \${_result.data}',
+        ),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -473,7 +497,13 @@ enum FromJsonEnum {
 
 @ShouldGenerate(
   '''
-    final value = FromJsonEnum.fromJson(_result.data!);
+    late FromJsonEnum value;
+    try {
+      value = FromJsonEnum.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -571,7 +601,13 @@ Map<String, dynamic> serializeUser(User object) => object.toJson();
 
 @ShouldGenerate(
   '''
-    final value = _result.data!;
+    late String value;
+    try {
+      value = _result.data!;
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -584,7 +620,13 @@ abstract class GenericCastBasicType {
 
 @ShouldGenerate(
   '''
-    final value = _result.data;
+    late String? value;
+    try {
+      value = _result.data;
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -715,11 +757,17 @@ abstract class TestCustomObjectBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) => MapEntry(
-        k,
-        (v as List)
-            .map((i) => User.fromJson(i as Map<String, dynamic>))
-            .toList()));
+    late Map<String, List<User>> value;
+    try {
+      value = _result.data!.map((k, dynamic v) => MapEntry(
+          k,
+          (v as List)
+              .map((i) => User.fromJson(i as Map<String, dynamic>))
+              .toList()));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -732,11 +780,17 @@ abstract class TestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map((k, dynamic v) => MapEntry(
-        k,
-        (v as List)
-            .map((i) => User.fromJson(i as Map<String, dynamic>))
-            .toList()));
+    late Map<String, List<User>>? value;
+    try {
+      value = _result.data?.map((k, dynamic v) => MapEntry(
+          k,
+          (v as List)
+              .map((i) => User.fromJson(i as Map<String, dynamic>))
+              .toList()));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -749,8 +803,14 @@ abstract class NullableTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) =>
-        MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
+    late Map<String, User> value;
+    try {
+      value = _result.data!.map((k, dynamic v) =>
+          MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -763,8 +823,14 @@ abstract class TestMapBody2 {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map((k, dynamic v) =>
-        MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
+    late Map<String, User>? value;
+    try {
+      value = _result.data?.map((k, dynamic v) =>
+          MapEntry(k, User.fromJson(v as Map<String, dynamic>)));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -777,7 +843,13 @@ abstract class NullableTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<String>();
+    late List<String> value;
+    try {
+      value = _result.data!.cast<String>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -790,7 +862,13 @@ abstract class TestBasicListString {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<String>();
+    late List<String>? value;
+    try {
+      value = _result.data?.cast<String>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -803,7 +881,13 @@ abstract class NullableTestBasicListString {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<bool>();
+    late List<bool> value;
+    try {
+      value = _result.data!.cast<bool>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -816,7 +900,13 @@ abstract class TestBasicListBool {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<bool>();
+    late List<bool>? value;
+    try {
+      value = _result.data?.cast<bool>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -829,7 +919,13 @@ abstract class NullableTestBasicListBool {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<int>();
+    late List<int> value;
+    try {
+      value = _result.data!.cast<int>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -842,7 +938,13 @@ abstract class TestBasicListInt {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<int>();
+    late List<int>? value;
+    try {
+      value = _result.data?.cast<int>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -855,7 +957,13 @@ abstract class NullableTestBasicListInt {
 
 @ShouldGenerate(
   '''
-    final value = _result.data!.cast<double>();
+    late List<double> value;
+    try {
+      value = _result.data!.cast<double>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -868,7 +976,13 @@ abstract class TestBasicListDouble {
 
 @ShouldGenerate(
   '''
-    final value = _result.data?.cast<double>();
+    late List<double>? value;
+    try {
+      value = _result.data?.cast<double>();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1145,12 +1259,13 @@ abstract class TestModelList {
     newOptions.extra.addAll(_extra);
     newOptions.headers.addAll(_dio.options.headers);
     newOptions.headers.addAll(_headers);
-    await _dio.fetch<void>(newOptions.copyWith(
+    final options = newOptions.copyWith(
       method: 'GET',
       baseUrl: baseUrl ?? _dio.options.baseUrl,
       queryParameters: queryParameters,
       path: '',
-    )..data = _data);
+    )..data = _data;
+    await _dio.fetch<void>(options);
   ''',
   contains: true,
 )
@@ -1162,7 +1277,13 @@ abstract class CustomOptions {
 
 @ShouldGenerate(
   '''
-    final value = JsonMapper.fromMap<User>(_result.data!)!;
+    late User value;
+    try {
+      value = JsonMapper.fromMap<User>(_result.data!)!;
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1178,8 +1299,15 @@ abstract class JsonMapperGenericCast {
 
 @ShouldGenerate(
   '''
-    final value =
-        _result.data == null ? null : JsonMapper.fromMap<User>(_result.data!)!;
+    late User? value;
+    try {
+      value = _result.data == null
+          ? null
+          : JsonMapper.fromMap<User>(_result.data!)!;
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1195,10 +1323,16 @@ abstract class NullableJsonMapperGenericCast {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!
-        .map(
-            (dynamic i) => JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
-        .toList();
+    late List<User> value;
+    try {
+      value = _result.data!
+          .map((dynamic i) =>
+              JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1214,11 +1348,17 @@ abstract class JsonMapperTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) => MapEntry(
-        k,
-        (v as List)
-            .map((i) => JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
-            .toList()));
+    late Map<String, List<User>> value;
+    try {
+      value = _result.data!.map((k, dynamic v) => MapEntry(
+          k,
+          (v as List)
+              .map((i) => JsonMapper.fromMap<User>(i as Map<String, dynamic>)!)
+              .toList()));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1234,8 +1374,14 @@ abstract class JsonMapperTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) =>
-        MapEntry(k, JsonMapper.fromMap<User>(v as Map<String, dynamic>)!));
+    late Map<String, User> value;
+    try {
+      value = _result.data!.map((k, dynamic v) =>
+          MapEntry(k, JsonMapper.fromMap<User>(v as Map<String, dynamic>)!));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1251,7 +1397,13 @@ abstract class JsonMapperTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    final value = User.fromMap(_result.data!);
+    late User value;
+    try {
+      value = User.fromMap(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1267,7 +1419,13 @@ abstract class MapSerializableGenericCast {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null ? null : User.fromMap(_result.data!);
+    late User? value;
+    try {
+      value = _result.data == null ? null : User.fromMap(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1283,9 +1441,15 @@ abstract class NullableMapSerializableGenericCast {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!
-        .map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
-        .toList();
+    late List<User> value;
+    try {
+      value = _result.data!
+          .map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1301,9 +1465,15 @@ abstract class MapSerializableTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data
-        ?.map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
-        .toList();
+    late List<User>? value;
+    try {
+      value = _result.data
+          ?.map((dynamic i) => User.fromMap(i as Map<String, dynamic>))
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1319,11 +1489,17 @@ abstract class NullableMapSerializableTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map((k, dynamic v) => MapEntry(
-        k,
-        (v as List)
-            .map((i) => User.fromMap(i as Map<String, dynamic>))
-            .toList()));
+    late Map<String, List<User>> value;
+    try {
+      value = _result.data!.map((k, dynamic v) => MapEntry(
+          k,
+          (v as List)
+              .map((i) => User.fromMap(i as Map<String, dynamic>))
+              .toList()));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1339,11 +1515,17 @@ abstract class MapSerializableTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map((k, dynamic v) => MapEntry(
-        k,
-        (v as List)
-            .map((i) => User.fromMap(i as Map<String, dynamic>))
-            .toList()));
+    late Map<String, List<User>>? value;
+    try {
+      value = _result.data?.map((k, dynamic v) => MapEntry(
+          k,
+          (v as List)
+              .map((i) => User.fromMap(i as Map<String, dynamic>))
+              .toList()));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1359,8 +1541,14 @@ abstract class NullableMapSerializableTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data!.map(
-        (k, dynamic v) => MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
+    late Map<String, User> value;
+    try {
+      value = _result.data!.map((k, dynamic v) =>
+          MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1376,8 +1564,14 @@ abstract class MapSerializableTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    var value = _result.data?.map(
-        (k, dynamic v) => MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
+    late Map<String, User>? value;
+    try {
+      value = _result.data?.map((k, dynamic v) =>
+          MapEntry(k, User.fromMap(v as Map<String, dynamic>)));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1393,7 +1587,12 @@ abstract class NullableMapSerializableTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    final value = await compute(deserializeUser, _result.data!);
+    try {
+      value = await compute(deserializeUser, _result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1409,9 +1608,15 @@ abstract class ComputeGenericCast {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
-        ? null
-        : await compute(deserializeUser, _result.data!);
+    late User? value;
+    try {
+      value = _result.data == null
+          ? null
+          : await compute(deserializeUser, _result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1427,10 +1632,15 @@ abstract class NullableComputeGenericCast {
 
 @ShouldGenerate(
   '''
-    var value = await compute(
-      deserializeUserList,
-      _result.data!.cast<Map<String, dynamic>>(),
-    );
+    try {
+      value = await compute(
+        deserializeUserList,
+        _result.data!.cast<Map<String, dynamic>>(),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1446,12 +1656,18 @@ abstract class ComputeTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = _result.data == null
-        ? null
-        : await compute(
-            deserializeUserList,
-            _result.data!.cast<Map<String, dynamic>>(),
-          );
+    late List<User>? value;
+    try {
+      value = _result.data == null
+          ? null
+          : await compute(
+              deserializeUserList,
+              _result.data!.cast<Map<String, dynamic>>(),
+            );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1467,11 +1683,16 @@ abstract class NullableComputeTestListBody {
 
 @ShouldGenerate(
   '''
-    var value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
-        (e) async => MapEntry(
-            e.key,
-            await compute(deserializeUserList,
-                (e.value as List).cast<Map<String, dynamic>>())))));
+    try {
+      value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
+          (e) async => MapEntry(
+              e.key,
+              await compute(deserializeUserList,
+                  (e.value as List).cast<Map<String, dynamic>>())))));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1493,11 +1714,17 @@ abstract class ComputeTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
-        (e) async => MapEntry(
-            e.key,
-            await compute(deserializeUserList,
-                (e.value as List).cast<Map<String, dynamic>>())))));
+    late Map<String, List<User>>? value;
+    try {
+      value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
+          (e) async => MapEntry(
+              e.key,
+              await compute(deserializeUserList,
+                  (e.value as List).cast<Map<String, dynamic>>())))));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1519,9 +1746,17 @@ abstract class NullableComputeTestMapBody {
 
 @ShouldGenerate(
   '''
-    var value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
-        (e) async => MapEntry(e.key,
-            await compute(deserializeUser, e.value as Map<String, dynamic>)))));
+    late Map<String, User> value;
+    try {
+      value = Map.fromEntries(await Future.wait(_result.data!.entries.map(
+          (e) async => MapEntry(
+              e.key,
+              await compute(
+                  deserializeUser, e.value as Map<String, dynamic>)))));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1543,13 +1778,19 @@ abstract class ComputeTestMapBody2 {
 
 @ShouldGenerate(
   '''
-    var value = _result.data == null
-        ? null
-        : Map.fromEntries(await Future.wait(_result.data!.entries.map(
-            (e) async => MapEntry(
-                e.key,
-                await compute(
-                    deserializeUser, e.value as Map<String, dynamic>)))));
+    late Map<String, User>? value;
+    try {
+      value = _result.data == null
+          ? null
+          : Map.fromEntries(await Future.wait(_result.data!.entries.map(
+              (e) async => MapEntry(
+                  e.key,
+                  await compute(
+                      deserializeUser, e.value as Map<String, dynamic>)))));
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
 ''',
   contains: true,
@@ -1674,7 +1915,7 @@ abstract class JsonSerializableBodyShouldBeCleanTest {
 @ShouldGenerate(
   '''
     final _data = str;
-    await _dio.fetch<void>(_setStreamType<void>(Options(''',
+    final options = _setStreamType<void>(Options(''',
   contains: true,
   expectedLogItems: [
     "String must provide a `toJson()` method which return a Map.\nIt is programmer's responsibility to make sure the String is properly serialized"
@@ -1689,7 +1930,23 @@ abstract class NonJsonSerializableBodyShouldNotBeCleanTest {
 @ShouldGenerate(
   '''
     final _data = users.map((e) => e.toJson()).toList();
-    await _dio.fetch<void>(_setStreamType<void>(Options(
+    final options = _setStreamType<void>(Options(
+      method: 'PUT',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    await _dio.fetch<void>(options);
   ''',
   contains: true,
 )
@@ -1701,10 +1958,16 @@ abstract class ListBodyShouldNotBeCleanTest {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<dynamic>.fromJson(
-      _result.data!,
-      (json) => json as dynamic,
-    );
+    late GenericUser<dynamic> value;
+    try {
+      value = GenericUser<dynamic>.fromJson(
+        _result.data!,
+        (json) => json as dynamic,
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1717,14 +1980,20 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsDynamic {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<List<User>>.fromJson(
-      _result.data!,
-      (json) => json is List<dynamic>
-          ? json
-              .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
-              .toList()
-          : List.empty(),
-    );
+    late GenericUser<List<User>> value;
+    try {
+      value = GenericUser<List<User>>.fromJson(
+        _result.data!,
+        (json) => json is List<dynamic>
+            ? json
+                .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
+                .toList()
+            : List.empty(),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1737,16 +2006,23 @@ abstract class DynamicInnerListGenericTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
-        ? null
-        : GenericUser<List<User>>.fromJson(
-            _result.data!,
-            (json) => json is List<dynamic>
-                ? json
-                    .map<User>((i) => User.fromJson(i as Map<String, dynamic>))
-                    .toList()
-                : List.empty(),
-          );
+    late GenericUser<List<User>>? value;
+    try {
+      value = _result.data == null
+          ? null
+          : GenericUser<List<User>>.fromJson(
+              _result.data!,
+              (json) => json is List<dynamic>
+                  ? json
+                      .map<User>(
+                          (i) => User.fromJson(i as Map<String, dynamic>))
+                      .toList()
+                  : List.empty(),
+            );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1759,10 +2035,16 @@ abstract class NullableDynamicInnerListGenericTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<User>.fromJson(
-      _result.data!,
-      (json) => User.fromJson(json as Map<String, dynamic>),
-    );
+late GenericUser<User> value;
+    try {
+      value = GenericUser<User>.fromJson(
+        _result.data!,
+        (json) => User.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1775,13 +2057,19 @@ abstract class DynamicInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<GenericUser<User>>.fromJson(
-      _result.data!,
-      (json) => GenericUser<User>.fromJson(
-        json as Map<String, dynamic>,
-        (json) => User.fromJson(json as Map<String, dynamic>),
-      ),
-    );
+    late GenericUser<GenericUser<User>> value;
+    try {
+      value = GenericUser<GenericUser<User>>.fromJson(
+        _result.data!,
+        (json) => GenericUser<User>.fromJson(
+          json as Map<String, dynamic>,
+          (json) => User.fromJson(json as Map<String, dynamic>),
+        ),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1794,12 +2082,18 @@ abstract class NestGenericTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
-        ? null
-        : GenericUser<User>.fromJson(
-            _result.data!,
-            (json) => User.fromJson(json as Map<String, dynamic>),
-          );
+    late GenericUser<User>? value;
+    try {
+      value = _result.data == null
+          ? null
+          : GenericUser<User>.fromJson(
+              _result.data!,
+              (json) => User.fromJson(json as Map<String, dynamic>),
+            );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1812,11 +2106,17 @@ abstract class NullableDynamicInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<User?>.fromJson(
-      _result.data!,
-      (json) =>
-          json == null ? null : User.fromJson(json as Map<String, dynamic>),
-    );
+late GenericUser<User?> value;
+    try {
+      value = GenericUser<User?>.fromJson(
+        _result.data!,
+        (json) =>
+            json == null ? null : User.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1829,14 +2129,20 @@ abstract class DynamicNullableInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
-        ? null
-        : GenericUser<User?>.fromJson(
-            _result.data!,
-            (json) => json == null
-                ? null
-                : User.fromJson(json as Map<String, dynamic>),
-          );
+    late GenericUser<User?>? value;
+    try {
+      value = _result.data == null
+          ? null
+          : GenericUser<User?>.fromJson(
+              _result.data!,
+              (json) => json == null
+                  ? null
+                  : User.fromJson(json as Map<String, dynamic>),
+            );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1849,12 +2155,18 @@ abstract class NullableDynamicNullableInnerGenericTypeShouldBeCastedAsMap {
 
 @ShouldGenerate(
   '''
-    final value = GenericUser<List<double>>.fromJson(
-      _result.data!,
-      (json) => json is List<dynamic>
-          ? json.map<double>((i) => i as double).toList()
-          : List.empty(),
-    );
+    late GenericUser<List<double>> value;
+    try {
+      value = GenericUser<List<double>>.fromJson(
+        _result.data!,
+        (json) => json is List<dynamic>
+            ? json.map<double>((i) => i as double).toList()
+            : List.empty(),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1867,14 +2179,20 @@ abstract class DynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursively {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
-        ? null
-        : GenericUser<List<double>>.fromJson(
-            _result.data!,
-            (json) => json is List<dynamic>
-                ? json.map<double>((i) => i as double).toList()
-                : List.empty(),
-          );
+    late GenericUser<List<double>>? value;
+    try {
+      value = _result.data == null
+          ? null
+          : GenericUser<List<double>>.fromJson(
+              _result.data!,
+              (json) => json is List<dynamic>
+                  ? json.map<double>((i) => i as double).toList()
+                  : List.empty(),
+            );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1887,8 +2205,14 @@ abstract class NullableDynamicInnerListGenericPrimitiveTypeShouldBeCastedRecursi
 
 @ShouldGenerate(
   '''
-    final value = GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
-        _result.data!);
+    late GenericUserWithoutGenericArgumentFactories<dynamic> value;
+    try {
+      value = GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
+          _result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1901,10 +2225,16 @@ abstract class DynamicInnerGenericTypeShouldBeWithoutGenericArgumentType {
 
 @ShouldGenerate(
   '''
-    final value = _result.data == null
-        ? null
-        : GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
-            _result.data!);
+    late GenericUserWithoutGenericArgumentFactories<dynamic>? value;
+    try {
+      value = _result.data == null
+          ? null
+          : GenericUserWithoutGenericArgumentFactories<dynamic>.fromJson(
+              _result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, options);
+      rethrow;
+    }
     return value;
   ''',
   contains: true,
@@ -1965,11 +2295,11 @@ abstract class GenericCastFetch {
 
 @ShouldGenerate(
   '''
-            .copyWith(
-                baseUrl: _combineBaseUrls(
-              _dio.options.baseUrl,
-              baseUrl,
-            ))));
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
   ''',
   contains: true,
 )

--- a/retrofit/lib/error_logger.dart
+++ b/retrofit/lib/error_logger.dart
@@ -1,0 +1,11 @@
+import 'package:dio/dio.dart';
+
+/// Base class for logging errors that occur during parsing of response data.
+abstract class ParseErrorLogger {
+  /// Logs an error that occurred during parsing of response data.
+  /// 
+  /// - [error] is the error that occurred.
+  /// - [stackTrace] is the stack trace of the error.
+  /// - [options] are the options that were used to make the request.
+  void logError(Object error, StackTrace stackTrace, RequestOptions options);
+}

--- a/retrofit/lib/retrofit.dart
+++ b/retrofit/lib/retrofit.dart
@@ -1,2 +1,3 @@
 export 'dio.dart';
 export 'http.dart';
+export 'error_logger.dart';


### PR DESCRIPTION
# Reincarnation of #680 with fixed unit tests

## Problem

Sometimes, the back-end changes the response structure unexpectedly. For example, our app expects this:

```json
 {
    "id": "0",
    "name": "Name"
 }
```

but we get this instead:

```json
{
    "id": 0,
    "name": "Name"
 }
```

Logging these discrepancies would be really useful. To make the logs as helpful as possible, we need to capture:
* Request details (path, URI, params, etc.); 
* Parsing error details (we can use `CheckedFromJsonException` from `json_serializable`).

The most logical place for such logging is within the client.

## Solution

Let's introduce a new entity - `ParseErrorLogger` :

```dart
import 'package:dio/dio.dart';

/// Base class for logging errors that occur during parsing of response data.
abstract class ParseErrorLogger {
  /// Logs an error that occurred during parsing of response data.
  /// 
  /// - [error] is the error that occurred.
  /// - [stackTrace] is the stack trace of the error.
  /// - [options] are the options that were used to make the request.
  void logError(Object error, StackTrace stackTrace, RequestOptions options);
}
```

This entity can be injected into our client:

```dart
import 'package:dio/dio.dart';
import 'package:retrofit/retrofit.dart';

part 'rest_client.g.dart';

@RestApi()
abstract class RestClient {
  /// API creation factory using [Dio].
  factory RestClient(
    Dio dio, {
    String baseUrl,
    ParseErrorLogger? errorLogger,
  }) = _RestClient;

  @GET('')
  Future<SomeDto> someRequest();
}
```

And this entity will be called if parsing fails.

For example, this is `rest_client.g.dart`. As shown in the `After` example, `errorLogger` is called if there are any issues with parsing:

<table>
  <tr> 
    <th>
      Before
    </th>
    <th>
      After
    </th>
  </tr>
  <tr valign="top">
  <td>
  
  ```dart
    @override
    Future<SomeDto> someRequest() async {
      const _extra = <String, dynamic>{};
      final queryParameters = <String, dynamic>{};
      final _headers = <String, dynamic>{};
      final Map<String, dynamic>? _data = null;
      final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<SomeDto>(Options(
        method: 'GET',
        headers: _headers,
        extra: _extra,
      )
          .compose(
            _dio.options,
            '',
            queryParameters: queryParameters,
            data: _data,
          )
          .copyWith(
              baseUrl: _combineBaseUrls(
            _dio.options.baseUrl,
            baseUrl,
          ))));
      final value = SomeDto.fromJson(_result.data!);
      return value;
    }
  ```
  
    
  </td>
  <td>
  
  ```dart
    @override
    Future<SomeDto> someRequest() async {
      final _extra = <String, dynamic>{};
      final queryParameters = <String, dynamic>{};
      final _headers = <String, dynamic>{};
      const Map<String, dynamic>? _data = null;
      final options = _setStreamType<SomeDto>(Options(
        method: 'GET',
        headers: _headers,
        extra: _extra,
      )
          .compose(
            _dio.options,
            '',
            queryParameters: queryParameters,
            data: _data,
          )
          .copyWith(
              baseUrl: _combineBaseUrls(
            _dio.options.baseUrl,
            baseUrl,
          )));
      final _result = await _dio.fetch<Map<String, dynamic>>(options);
      late SomeDto value;
      try {
        value = SomeDto.fromJson(_result.data!);
      } on Object catch (e, s) {
        errorLogger?.logError(e, s, options);
        rethrow;
      }
      return value;
    }
  ```
  
  </td>
  </tr>
</table>
