### PR TITLE
Feat: Enable passing in Extras using Custom Annotations

### DIFF
--- a/example_dartmapper/pubspec.yaml
+++ b/example_dartmapper/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   reflectable: ^3.0.0
 
 dev_dependencies:
-  test: 1.16.5
+  test: 1.24.0
   retrofit_generator:
   build_runner: ^2.0.1
   json_serializable: ^4.0.3

--- a/example_dartmapper/pubspec.yaml
+++ b/example_dartmapper/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   reflectable: ^3.0.0
 
 dev_dependencies:
-  test: 1.24.0
+  test: 1.16.5
   retrofit_generator:
   build_runner: ^2.0.1
   json_serializable: ^4.0.3

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 9.1.0
+
+- Added `@TypedExtras` to pass extra options to dio requests using custom annotations.
+
+  Example :
+
+  ```dart
+  @TypedExtrasSubClass(
+    id: 'abcd',
+    count: 5,
+    shouldProceed: true,
+  )
+  @http.POST('/path/')
+  Future<String> myMethod(@Extras() Map<String, dynamic> extras);
+  ```
+
 ## 9.0.0
 
 - Require Dart 3.3

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2274,6 +2274,43 @@ ${bodyName.displayName} == null
     return result;
   }
 
+  dynamic _getFieldValue(ConstantReader? value) {
+    if (value?.isBool ?? false) return value?.boolValue;
+    if (value?.isDouble ?? false) return value?.doubleValue;
+    if (value?.isInt ?? false) return value?.intValue;
+    if (value?.isString ?? false) return value?.stringValue;
+    if (value?.isList ?? false) {
+      return value?.listValue.map((item) => _getFieldValue(ConstantReader(item))).toList();
+    }
+    if (value?.isMap ?? false) {
+      final mapValue = value?.mapValue.map((key, val) {
+        return MapEntry(
+          _getFieldValue(ConstantReader(key)),
+          _getFieldValue(ConstantReader(val)),
+        );
+      });
+      return mapValue;
+    }
+    if (value?.isSet ?? false) {
+      return value?.setValue.map((item) {
+        return _getFieldValue(ConstantReader(item));
+      }).toSet();
+    }
+    return null;
+  }
+
+  Map<String, Object> _getExtrasFromClass(MethodElement m) {
+    final annotation = _getMethodAnnotations(m, retrofit.TypedExtra).firstOrNull;
+    final fields = annotation?.objectValue.type?.element?.children
+        .whereType<FieldElement>();
+    Map<String, Object> extraFromClass = {};
+    for (var field in fields ?? <FieldElement>[]) {
+      final value = annotation?.peek(field.name);
+      extraFromClass[field.name] = _getFieldValue(value);
+    }
+    return extraFromClass;
+  }
+
   void _generateExtra(
     MethodElement m,
     List<Code> blocks,
@@ -2309,7 +2346,9 @@ ${bodyName.displayName} == null
                       ),
                     ),
                   )
-                  .fold<Map<String, Object>>({}, (p, e) => p..addAll(e ?? {})),
+                  .fold<Map<String, Object>>({}, (p, e) {
+                    return p..addAll(e ?? {});
+                  })..addAll(_getExtrasFromClass(m)),
               refer('String'),
               refer('dynamic'),
             ),

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2306,7 +2306,10 @@ ${bodyName.displayName} == null
     Map<String, Object> mapFromTypedExtras = {};
     for (var field in fields ?? <FieldElement>[]) {
       final value = annotation?.peek(field.name);
-      mapFromTypedExtras[field.name] = _getFieldValue(value);
+      final fieldValue = _getFieldValue(value);
+      if (fieldValue != null) {
+        mapFromTypedExtras[field.name] = fieldValue;
+      }
     }
     return mapFromTypedExtras;
   }

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2300,7 +2300,7 @@ ${bodyName.displayName} == null
   }
 
   Map<String, Object> _getExtrasFromClass(MethodElement m) {
-    final annotation = _getMethodAnnotations(m, retrofit.TypedExtra).firstOrNull;
+    final annotation = _getMethodAnnotations(m, retrofit.TypedExtras).firstOrNull;
     final fields = annotation?.objectValue.type?.element?.children
         .whereType<FieldElement>();
     Map<String, Object> extraFromClass = {};

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1433,7 +1433,9 @@ if (T != dynamic &&
         _typeChecker(double).isExactlyType(returnType) ||
         _typeChecker(num).isExactlyType(returnType) ||
         _typeChecker(Double).isExactlyType(returnType) ||
-        _typeChecker(Float).isExactlyType(returnType);
+        _typeChecker(Float).isExactlyType(returnType) ||
+        _typeChecker(BigInt).isExactlyType(returnType) ||
+        _typeChecker(Long).isExactlyType(returnType);
   }
 
   bool _isEnum(DartType? dartType) {

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2299,16 +2299,16 @@ ${bodyName.displayName} == null
     return null;
   }
 
-  Map<String, Object> _getExtrasFromClass(MethodElement m) {
+  Map<String, Object> _getMapFromTypedExtras(MethodElement m) {
     final annotation = _getMethodAnnotations(m, retrofit.TypedExtras).firstOrNull;
     final fields = annotation?.objectValue.type?.element?.children
         .whereType<FieldElement>();
-    Map<String, Object> extraFromClass = {};
+    Map<String, Object> mapFromTypedExtras = {};
     for (var field in fields ?? <FieldElement>[]) {
       final value = annotation?.peek(field.name);
-      extraFromClass[field.name] = _getFieldValue(value);
+      mapFromTypedExtras[field.name] = _getFieldValue(value);
     }
-    return extraFromClass;
+    return mapFromTypedExtras;
   }
 
   void _generateExtra(
@@ -2348,7 +2348,7 @@ ${bodyName.displayName} == null
                   )
                   .fold<Map<String, Object>>({}, (p, e) {
                     return p..addAll(e ?? {});
-                  })..addAll(_getExtrasFromClass(m)),
+                  })..addAll(_getMapFromTypedExtras(m)),
               refer('String'),
               refer('dynamic'),
             ),

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - retrofit
   - codegen
-version: 9.0.0
+version: 9.1.0
 environment:
   sdk: '>=3.3.0 <4.0.0'
 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -21,10 +21,8 @@ dependencies:
   dio: ^5.0.0
   retrofit:
     path: ../retrofit
-  source_gen: ^1.3.0
   tuple: ^2.0.1
   protobuf: ^3.1.0
-  retrofit: ^4.3.0
   source_gen: ^1.5.0
 
 dev_dependencies:

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -8,7 +8,8 @@ topics:
   - api
 version: 8.1.0
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
+publish_to: none
 
 dependencies:
   analyzer: '>=5.13.0 <7.0.0'
@@ -17,7 +18,11 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit: ^4.2.0
+  retrofit:
+    git: 
+      url: https://github.com/farmery/retrofit.git
+      path: retrofit
+      ref: feat/typed-extras
   source_gen: ^1.3.0
   tuple: ^2.0.1
   protobuf: ^3.1.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -17,7 +17,8 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit: ^4.2.0
+  retrofit:
+    path: ../retrofit
   source_gen: ^1.3.0
   tuple: ^2.0.1
   protobuf: ^3.1.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit: ^4.1.0
+  retrofit: ^4.2.0
   source_gen: ^1.3.0
   tuple: ^2.0.1
   protobuf: ^3.1.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -17,11 +17,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   dio: ^5.0.0
-  retrofit:
-    git: 
-      url: https://github.com/farmery/retrofit.git
-      path: retrofit
-      ref: feat/typed-extras
+  retrofit: ^4.2.0
   source_gen: ^1.3.0
   tuple: ^2.0.1
   protobuf: ^3.1.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -9,7 +9,6 @@ topics:
 version: 8.1.0
 environment:
   sdk: '>=3.0.0 <4.0.0'
-publish_to: none
 
 dependencies:
   analyzer: '>=5.13.0 <7.0.0'

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -10,12 +10,14 @@ class DummyTypedExtras extends TypedExtras {
   final List<String> fileTypes;
   final Set<String> sources;
   final bool shouldProceed;
+  final bool? canFly;
   const DummyTypedExtras({
     required this.id,
     required this.config,
     required this.fileTypes,
     required this.sources,
     required this.shouldProceed,
+    this.canFly,
   });
 }
 

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -4,7 +4,7 @@ import 'package:source_gen_test/annotations.dart';
 import 'package:retrofit/retrofit.dart';
 import 'query.pb.dart';
 
-class DummyTypedExtras extends TypedExtra {
+class DummyTypedExtras extends TypedExtras {
   final String id;
   final Map<String, dynamic> config;
   final List<String> fileTypes;
@@ -44,7 +44,7 @@ class DummyTypedExtras extends TypedExtra {
   contains: true,
 )
 @RestApi()
-abstract class TypedExtraTest {
+abstract class TypedExtrasTest {
   @DummyTypedExtras(
     id: '1234',
     config: {

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1,10 +1,72 @@
 import 'dart:io';
-
 import 'package:dio/dio.dart' hide Headers;
-import 'package:retrofit/retrofit.dart';
 import 'package:source_gen_test/annotations.dart';
-
+import 'package:retrofit/retrofit.dart';
 import 'query.pb.dart';
+
+class DummyTypedExtras extends TypedExtra {
+  final String id;
+  final Map<String, dynamic> config;
+  final List<String> fileTypes;
+  final Set<String> sources;
+  final bool shouldProceed;
+  const DummyTypedExtras({
+    required this.id,
+    required this.config,
+    required this.fileTypes,
+    required this.sources,
+    required this.shouldProceed,
+  });
+}
+
+@ShouldGenerate(
+  '''
+    final _extra = <String, dynamic>{
+      'id': '1234',
+      'config': {
+        'date': '24-10-2024',
+        'type': 'analytics',
+        'shouldReplace': true,
+        'subConfig': {'date': '24-11-2025'},
+      },
+      'fileTypes': [
+        'mp4',
+        'mp3',
+        'mkv',
+      ],
+      'sources': {
+        'internet',
+        'local',
+      },
+      'shouldProceed': true,
+    };
+  ''',
+  contains: true,
+)
+@RestApi()
+abstract class TypedExtraTest {
+  @DummyTypedExtras(
+    id: '1234',
+    config: {
+      'date': '24-10-2024',
+      'type': 'analytics',
+      'shouldReplace': true,
+      'subConfig': {'date': '24-11-2025'},
+    },
+    fileTypes: [
+      'mp4',
+      'mp3',
+      'mkv',
+    ],
+    sources: {
+      'internet',
+      'local',
+    },
+    shouldProceed: true,
+  )
+  @GET('path')
+  Future<void> list();
+}
 
 @ShouldGenerate(
   '''

--- a/retrofit/CHANGELOG.md
+++ b/retrofit/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 4.4.0
+
+- Added `@TypedExtras` to pass extra options to dio requests using custom annotations.
+
+  Example :
+
+  ```dart
+  @TypedExtrasSubClass(
+    id: 'abcd',
+    count: 5,
+    shouldProceed: true,
+  )
+  @http.POST('/path/')
+  Future<String> myMethod(@Extras() Map<String, dynamic> extras);
+  ```
+
 ## 4.3.0
 
 - Required Dart 2.19

--- a/retrofit/lib/dio.dart
+++ b/retrofit/lib/dio.dart
@@ -3,8 +3,8 @@ import 'package:meta/meta.dart';
 
 /// Extra data that will be passed to dio's request, response, transformer and interceptors.
 @immutable
-class TypedExtra {
-  const TypedExtra();
+class TypedExtras {
+  const TypedExtras();
 }
 
 /// Extra data that will be passed to dio's request, response, transformer and interceptors.

--- a/retrofit/lib/dio.dart
+++ b/retrofit/lib/dio.dart
@@ -1,7 +1,21 @@
 import 'package:dio/dio.dart';
 import 'package:meta/meta.dart';
 
-/// Extra data that will be passed to dio's request, response, transformer and interceptors.
+/// Extra data that will be passed to Dio's request, response, transformer, and interceptors.
+/// Extend [TypedExtras] and define fields that correspond to the keys passed into `extras`.
+/// The values of these fields will be derived from the data passed into your subclass.
+/// 
+/// Example:
+///
+/// ```dart
+/// @TypedExtrasSubClass(
+///   id: '1234',
+///   fileType: '.json',
+/// )
+/// @GET("/get")
+/// Future<String> foo(@Extras() Map<String, dynamic> extras);
+/// ```
+///
 @immutable
 class TypedExtras {
   const TypedExtras();

--- a/retrofit/lib/dio.dart
+++ b/retrofit/lib/dio.dart
@@ -13,7 +13,7 @@ import 'package:meta/meta.dart';
 ///   fileType: '.json',
 /// )
 /// @GET("/get")
-/// Future<String> foo(@Extras() Map<String, dynamic> extras);
+/// Future<String> foo();
 /// ```
 ///
 @immutable

--- a/retrofit/lib/dio.dart
+++ b/retrofit/lib/dio.dart
@@ -3,6 +3,12 @@ import 'package:meta/meta.dart';
 
 /// Extra data that will be passed to dio's request, response, transformer and interceptors.
 @immutable
+class TypedExtra {
+  const TypedExtra();
+}
+
+/// Extra data that will be passed to dio's request, response, transformer and interceptors.
+@immutable
 class Extra {
   final Map<String, Object> data;
 

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - dio
   - retrofit
-version: 4.3.0
+version: 4.4.0
 environment:
   sdk: '>=2.19.0 <4.0.0'
 


### PR DESCRIPTION
### Summary
This PR adds functionality that allows developers to pass extras with requests using custom classes.

### Problem
Imagine you want every request in your app to include some additional metadata, such as an id and a region. Without this feature, you would have to annotate each request manually with something like Extra({'id': '1234', 'region': 'ng'}). While this approach works, it requires passing the key-value pairs each time, which introduces several risks:

Developers may inadvertently misspell a key (e.g., regoin instead of region).
A required key might be forgotten or omitted.
The repeated manual input increases the chance of inconsistency,

### Solution
Introduce `TypedExtras`, which developers can extend to provide extras in a structured and type-safe manner. By defining fields within the custom class, developers can avoid manual key-value entry, ensuring consistency and reducing the risk of errors.

Example: 
```dart
class MetaData extend TypedExtras {
 final String id;
 final String region;
 const MetaData({required this.id, required region});
}

@MetaData(
  id: '1234',
  region: 'ng',
)
@GET("/get")
Future<String> fetchData(@Extras() Map<String, dynamic> extras);

// Which will generate 
final _extras = <String, dynamic>{
 'id': '1234',
 'region': 'ng',
}
```