### PR TITLE
Add Support for multiple TypedExtra subclasses.

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 9.1.3
+
+- Add support for multiple `TypedExtras`.
+
+  Example :
+
+  ```dart
+  @TypedExtrasSubClass(
+    id: 'abcd',
+    fileType: FileType.json,
+    destinations: [Destination.remote]
+  )
+  @AnotherTypedExtrasSubClass(
+    state: 'Ohio',
+    destinations: [Destination.remote]
+  )
+  @http.POST('/path/')
+  Future<String> myMethod();
+
 ## 9.1.2
 
 - Support passing Enums into `TypedExtras`.

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2302,19 +2302,22 @@ ${bodyName.displayName} == null
   }
 
   Map<String, Object> _getMapFromTypedExtras(MethodElement m) {
-    final annotation =
-        _getMethodAnnotations(m, retrofit.TypedExtras).firstOrNull;
-    final fields = annotation?.objectValue.type?.element?.children
-        .whereType<FieldElement>();
-    final mapFromTypedExtras = <String, Object>{};
-    for (final field in fields ?? <FieldElement>[]) {
-      final value = annotation?.peek(field.name);
-      final fieldValue = _getFieldValue(value);
-      if (fieldValue != null) {
-        mapFromTypedExtras[field.name] = fieldValue;
+    final annotations = _getMethodAnnotations(m, retrofit.TypedExtras);
+    final allTypedExtras = <String, Object>{};
+
+    for (final annotation in annotations) {
+      final fields = annotation.objectValue.type?.element?.children
+          .whereType<FieldElement>();
+      for (final field in fields ?? <FieldElement>[]) {
+        final value = annotation.peek(field.name);
+        final fieldValue = _getFieldValue(value);
+        if (fieldValue != null) {
+          allTypedExtras[field.name] = fieldValue;
+        }
       }
     }
-    return mapFromTypedExtras;
+
+    return allTypedExtras;
   }
 
   void _generateExtra(

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -6,7 +6,8 @@ import 'package:source_gen_test/annotations.dart';
 
 import 'query.pb.dart';
 
-enum FileType {mp4, mp3}
+enum FileType { mp4, mp3 }
+
 class DummyTypedExtras extends TypedExtras {
   final String id;
   final Map<String, dynamic> config;
@@ -82,9 +83,11 @@ class AnotherDummyTypedExtras extends TypedExtras {
   final String mac;
   final String id;
 }
+
 @ShouldGenerate(
   '''
     final _extra = <String, dynamic>{
+      'bacon': 'sausage',
       'id': '12345',
       'config': {
         'date': '24-10-2024',
@@ -132,6 +135,7 @@ abstract class MultipleTypedExtrasTest {
     mac: 'Cheese',
     id: '12345',
   )
+  @Extra({'bacon': 'sausage'})
   @GET('path')
   Future<void> list();
 }

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -73,12 +73,12 @@ abstract class TypedExtrasTest {
 
 class AnotherDummyTypedExtras extends TypedExtras {
   const AnotherDummyTypedExtras({
-    required this.simple,
-    required this.stuff,
+    required this.peanutButter,
+    required this.mac,
   });
 
-  final String simple;
-  final String stuff;
+  final String peanutButter;
+  final String mac;
 }
 @ShouldGenerate(
   '''
@@ -99,8 +99,8 @@ class AnotherDummyTypedExtras extends TypedExtras {
         'local',
       },
       'shouldProceed': true,
-      'simple': 'hello',
-      'stuff': 'world',
+      'peanutButter': 'Jelly',
+      'mac': 'Cheese',
     };
   ''',
   contains: true,
@@ -126,8 +126,8 @@ abstract class MultipleTypedExtrasTest {
     shouldProceed: true,
   )
   @AnotherDummyTypedExtras(
-    simple: 'hello',
-    stuff: 'world',
+    peanutButter: 'Jelly',
+    mac: 'Cheese',
   )
   @GET('path')
   Future<void> list();

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -75,15 +75,17 @@ class AnotherDummyTypedExtras extends TypedExtras {
   const AnotherDummyTypedExtras({
     required this.peanutButter,
     required this.mac,
+    required this.id,
   });
 
   final String peanutButter;
   final String mac;
+  final String id;
 }
 @ShouldGenerate(
   '''
     final _extra = <String, dynamic>{
-      'id': '1234',
+      'id': '12345',
       'config': {
         'date': '24-10-2024',
         'type': 'analytics',
@@ -128,6 +130,7 @@ abstract class MultipleTypedExtrasTest {
   @AnotherDummyTypedExtras(
     peanutButter: 'Jelly',
     mac: 'Cheese',
+    id: '12345',
   )
   @GET('path')
   Future<void> list();

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -71,6 +71,68 @@ abstract class TypedExtrasTest {
   Future<void> list();
 }
 
+class AnotherDummyTypedExtras extends TypedExtras {
+  const AnotherDummyTypedExtras({
+    required this.simple,
+    required this.stuff,
+  });
+
+  final String simple;
+  final String stuff;
+}
+@ShouldGenerate(
+  '''
+    final _extra = <String, dynamic>{
+      'id': '1234',
+      'config': {
+        'date': '24-10-2024',
+        'type': 'analytics',
+        'shouldReplace': true,
+        'subConfig': {'date': '24-11-2025'},
+      },
+      'fileTypes': [
+        'mp3',
+        'mp4',
+      ],
+      'sources': {
+        'internet',
+        'local',
+      },
+      'shouldProceed': true,
+      'simple': 'hello',
+      'stuff': 'world',
+    };
+  ''',
+  contains: true,
+)
+@RestApi()
+abstract class MultipleTypedExtrasTest {
+  @DummyTypedExtras(
+    id: '1234',
+    config: {
+      'date': '24-10-2024',
+      'type': 'analytics',
+      'shouldReplace': true,
+      'subConfig': {'date': '24-11-2025'},
+    },
+    fileTypes: [
+      FileType.mp3,
+      FileType.mp4,
+    ],
+    sources: {
+      'internet',
+      'local',
+    },
+    shouldProceed: true,
+  )
+  @AnotherDummyTypedExtras(
+    simple: 'hello',
+    stuff: 'world',
+  )
+  @GET('path')
+  Future<void> list();
+}
+
 @ShouldGenerate(
   '''
 // ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element


### PR DESCRIPTION
# Handle Multiple @TypedExtras Annotations/Subclasses

## Description
This PR enhances the flexibility of the Retrofit generator by allowing multiple TypedExtras subclass to be used on a single method. Previously, only one TypedExtras subclass was supported, limiting the ability to organise and group extra parameters. This change brings the behavior of TypedExtras subclass in line with how Extra subclasses are handled.

## Changes
- Updated the logic of `_getMapFromTypedExtras` to include all @TypedExtras data
- Maintained backward compatibility with existing implementation

## Implementation Details
- The `_getMapFromTypedExtras` method now iterates through all @TypedExtras annotations on a method, extracting and combining their field values.
- In case of conflicting keys across multiple @TypedExtras annotations, the later annotations take precedence.

## Benefits
- Greater flexibility in organising and grouping extra parameters

## Testing
- Added unit tests to verify the correct handling of multiple @TypedExtras annotations
- Ensured existing tests for @Extra continue to pass
- Tested with various combinations of @Extra, @TypedExtras, to ensure correct merging behaviour.

## Example Usage
```dart
@TypedExtraSubclass1({'group1': 'value1'})
@TypedExtraSubclass2({'group2': 'value2'})
@GET('/endpoint')
Future<void> someMethod();