### PR TITLE
Fix deprecations of `withNullability`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 ![Pub Likes](https://img.shields.io/pub/likes/retrofit)
 [![Testing](https://github.com/trevorwang/retrofit.dart/actions/workflows/test.yml/badge.svg)](https://github.com/trevorwang/retrofit.dart/actions/workflows/test.yml)
 
-
-
 retrofit.dart is a type conversion [dio](https://github.com/flutterchina/dio/) client generator using [source_gen](https://github.com/dart-lang/source_gen) and inspired by [Chopper](https://github.com/lejard-h/chopper) and [Retrofit](https://github.com/square/retrofit).
 
 ## Usage
@@ -17,14 +15,14 @@ Add the generator to your dev dependencies
 
 ```yaml
 dependencies:
-  retrofit: '>=4.0.0 <5.0.0'
-  logger: any  #for logging purpose
-  json_annotation: ^4.8.1
+  retrofit: ^4.3.0
+  logger: ^1.2.0  # for logging purpose
+  json_annotation: ^4.9.0
 
 dev_dependencies:
-  retrofit_generator: '>=7.0.0 <8.0.0'   // required dart >=2.19
-  build_runner: '>=2.3.0 <4.0.0'
-  json_serializable: ^6.6.2
+  retrofit_generator: '>=8.0.0 <10.0.0' # for Dart 3.3 use ^9.0.0
+  build_runner: ^2.3.3
+  json_serializable: ^6.8.0
 ```
 
 ### Define and Generate your API

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 8.2.0
+## 9.0.0
 
 - Require Dart 3.3
 - Fix issue with deprecated `getDisplayString(withNullability: true)`

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 8.2.0
+
+- Require Dart 3.3
+- Fix issue with deprecated `getDisplayString(withNullability: true)`
+- Update `analyzer: ^6.5.0`
+- Update `lints: ^4.0.0` and fix issues
+- Remove `tuple` dependency
+
 ## 8.1.0
 
 - Added `@Extras` to pass extra options to dio requests, response, transformer and interceptors.

--- a/generator/lib/retrofit_generator.dart
+++ b/generator/lib/retrofit_generator.dart
@@ -1,3 +1,5 @@
+library;
+
 import 'package:build/build.dart';
 
 import 'src/generator.dart';

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -194,7 +194,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               c.requiredParameters.add(
                 Parameter(
                   (p) => p
-                    ..type = refer(element.type.toStringNonNullable())
+                    ..type = refer(_displayString(element.type))
                     ..name = element.name,
                 ),
               );
@@ -2562,8 +2562,6 @@ String _displayString(DartType? e, {bool withNullability = false}) {
     } else {
       return e!.getDisplayString();
     }
-  } on Object {
-    rethrow;
   }
 }
 

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -13,7 +13,6 @@ import 'package:dio/dio.dart';
 import 'package:protobuf/protobuf.dart';
 import 'package:retrofit/retrofit.dart' as retrofit;
 import 'package:source_gen/source_gen.dart';
-import 'package:tuple/tuple.dart';
 
 const _analyzerIgnores =
     '// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element';
@@ -195,7 +194,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
               c.requiredParameters.add(
                 Parameter(
                   (p) => p
-                    ..type = refer(_displayString(element.type))
+                    ..type = refer(element.type.toStringNonNullable())
                     ..name = element.name,
                 ),
               );
@@ -226,7 +225,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
   Iterable<Method> _parseMethods(ClassElement element) => <MethodElement>[
         ...element.methods,
-        ...element.mixins.expand((i) => i.methods)
+        ...element.mixins.expand((i) => i.methods),
       ].where((m) {
         final methodAnnotation = _getMethodAnnotation(m);
         return methodAnnotation != null &&
@@ -319,14 +318,14 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return annotation;
   }
 
-  Tuple2<ParameterElement, ConstantReader>? _getAnnotation(
+  ({ParameterElement element, ConstantReader reader})? _getAnnotation(
     MethodElement m,
     Type type,
   ) {
     for (final p in m.parameters) {
       final a = _typeChecker(type).firstAnnotationOf(p);
       if (a != null) {
-        return Tuple2(p, ConstantReader(a));
+        return (element: p, reader: ConstantReader(a));
       }
     }
     return null;
@@ -387,7 +386,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
             : MethodModifier.asyncStar
         ..annotations.add(const CodeExpression(Code('override')));
 
-      if (globalOptions.useResult == true) {
+      if (globalOptions.useResult ?? false) {
         final returnType = m.returnType;
         if (returnType is ParameterizedType &&
             returnType.typeArguments.first is! VoidType) {
@@ -402,8 +401,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                 (p) => p
                   ..name = it.name
                   ..named = it.isNamed
-                  ..type =
-                      refer(it.type.getDisplayString(withNullability: true)),
+                  ..type = refer(it.type.getDisplayString()),
               ),
             ),
       );
@@ -418,8 +416,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                       !it.hasDefaultValue)
                   ..name = it.name
                   ..named = it.isNamed
-                  ..type =
-                      refer(it.type.getDisplayString(withNullability: true))
+                  ..type = refer(it.type.getDisplayString())
                   ..defaultTo = it.defaultValueCode == null
                       ? null
                       : Code(it.defaultValueCode!),
@@ -499,12 +496,13 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     /// gen code for request body for content-type on Protobuf body
     final annotation = _getAnnotation(m, retrofit.Body);
-    final bodyName = annotation?.item1;
+    final bodyName = annotation?.element;
     if (bodyName != null) {
       if (const TypeChecker.fromRuntime(GeneratedMessage)
           .isAssignableFromType(bodyName.type)) {
         extraOptions[_contentType] = literal(
-            "application/x-protobuf; \${${bodyName.displayName}.info_.qualifiedMessageName == \"\" ? \"\" :\"messageType=\${${bodyName.displayName}.info_.qualifiedMessageName}\"}");
+          'application/x-protobuf; \${${bodyName.displayName}.info_.qualifiedMessageName == "" ? "" :"messageType=\${${bodyName.displayName}.info_.qualifiedMessageName}"}',
+        );
       }
     }
 
@@ -537,25 +535,27 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final cancelToken = _getAnnotation(m, retrofit.CancelRequest);
     if (cancelToken != null) {
-      namedArguments[_cancelToken] = refer(cancelToken.item1.displayName);
+      namedArguments[_cancelToken] = refer(cancelToken.element.displayName);
     }
 
     final sendProgress = _getAnnotation(m, retrofit.SendProgress);
     if (sendProgress != null) {
-      namedArguments[_onSendProgress] = refer(sendProgress.item1.displayName);
+      namedArguments[_onSendProgress] = refer(sendProgress.element.displayName);
     }
 
     final receiveProgress = _getAnnotation(m, retrofit.ReceiveProgress);
     if (receiveProgress != null) {
       namedArguments[_onReceiveProgress] =
-          refer(receiveProgress.item1.displayName);
+          refer(receiveProgress.element.displayName);
     }
 
     final wrappedReturnType = _getResponseType(m.returnType);
 
-    blocks.add(declareFinal(_optionsVar)
-        .assign(_parseOptions(m, namedArguments, blocks, extraOptions))
-        .statement);
+    blocks.add(
+      declareFinal(_optionsVar)
+          .assign(_parseOptions(m, namedArguments, blocks, extraOptions))
+          .statement,
+    );
 
     final options = refer(_optionsVar).expression;
 
@@ -620,7 +620,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                         innerReturnType,
                         withNullability: innerReturnType?.isNullable ?? false,
                       ),
-                    )
+                    ),
                   ]),
                 )
                 .statement,
@@ -646,7 +646,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                         refer(
                           'deserialize${_displayString(innerReturnType)}List',
                         ),
-                        refer('$_resultVar.data!.cast<Map<String,dynamic>>()')
+                        refer('$_resultVar.data!.cast<Map<String,dynamic>>()'),
                       ]),
                     ),
                   )
@@ -662,7 +662,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                 mapperCode = refer(
                   '(dynamic i) => ${_displayString(innerReturnType)}.fromMap(i as $castType)',
                 );
-                break;
               case retrofit.Parser.JsonSerializable:
                 if (innerReturnType?.isNullable ?? false) {
                   mapperCode = refer(
@@ -673,12 +672,10 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                     '(dynamic i) => ${_displayString(innerReturnType)}.fromJson(i as $castType)',
                   );
                 }
-                break;
               case retrofit.Parser.DartJsonMapper:
                 mapperCode = refer(
                   '(dynamic i) => JsonMapper.fromMap<${_displayString(innerReturnType)}>(i as $castType)!',
                 );
-                break;
               case retrofit.Parser.FlutterCompute:
                 throw Exception('Unreachable code');
             }
@@ -733,7 +730,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                     .toList()
                 )
             ''');
-                break;
               case retrofit.Parser.JsonSerializable:
                 mapperCode = refer('''
             (k, dynamic v) =>
@@ -743,7 +739,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                     .toList()
                 )
             ''');
-                break;
               case retrofit.Parser.DartJsonMapper:
                 mapperCode = refer('''
             (k, dynamic v) =>
@@ -753,7 +748,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
                     .toList()
                 )
             ''');
-                break;
               case retrofit.Parser.FlutterCompute:
                 log.warning('''
 Return types should not be a map when running `Parser.FlutterCompute`, as spawning an isolate per entry is extremely intensive.
@@ -766,7 +760,6 @@ You should create a new class to encapsulate the response.
                     await compute(deserialize${_displayString(type)}List,
                         (e.value as List).cast<Map<String, dynamic>>()))
             ''');
-                break;
             }
             if (future) {
               _wrapInTryCatch(
@@ -778,8 +771,8 @@ You should create a new class to encapsulate the response.
                       refer('Map.fromEntries').call([
                         refer('await Future.wait').call([
                           refer('$_resultVar.data!.entries.map')
-                              .call([mapperCode])
-                        ])
+                              .call([mapperCode]),
+                        ]),
                       ]),
                     )
                     .statement,
@@ -809,18 +802,15 @@ You should create a new class to encapsulate the response.
                 mapperCode = refer(
                   '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromMap(v as Map<String, dynamic>))',
                 );
-                break;
               case retrofit.Parser.JsonSerializable:
                 mapperCode = refer(
                   '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}.fromJson(v as Map<String, dynamic>))',
                 );
 
-                break;
               case retrofit.Parser.DartJsonMapper:
                 mapperCode = refer(
                   '(k, dynamic v) => MapEntry(k, JsonMapper.fromMap<${_displayString(secondType)}>(v as Map<String, dynamic>)!)',
                 );
-                break;
               case retrofit.Parser.FlutterCompute:
                 log.warning('''
 Return types should not be a map when running `Parser.FlutterCompute`, as spawning an isolate per entry is extremely intensive.
@@ -831,7 +821,6 @@ You should create a new class to encapsulate the response.
                 (e) async => MapEntry(
                     e.key, await compute(deserialize${_displayString(secondType)}, e.value as Map<String, dynamic>))
             ''');
-                break;
             }
             if (future) {
               _wrapInTryCatch(
@@ -845,8 +834,8 @@ You should create a new class to encapsulate the response.
                         whenFalse: refer('Map.fromEntries').call([
                           refer('await Future.wait').call([
                             refer('$_resultVar.data!.entries.map')
-                                .call([mapperCode])
-                          ])
+                                .call([mapperCode]),
+                          ]),
                         ]),
                       ),
                     )
@@ -923,14 +912,19 @@ You should create a new class to encapsulate the response.
             )
             ..add(const Code('final $_valueVar = $_resultVar.data;'));
         } else if (_typeChecker(GeneratedMessage).isSuperTypeOf(returnType)) {
-          blocks.add(
-            declareFinal(_resultVar)
-                .assign(
-                    refer("await $_dioVar.fetch<List<int>>").call([options]))
-                .statement,
-          );
-          blocks.add(Code(
-              "final $_valueVar = await compute(${_displayString(returnType)}.fromBuffer, $_resultVar.data!);"));
+          blocks
+            ..add(
+              declareFinal(_resultVar)
+                  .assign(
+                    refer('await $_dioVar.fetch<List<int>>').call([options]),
+                  )
+                  .statement,
+            )
+            ..add(
+              Code(
+                'final $_valueVar = await compute(${_displayString(returnType)}.fromBuffer, $_resultVar.data!);',
+              ),
+            );
         } else {
           final fetchType = returnType.isNullable
               ? 'Map<String,dynamic>?'
@@ -950,7 +944,6 @@ You should create a new class to encapsulate the response.
               mapperCode = refer(
                 '${_displayString(returnType)}.fromMap($_resultVar.data!)',
               );
-              break;
             case retrofit.Parser.JsonSerializable:
               final genericArgumentFactories =
                   isGenericArgumentFactories(returnType);
@@ -975,9 +968,9 @@ You should create a new class to encapsulate the response.
               } else {
                 if (_isEnum(returnType) && !_hasFromJson(returnType)) {
                   mapperCode = refer(
-                    '${_displayString(returnType)}.values.firstWhere((e) => e.name == _result.data,'
-                    'orElse: () => throw ArgumentError('
-                    '\'${_displayString(returnType)} does not contain value \${_result.data}\','
+                    '${_displayString(returnType)}.values.firstWhere((e) => e.name == _result.data, '
+                    'orElse: () => throw ArgumentError( '
+                    "'${_displayString(returnType)} does not contain value \${_result.data}', "
                     '),'
                     ')',
                   );
@@ -987,17 +980,14 @@ You should create a new class to encapsulate the response.
                   );
                 }
               }
-              break;
             case retrofit.Parser.DartJsonMapper:
               mapperCode = refer(
                 'JsonMapper.fromMap<${_displayString(returnType)}>($_resultVar.data!)!',
               );
-              break;
             case retrofit.Parser.FlutterCompute:
               mapperCode = refer(
                 'await compute(deserialize${_displayString(returnType).replaceFirst('<', '').replaceFirst('>', '')}, $_resultVar.data!)',
               );
-              break;
           }
           _wrapInTryCatch(
             blocks,
@@ -1045,7 +1035,9 @@ You should create a new class to encapsulate the response.
         final obj = annotation.peek('genericArgumentFactories');
         // ignore: invalid_null_aware_operator
         genericArgumentFactories = obj?.boolValue ?? false;
-      } catch (_) {}
+      } on Object {
+        // nothing
+      }
     }
 
     return genericArgumentFactories ||
@@ -1055,19 +1047,29 @@ You should create a new class to encapsulate the response.
   /// Checks for a compatible fromJson signature for generic argument factories
   // TODO: But does the code work with multiple generic types?
   bool hasGenericArgumentFactoriesCompatibleSignature(DartType? dartType) {
-    if (dartType == null) return false;
+    if (dartType == null) {
+      return false;
+    }
     final element = dartType.element;
-    if (element is! InterfaceElement) return false;
+    if (element is! InterfaceElement) {
+      return false;
+    }
 
     final typeParameters = element.typeParameters;
-    if (typeParameters.isEmpty) return false;
+    if (typeParameters.isEmpty) {
+      return false;
+    }
 
     final constructors = element.constructors;
-    if (constructors.isEmpty) return false;
+    if (constructors.isEmpty) {
+      return false;
+    }
     final fromJson = constructors
         .firstWhereOrNull((constructor) => constructor.name == 'fromJson');
 
-    if (fromJson == null || fromJson.parameters.length == 1) return false;
+    if (fromJson == null || fromJson.parameters.length == 1) {
+      return false;
+    }
 
     final fromJsonArguments = fromJson.parameters;
 
@@ -1250,7 +1252,7 @@ You should create a new class to encapsulate the response.
 
       final composeArguments = <String, Expression>{
         _queryParamsVar: queryParams,
-        _dataVar: dataVar
+        _dataVar: dataVar,
       };
       if (cancelToken != null) {
         composeArguments[_cancelToken] = cancelToken;
@@ -1275,10 +1277,10 @@ You should create a new class to encapsulate the response.
               _baseUrlVar: refer('_combineBaseUrls').call([
                 refer(_dioVar).property('options').property('baseUrl'),
                 baseUrl,
-              ])
-            })
+              ]),
+            }),
       ], {}, [
-        type
+        type,
       ]);
     } else {
       hasCustomOptions = true;
@@ -1286,7 +1288,7 @@ You should create a new class to encapsulate the response.
         declareFinal('newOptions')
             .assign(
               refer('newRequestOptions')
-                  .call([refer(annoOptions.item1.displayName)]),
+                  .call([refer(annoOptions.element.displayName)]),
             )
             .statement,
       );
@@ -1383,7 +1385,7 @@ You should create a new class to encapsulate the response.
           ..returns = refer('String')
           ..requiredParameters =
               ListBuilder(<Parameter>[dioBaseUrlParam, baseUrlParam])
-          ..body = const Code(r'''
+          ..body = const Code('''
             if (baseUrl == null || baseUrl.trim().isEmpty) {
               return dioBaseUrl;
             }
@@ -1506,20 +1508,16 @@ if (T != dynamic &&
                   ? refer(p.displayName).nullSafeProperty('toJson').call([])
                   : refer(p.displayName).property('toJson').call([]);
             }
-            break;
           case retrofit.Parser.MapSerializable:
             value = p.type.nullabilitySuffix == NullabilitySuffix.question
                 ? refer(p.displayName).nullSafeProperty('toMap').call([])
                 : refer(p.displayName).property('toMap').call([]);
-            break;
           case retrofit.Parser.DartJsonMapper:
             value = refer(p.displayName);
-            break;
           case retrofit.Parser.FlutterCompute:
             value = refer(
               'await compute(serialize${_displayString(p.type)}, ${p.displayName})',
             );
-            break;
         }
       }
       return MapEntry(literalString(key, raw: true), value);
@@ -1549,20 +1547,16 @@ if (T != dynamic &&
             value = p.type.nullabilitySuffix == NullabilitySuffix.question
                 ? refer(displayName).nullSafeProperty('toJson').call([])
                 : refer(displayName).property('toJson').call([]);
-            break;
           case retrofit.Parser.MapSerializable:
             value = p.type.nullabilitySuffix == NullabilitySuffix.question
                 ? refer(displayName).nullSafeProperty('toMap').call([])
                 : refer(displayName).property('toMap').call([]);
-            break;
           case retrofit.Parser.DartJsonMapper:
             value = refer(displayName);
-            break;
           case retrofit.Parser.FlutterCompute:
             value = refer(
               'await compute(serialize${_displayString(p.type)}, ${p.displayName})',
             );
-            break;
         }
       }
 
@@ -1609,10 +1603,10 @@ if (T != dynamic &&
         _getMethodAnnotationByType(m, retrofit.PreventNullToAbsent);
 
     final annotation = _getAnnotation(m, retrofit.Body);
-    final bodyName = annotation?.item1;
+    final bodyName = annotation?.element;
     if (bodyName != null) {
       final nullToAbsent =
-          annotation!.item2.peek('nullToAbsent')?.boolValue ?? false;
+          annotation!.reader.peek('nullToAbsent')?.boolValue ?? false;
       final bodyTypeElement = bodyName.type.element;
       if (const TypeChecker.fromRuntime(Map)
           .isAssignableFromType(bodyName.type)) {
@@ -1626,7 +1620,7 @@ if (T != dynamic &&
             refer('$dataVar.addAll').call([
               refer(
                 "${bodyName.displayName}${m.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''}",
-              )
+              ),
             ]).statement,
           );
         if (preventNullToAbsent == null && nullToAbsent) {
@@ -1648,7 +1642,6 @@ if (T != dynamic &&
                   )
                   .statement,
             );
-            break;
           case retrofit.Parser.MapSerializable:
             blocks.add(
               declareFinal(dataVar)
@@ -1659,7 +1652,6 @@ if (T != dynamic &&
                   )
                   .statement,
             );
-            break;
           case retrofit.Parser.FlutterCompute:
             blocks.add(
               declareFinal(dataVar)
@@ -1670,16 +1662,18 @@ if (T != dynamic &&
                   )
                   .statement,
             );
-            break;
         }
       } else if (_typeChecker(GeneratedMessage).isSuperTypeOf(bodyName.type)) {
         if (bodyName.type.nullabilitySuffix != NullabilitySuffix.none) {
           log.warning(
-              "GeneratedMessage body ${_displayString(bodyName.type)} can not be nullable.");
+            'GeneratedMessage body ${_displayString(bodyName.type)} can not be nullable.',
+          );
         }
-        blocks.add(declareFinal(dataVar)
-            .assign(refer("${bodyName.displayName}.writeToBuffer()"))
-            .statement);
+        blocks.add(
+          declareFinal(dataVar)
+              .assign(refer('${bodyName.displayName}.writeToBuffer()'))
+              .statement,
+        );
       } else if (bodyTypeElement != null &&
           _typeChecker(File).isExactly(bodyTypeElement)) {
         blocks.add(
@@ -1694,7 +1688,8 @@ if (T != dynamic &&
       } else if (bodyName.type.element is ClassElement) {
         final ele = bodyName.type.element! as ClassElement;
         if (clientAnnotation.parser == retrofit.Parser.MapSerializable) {
-          final toMap = ele.lookUpMethod('toMap', ele.library);
+          final toMap =
+              ele.augmented.lookUpMethod(name: 'toMap', library: ele.library);
           if (toMap == null) {
             log.warning(
                 '${_displayString(bodyName.type)} must provide a `toMap()` method which return a Map.\n'
@@ -1716,7 +1711,7 @@ if (T != dynamic &&
                   [
                     refer(
                       '${bodyName.displayName}?.toMap() ?? <String,dynamic>{}',
-                    )
+                    ),
                   ],
                 ).statement,
               );
@@ -1767,7 +1762,7 @@ if (T != dynamic &&
                     NullabilitySuffix.question) {
                   blocks.add(
                     refer('$dataVar.addAll').call([
-                      refer('${bodyName.displayName}.toJson($toJsonCode)')
+                      refer('${bodyName.displayName}.toJson($toJsonCode)'),
                     ]).statement,
                   );
                 } else {
@@ -1775,11 +1770,10 @@ if (T != dynamic &&
                     refer('$dataVar.addAll').call([
                       refer(
                         '${bodyName.displayName}?.toJson($toJsonCode) ?? <String,dynamic>{}',
-                      )
+                      ),
                     ]).statement,
                   );
                 }
-                break;
               case retrofit.Parser.FlutterCompute:
                 if (bodyName.type.nullabilitySuffix !=
                     NullabilitySuffix.question) {
@@ -1787,7 +1781,7 @@ if (T != dynamic &&
                     refer('$dataVar.addAll').call([
                       refer(
                         'await compute(serialize${_displayString(bodyName.type)}, ${bodyName.displayName})',
-                      )
+                      ),
                     ]).statement,
                   );
                 } else {
@@ -1797,11 +1791,10 @@ if (T != dynamic &&
 ${bodyName.displayName} == null
                       ? <String, dynamic>{}
                       : await compute(serialize${_displayString(bodyName.type)}, ${bodyName.displayName})
-                  ''')
+                  '''),
                     ]).statement,
                   );
                 }
-                break;
               case retrofit.Parser.MapSerializable:
                 // Unreachable code
                 break;
@@ -1880,14 +1873,14 @@ ${bodyName.displayName} == null
                   .property('path.split(Platform.pathSeparator).last');
 
           final uploadFileInfo = refer('$MultipartFile.fromFileSync').call([
-            refer(p.displayName).property('path')
+            refer(p.displayName).property('path'),
           ], {
             'filename': fileName,
             if (contentType != null)
               'contentType':
                   refer('MediaType', 'package:http_parser/http_parser.dart')
                       .property('parse')
-                      .call([literal(contentType)])
+                      .call([literal(contentType)]),
           });
 
           final optionalFile = m.parameters
@@ -1897,7 +1890,7 @@ ${bodyName.displayName} == null
 
           final returnCode =
               refer(dataVar).property('files').property('add').call([
-            refer('MapEntry').newInstance([literal(fieldName), uploadFileInfo])
+            refer('MapEntry').newInstance([literal(fieldName), uploadFileInfo]),
           ]).statement;
           if (optionalFile) {
             final condition = refer(p.displayName).notEqualTo(literalNull).code;
@@ -1907,7 +1900,7 @@ ${bodyName.displayName} == null
                 condition,
                 const Code(') {'),
                 returnCode,
-                const Code('}')
+                const Code('}'),
               ],
             );
           } else {
@@ -1932,7 +1925,7 @@ ${bodyName.displayName} == null
                 filename:${literal(fileName)},
                     $conType
                     ))
-                  ''')
+                  '''),
           ]).statement;
           if (optionalFile) {
             final condition = refer(p.displayName).notEqualTo(literalNull).code;
@@ -1942,7 +1935,7 @@ ${bodyName.displayName} == null
                 condition,
                 const Code(') {'),
                 returnCode,
-                const Code('}')
+                const Code('}'),
               ],
             );
           } else {
@@ -1966,7 +1959,7 @@ ${bodyName.displayName} == null
                     filename:${literal(fileName)},
                     $conType
                     )))
-                  ''')
+                  '''),
               ]).statement,
             );
           } else if (_isBasicType(innerType) ||
@@ -2004,7 +1997,7 @@ ${bodyName.displayName} == null
                     filename: i.path.split(Platform.pathSeparator).last,
                     $conType
                     )))
-                  ''')
+                  '''),
               ]).statement,
             );
             if (p.type.isNullable) {
@@ -2021,7 +2014,7 @@ ${bodyName.displayName} == null
                   ${p.displayName}.map((i) => MapEntry(
                 '$fieldName',
                 i))
-                  ''')
+                  '''),
               ]).statement,
             );
             if (p.type.isNullable) {
@@ -2032,13 +2025,12 @@ ${bodyName.displayName} == null
             if (_missingToJson(ele)) {
               if (_isDateTime(p.type)) {
                 final expr = [
-                  p.type.nullabilitySuffix == NullabilitySuffix.question
-                      ? refer(p.displayName)
-                          .nullSafeProperty('toIso8601String')
-                          .call([])
-                      : refer(p.displayName)
-                          .property('toIso8601String')
-                          .call([])
+                  if (p.type.nullabilitySuffix == NullabilitySuffix.question)
+                    refer(p.displayName)
+                        .nullSafeProperty('toIso8601String')
+                        .call([])
+                  else
+                    refer(p.displayName).property('toIso8601String').call([]),
                 ];
                 refer(dataVar).property('fields').property('add').call(expr);
               } else {
@@ -2049,8 +2041,8 @@ ${bodyName.displayName} == null
                 refer(dataVar).property('fields').property('add').call([
                   refer('MapEntry').newInstance([
                     literal(fieldName),
-                    refer('jsonEncode(${p.displayName})')
-                  ])
+                    refer('jsonEncode(${p.displayName})'),
+                  ]),
                 ]).statement,
               );
             }
@@ -2070,8 +2062,8 @@ ${bodyName.displayName} == null
                 else if (_isEnum(p.type))
                   refer(p.displayName).property('name')
                 else
-                  refer(p.displayName).property('toString').call([])
-              ])
+                  refer(p.displayName).property('toString').call([]),
+              ]),
             ]).statement,
           );
           if (p.type.nullabilitySuffix == NullabilitySuffix.question) {
@@ -2083,7 +2075,7 @@ ${bodyName.displayName} == null
             refer(dataVar).property('fields').property('add').call([
               refer('MapEntry').newInstance(
                 [literal(fieldName), refer('jsonEncode(${p.displayName})')],
-              )
+              ),
             ]).statement,
           );
         } else if (p.type.element is ClassElement) {
@@ -2091,11 +2083,12 @@ ${bodyName.displayName} == null
           if (_missingToJson(ele)) {
             if (_isDateTime(p.type)) {
               final expr = [
-                p.type.nullabilitySuffix == NullabilitySuffix.question
-                    ? refer(p.displayName)
-                        .nullSafeProperty('toIso8601String')
-                        .call([])
-                    : refer(p.displayName).property('toIso8601String').call([])
+                if (p.type.nullabilitySuffix == NullabilitySuffix.question)
+                  refer(p.displayName)
+                      .nullSafeProperty('toIso8601String')
+                      .call([])
+                else
+                  refer(p.displayName).property('toIso8601String').call([]),
               ];
               refer(dataVar).property('fields').property('add').call(expr);
             } else {
@@ -2106,12 +2099,12 @@ ${bodyName.displayName} == null
               final uploadFileInfo = refer('$MultipartFile.fromString').call([
                 refer(
                   "jsonEncode(${p.displayName}${p.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''})",
-                )
+                ),
               ], {
                 'contentType':
                     refer('MediaType', 'package:http_parser/http_parser.dart')
                         .property('parse')
-                        .call([literal(contentType)])
+                        .call([literal(contentType)]),
               });
 
               final optionalFile = m.parameters
@@ -2122,7 +2115,7 @@ ${bodyName.displayName} == null
               final returnCode =
                   refer(dataVar).property('files').property('add').call([
                 refer('MapEntry')
-                    .newInstance([literal(fieldName), uploadFileInfo])
+                    .newInstance([literal(fieldName), uploadFileInfo]),
               ]).statement;
               if (optionalFile) {
                 final condition =
@@ -2133,7 +2126,7 @@ ${bodyName.displayName} == null
                     condition,
                     const Code(') {'),
                     returnCode,
-                    const Code('}')
+                    const Code('}'),
                   ],
                 );
               } else {
@@ -2146,8 +2139,8 @@ ${bodyName.displayName} == null
                     literal(fieldName),
                     refer(
                       "jsonEncode(${p.displayName}${p.type.nullabilitySuffix == NullabilitySuffix.question ? ' ?? <String,dynamic>{}' : ''})",
-                    )
-                  ])
+                    ),
+                  ]),
                 ]).statement,
               );
             }
@@ -2156,7 +2149,7 @@ ${bodyName.displayName} == null
           blocks.add(
             refer(dataVar).property('fields').property('add').call([
               refer('MapEntry')
-                  .newInstance([literal(fieldName), refer(p.displayName)])
+                  .newInstance([literal(fieldName), refer(p.displayName)]),
             ]).statement,
           );
         }
@@ -2165,7 +2158,7 @@ ${bodyName.displayName} == null
     }
 
     /// There is no body
-    if (globalOptions.emptyRequestBody == true) {
+    if (globalOptions.emptyRequestBody ?? false) {
       blocks.add(
         declareFinal(dataVar)
             .assign(literalMap({}, refer('String'), refer('dynamic')))
@@ -2189,13 +2182,13 @@ ${bodyName.displayName} == null
               dynamic val;
               if (v == null) {
                 val = null;
-              } else if (v.type?.isDartCoreBool == true) {
+              } else if (v.type?.isDartCoreBool ?? false) {
                 val = v.toBoolValue();
-              } else if (v.type?.isDartCoreString == true) {
+              } else if (v.type?.isDartCoreString ?? false) {
                 val = v.toStringValue();
-              } else if (v.type?.isDartCoreDouble == true) {
+              } else if (v.type?.isDartCoreDouble ?? false) {
                 val = v.toDoubleValue();
-              } else if (v.type?.isDartCoreInt == true) {
+              } else if (v.type?.isDartCoreInt ?? false) {
                 val = v.toIntValue();
               } else {
                 val = v.toStringValue();
@@ -2224,12 +2217,15 @@ ${bodyName.displayName} == null
 
     if (returnType != null &&
         _typeChecker(GeneratedMessage).isAssignableFromType(returnType)) {
-      headers.removeWhere(
-          (key, value) => "accept".toLowerCase() == key.toLowerCase());
-      headers.addAll({
-        "accept": literal(
-            "application/x-protobuf; \${${_displayString(returnType)}.getDefault().info_.qualifiedMessageName == \"\" ? \"\" :\"messageType=\${${_displayString(returnType)}.getDefault().info_.qualifiedMessageName}\"}")
-      });
+      headers
+        ..removeWhere(
+          (key, value) => 'accept'.toLowerCase() == key.toLowerCase(),
+        )
+        ..addAll({
+          'accept': literal(
+            'application/x-protobuf; \${${_displayString(returnType)}.getDefault().info_.qualifiedMessageName == "" ? "" :"messageType=\${${_displayString(returnType)}.getDefault().info_.qualifiedMessageName}"}',
+          ),
+        });
     }
 
     return headers;
@@ -2264,7 +2260,7 @@ ${bodyName.displayName} == null
         if (noStore ?? false) 'no-store' else '',
         if (noTransform ?? false) 'no-transform' else '',
         if (onlyIfCached ?? false) 'only-if-cached' else '',
-        ...otherResult
+        ...otherResult,
       ];
 
       final value = values.where((element) => element != '').join(', ');
@@ -2334,20 +2330,16 @@ ${bodyName.displayName} == null
             value = p.type.nullabilitySuffix == NullabilitySuffix.question
                 ? refer(displayName).nullSafeProperty('toJson').call([])
                 : refer(displayName).property('toJson').call([]);
-            break;
           case retrofit.Parser.MapSerializable:
             value = p.type.nullabilitySuffix == NullabilitySuffix.question
                 ? refer(displayName).nullSafeProperty('toMap').call([])
                 : refer(displayName).property('toMap').call([]);
-            break;
           case retrofit.Parser.DartJsonMapper:
             value = refer(displayName);
-            break;
           case retrofit.Parser.FlutterCompute:
             value = refer(
               'await compute(serialize${_displayString(p.type)}, ${p.displayName})',
             );
-            break;
         }
       }
 
@@ -2367,7 +2359,8 @@ ${bodyName.displayName} == null
     switch (clientAnnotation.parser) {
       case retrofit.Parser.JsonSerializable:
       case retrofit.Parser.DartJsonMapper:
-        final toJson = ele.lookUpMethod('toJson', ele.library);
+        final toJson =
+            ele.augmented.lookUpMethod(name: 'toJson', library: ele.library);
         return toJson == null;
       case retrofit.Parser.MapSerializable:
       case retrofit.Parser.FlutterCompute:
@@ -2393,7 +2386,11 @@ ${bodyName.displayName} == null
   }
 
   void _wrapInTryCatch(
-      List<Code> blocks, Expression options, DartType? returnType, Code child) {
+    List<Code> blocks,
+    Expression options,
+    DartType? returnType,
+    Code child,
+  ) {
     blocks.addAll(
       [
         declareVar(
@@ -2401,12 +2398,12 @@ ${bodyName.displayName} == null
           type: refer(_displayString(returnType, withNullability: true)),
           late: true,
         ).statement,
-        Code('try {'),
+        const Code('try {'),
         child,
-        Code('} on Object catch (e, s) {'),
-        Code('$_errorLoggerVar?.logError(e, s, $_optionsVar);'),
-        Code('rethrow;'),
-        Code('}'),
+        const Code('} on Object catch (e, s) {'),
+        const Code('$_errorLoggerVar?.logError(e, s, $_optionsVar);'),
+        const Code('rethrow;'),
+        const Code('}'),
       ],
     );
   }
@@ -2554,9 +2551,17 @@ extension DartTypeStreamAnnotation on DartType {
 
 String _displayString(DartType? e, {bool withNullability = false}) {
   try {
-    return e!.getDisplayString(withNullability: withNullability);
+    if (!withNullability) {
+      return e!.toStringNonNullable();
+    } else {
+      return e!.getDisplayString();
+    }
   } on TypeError {
-    return e!.getDisplayString(withNullability: withNullability);
+    if (!withNullability) {
+      return e!.toStringNonNullable();
+    } else {
+      return e!.getDisplayString();
+    }
   } on Object {
     rethrow;
   }
@@ -2564,6 +2569,14 @@ String _displayString(DartType? e, {bool withNullability = false}) {
 
 extension DartTypeExt on DartType {
   bool get isNullable => nullabilitySuffix == NullabilitySuffix.question;
+
+  String toStringNonNullable() {
+    final val = getDisplayString();
+    if (val.endsWith('?')) {
+      return val.substring(0, val.length - 1);
+    }
+    return val;
+  }
 }
 
 extension ReferenceExt on Reference {

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   dart_style: ^2.3.0
   dio: ^5.0.0
   protobuf: ^3.1.0
-  retrofit: ^4.2.0
+  retrofit: ^4.3.0
   source_gen: ^1.5.0
 
 dev_dependencies:

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -3,26 +3,27 @@ description: retrofit generator is an dio client generator using source_gen and 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
 topics:
+  - retrofit
   - build-runner
   - codegen
   - api
-version: 8.1.0
+version: 8.2.0
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  analyzer: '>=5.13.0 <7.0.0'
-  build: ^2.3.1
+  analyzer: ^6.5.0
+  build: ^2.4.1
   built_collection: ^5.1.1
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit: ^4.2.0
-  source_gen: ^1.3.0
-  tuple: ^2.0.1
   protobuf: ^3.1.0
+  retrofit: ^4.2.0
+  source_gen: ^1.5.0
 
 dev_dependencies:
-  lints: ^2.0.1
-  source_gen_test: ^1.0.5
-  test: ^1.24.0
+  build_runner:
+  lints: ^4.0.0
+  source_gen_test: ^1.0.6
+  test: ^1.25.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - build-runner
   - codegen
   - api
-version: 8.2.0
+version: 9.0.0
 environment:
   sdk: '>=3.3.0 <4.0.0'
 
@@ -23,7 +23,6 @@ dependencies:
   source_gen: ^1.5.0
 
 dev_dependencies:
-  build_runner:
   lints: ^4.0.0
   source_gen_test: ^1.0.6
   test: ^1.25.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -3,10 +3,11 @@ description: retrofit generator is an dio client generator using source_gen and 
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
 topics:
-  - retrofit
-  - build-runner
-  - codegen
   - api
+  - http
+  - rest
+  - retrofit
+  - codegen
 version: 9.0.0
 environment:
   sdk: '>=3.3.0 <4.0.0'

--- a/generator/test/src/query.pb.dart
+++ b/generator/test/src/query.pb.dart
@@ -1,8 +1,6 @@
 //
 //  Generated code. Do not modify.
 //  source: proto/params.proto
-//
-// @dart = 2.12
 
 // ignore_for_file: annotate_overrides, camel_case_types, comment_references
 // ignore_for_file: constant_identifier_names, library_prefixes
@@ -24,24 +22,28 @@ class Params extends $pb.GeneratedMessage {
     return $result;
   }
   Params._() : super();
-  factory Params.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Params.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory Params.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Params.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Params', createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Params',
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Params clone() => Params()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Params copyWith(void Function(Params) updates) => super.copyWith((message) => updates(message as Params)) as Params;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Params copyWith(void Function(Params) updates) =>
+      super.copyWith((message) => updates(message as Params)) as Params;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -50,13 +52,17 @@ class Params extends $pb.GeneratedMessage {
   Params createEmptyInstance() => create();
   static $pb.PbList<Params> createRepeated() => $pb.PbList<Params>();
   @$core.pragma('dart2js:noInline')
-  static Params getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Params>(create);
+  static Params getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Params>(create);
   static Params? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get key => $_getSZ(0);
   @$pb.TagNumber(1)
-  set key($core.String v) { $_setString(0, v); }
+  set key($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasKey() => $_has(0);
   @$pb.TagNumber(1)
@@ -74,24 +80,28 @@ class Result extends $pb.GeneratedMessage {
     return $result;
   }
   Result._() : super();
-  factory Result.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Result.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory Result.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Result.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Result', createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Result',
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'value')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Result clone() => Result()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Result copyWith(void Function(Result) updates) => super.copyWith((message) => updates(message as Result)) as Result;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Result copyWith(void Function(Result) updates) =>
+      super.copyWith((message) => updates(message as Result)) as Result;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -100,19 +110,23 @@ class Result extends $pb.GeneratedMessage {
   Result createEmptyInstance() => create();
   static $pb.PbList<Result> createRepeated() => $pb.PbList<Result>();
   @$core.pragma('dart2js:noInline')
-  static Result getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Result>(create);
+  static Result getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Result>(create);
   static Result? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get value => $_getSZ(0);
   @$pb.TagNumber(1)
-  set value($core.String v) { $_setString(0, v); }
+  set value($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
   void clearValue() => clearField(1);
 }
 
-
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/retrofit/CHANGELOG.md
+++ b/retrofit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.3.0
+
+- Required Dart 2.19
+- Update README
+
 ## 4.1.0
 
 - Added `@Extras` to pass extra options to dio requests, response, transformer and interceptors.

--- a/retrofit/lib/error_logger.dart
+++ b/retrofit/lib/error_logger.dart
@@ -3,7 +3,7 @@ import 'package:dio/dio.dart';
 /// Base class for logging errors that occur during parsing of response data.
 abstract class ParseErrorLogger {
   /// Logs an error that occurred during parsing of response data.
-  /// 
+  ///
   /// - [error] is the error that occurred.
   /// - [stackTrace] is the stack trace of the error.
   /// - [options] are the options that were used to make the request.

--- a/retrofit/lib/http.dart
+++ b/retrofit/lib/http.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: constant_identifier_names
 import 'package:meta/meta.dart';
 
 /// A holder that includes all http methods which are supported by retrofit.

--- a/retrofit/lib/retrofit.dart
+++ b/retrofit/lib/retrofit.dart
@@ -1,3 +1,3 @@
 export 'dio.dart';
-export 'http.dart';
 export 'error_logger.dart';
+export 'http.dart';

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -2,8 +2,13 @@ name: retrofit
 description: retrofit.dart is an dio client generator using source_gen and inspired by Chopper and Retrofit.
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
+topics:
+  - api
+  - http
+  - rest
+  - dio
+  - retrofit
 version: 4.3.0
-
 environment:
   sdk: '>=2.19.0 <4.0.0'
 

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -2,7 +2,7 @@ name: retrofit
 description: retrofit.dart is an dio client generator using source_gen and inspired by Chopper and Retrofit.
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
-version: 4.1.0
+version: 4.2.0
 
 environment:
   sdk: '>=2.17.0 <4.0.0'
@@ -12,4 +12,4 @@ dependencies:
   meta: ^1.8.0
 
 dev_dependencies:
-  lints: ^2.0.1
+  lints: ^4.0.0

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -2,10 +2,10 @@ name: retrofit
 description: retrofit.dart is an dio client generator using source_gen and inspired by Chopper and Retrofit.
 homepage: https://mings.in/retrofit.dart/
 repository: https://github.com/trevorwang/retrofit.dart/
-version: 4.2.0
+version: 4.3.0
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
   dio: ^5.0.0


### PR DESCRIPTION
In analyzer 6.5.0 they remove support for `getDisplayString(withNullability: false)`:
`String getDisplayString` Only non-nullable by default mode is supported.

Analyzer 6.5.0 and higher support Dart ^3.3 and I also update sdk and replace tuple with records