### PR TITLE
[generator] Adds a `unnecessary_string_interpolations` rule to suppress the analyzer warnings for the generated files.

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -15,7 +15,7 @@ import 'package:retrofit/retrofit.dart' as retrofit;
 import 'package:source_gen/source_gen.dart';
 
 const _analyzerIgnores =
-    '// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element';
+    '// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations';
 
 class RetrofitOptions {
   RetrofitOptions({

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -142,7 +142,7 @@ abstract class MultipleTypedExtrasTest {
 
 @ShouldGenerate(
   '''
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
 
 class _RestClient implements RestClient {
   _RestClient(


### PR DESCRIPTION
This pull request introduces an `unnecessary_string_interpolations` rule aimed at suppressing warnings when URLs are directly provided through the `Path` field. Previously, using interpolation on paths in functions such as:
```dart
  @GET('{url}')
  @DioResponseType(ResponseType.bytes)
  Future<List<int>?> loadAsBytes(
    @Path('url') String url,
  );
```
would result in:
```dart
.compose(
  _dio.options,
  '${url}',
  queryParameters: queryParameters,
  data: _data,
)
```
which triggers an `"Unnecessary use of string interpolation"` warning.

With this new rule, these warnings are prevented, improving code clarity and ensuring paths are treated as intended without redundant alerts.