### PR TITLE
Draft: Introduce CallAdapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,15 +245,15 @@ final client = RestClient(dio);
 ### Call Adapter
 
 This feature enables custom handling of responses and errors, allowing you to intercept and adapt calls based on your needs. 
-This can be done by creating a custom adapter that extends CallAdapterInterface, then overriding onError or onResponse depending on your useCase, then passing it to the @CallAdapter annotation or @RestApi.
+This can be done by creating a custom adapter that extends CallAdapterInterface, then overriding either onError or onResponse depending on your useCase, then passing it to the @CallAdapter annotation or @RestApi.
 
 ```dart
-class MyCallAdapter extends CallAdapterInterface<User> {
+class MyCallAdapter extends CallAdapterInterface<User, CustomException> {
   @override
-  void onError(error) => throw Exception();
+  Future<CustomException> onError(error) async => CustomException(message: error.toString());
 
   @override
-  User onResponse(dynamic data) => User.customParsing(data);
+  Future<User> onResponse(dynamic data) async => User.customParsing(data);
 }
 
 // Usage 1

--- a/README.md
+++ b/README.md
@@ -242,6 +242,52 @@ dio.options.baseUrl = 'https://5d42a6e2bc64f90014a56ca0.mockapi.io/api/v1';
 final client = RestClient(dio);
 ```
 
+### Call Adapter
+
+This feature enables custom handling of responses and errors, allowing you to intercept and adapt calls based on your needs. 
+This can be done by creating a custom adapter that extends CallAdapterInterface, and passing it to the @CallAdapter annotation or @RestApi.
+
+```dart
+class MyCallAdapter extends CallAdapterInterface<User> {
+  @override
+  void onError(error) => throw Exception();
+
+  @override
+  User onResponse(dynamic data) => User.customParsing(data);
+}
+
+// Usage 1
+// This approach applies the adapter to only the request method annotated with `@CallAdapter`
+@RestApi()
+abstract class RestClient {
+  factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
+
+  @CallAdapter(MyCallAdapter)
+  @GET('/')
+  Future<User> getTasks();
+}
+
+// Usage 2
+// This approach applies the adapter to all request methods in the api interface
+// Note that you can then override particular methods in the api interface by annotating it with `@CallAdapter`
+@RestApi(callAdapterInterface: MyCallAdapter)
+abstract class RestClient {
+  factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
+
+  @GET('/')
+  Future<User> getTasks();
+
+  @POST('/')
+  Future<User> submitTask();
+
+  @CallAdapter(MyCallAdapter)
+  @DELETE('/')
+  Future<void> deleteTask();
+}
+```
+
+If you want to use the base url from `dio.option.baseUrl`, which has lowest priority, please don't pass any parameter to `RestApi` annotation and `RestClient`'s structure method.
+
 ### Multiple endpoints support
 
 If you want to use multiple endpoints to your `RestClient`, you should pass your base url when you initiate `RestClient`. Any value defined in `RestApi` will be ignored.

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ final client = RestClient(dio);
 ### Call Adapter
 
 This feature enables custom handling of responses and errors, allowing you to intercept and adapt calls based on your needs. 
-This can be done by creating a custom adapter that extends CallAdapterInterface, and passing it to the @CallAdapter annotation or @RestApi.
+This can be done by creating a custom adapter that extends CallAdapterInterface, then overriding onError or onResponse depending on your useCase, then passing it to the @CallAdapter annotation or @RestApi.
 
 ```dart
 class MyCallAdapter extends CallAdapterInterface<User> {

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ abstract class RestClient {
   Future<void> deleteTask();
 }
 ```
+With this, when you call these request methods your transformed response is returned. or if there's an error, your transformed error is thrown.
 
 If you want to use the base url from `dio.option.baseUrl`, which has lowest priority, please don't pass any parameter to `RestApi` annotation and `RestClient`'s structure method.
 

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 9.1.4
+
+- Introduced CallAdapters, This feature enables custom handling of responses and errors, allowing you to intercept and adapt calls based on your needs.
+
+  Example :
+
+```dart
+  class MyCallAdapter extends CallAdapterInterface<User> {
+    @override
+    void onError(error) => throw Exception();
+
+    @override
+    User onResponse(dynamic data) => User.customParsing(data);
+  }
+  
+  @RestApi()
+  abstract class RestClient {
+    factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
+
+    @CallAdapter(MyCallAdapter)
+    @GET('/')
+    Future<User> getTasks();
+  }
+```
+
 ## 9.1.3
 
 - Add support for multiple `TypedExtras`.

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -7,12 +7,12 @@
   Example :
 
 ```dart
-  class MyCallAdapter extends CallAdapterInterface<User> {
+  class MyCallAdapter extends CallAdapterInterface<User, CustomException> {
     @override
-    void onError(error) => throw Exception();
+    Future<CustomException> onError(error) async => CustomException(error.toString());
 
     @override
-    User onResponse(dynamic data) => User.customParsing(data);
+    Future<User> onResponse(dynamic data) async => User.customParsing(data);
   }
   
   @RestApi()

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - retrofit
   - codegen
-version: 9.1.2
+version: 9.1.4
 environment:
   sdk: '>=3.3.0 <4.0.0'
 
@@ -20,7 +20,7 @@ dependencies:
   dart_style: ^2.3.0
   dio: ^5.0.0
   protobuf: ^3.1.0
-  retrofit: ^4.4.0
+  retrofit: ^4.4.2
   source_gen: ^1.5.0
 
 dev_dependencies:

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -8,7 +8,9 @@ import 'query.pb.dart';
 
 class DummyCallAdapter extends CallAdapterInterface {
   @override
-  onError(error) async {}
+  Future<Exception> onError(error) async {
+    return Exception();
+  }
 
   @override
   Future<bool> onResponse(dynamic data) async {
@@ -23,7 +25,9 @@ class ResponseAdapter extends CallAdapterInterface {
 }
 class ExceptionAdapter extends CallAdapterInterface {
   @override
-  onError(dynamic error) async {}
+  Future<Exception> onError(error) async {
+    return Exception();
+  }
 }
 
 @ShouldGenerate(

--- a/retrofit/CHANGELOG.md
+++ b/retrofit/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 4.4.2
+
+- Introduced CallAdapters, This feature enables custom handling of responses and errors, allowing you to intercept and adapt calls based on your needs.
+
+  Example :
+
+```dart
+  class MyCallAdapter extends CallAdapterInterface<User> {
+    @override
+    void onError(error) => throw Exception();
+
+    @override
+    User onResponse(dynamic data) => User.customParsing(data);
+  }
+  
+  @RestApi()
+  abstract class RestClient {
+    factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
+
+    @CallAdapter(MyCallAdapter)
+    @GET('/')
+    Future<User> getTasks();
+  }
+```
+
 ## 4.4.0
 
 - Added `@TypedExtras` to pass extra options to dio requests using custom annotations.

--- a/retrofit/CHANGELOG.md
+++ b/retrofit/CHANGELOG.md
@@ -7,12 +7,12 @@
   Example :
 
 ```dart
-  class MyCallAdapter extends CallAdapterInterface<User> {
+  class MyCallAdapter extends CallAdapterInterface<User, CustomException> {
     @override
-    void onError(error) => throw Exception();
+    Future<CustomException> onError(error) async => CustomException(error.toString());
 
     @override
-    User onResponse(dynamic data) => User.customParsing(data);
+    Future<User> onResponse(dynamic data) async => User.customParsing(data);
   }
   
   @RestApi()

--- a/retrofit/lib/call_adapter.dart
+++ b/retrofit/lib/call_adapter.dart
@@ -1,0 +1,55 @@
+/// Note that T must be the same as the type of `Future` for the method this is applied to
+abstract class CallAdapterInterface<T> {
+  void onError(dynamic error) {}
+
+  T? onResponse(dynamic data) {
+    return null;
+  }
+}
+
+/// Annotation to enable call adaptation by linking a
+/// custom [CallAdapterInterface].
+///
+/// By annotating a method with `@CallAdapter`, you can specify a custom adapter
+/// class that intercepts and adapts responses or handles errors before they
+/// reach the caller.
+///
+/// ### Usage
+///
+/// 1. Create a custom adapter by extending [CallAdapterInterface]:
+/// ```dart
+/// class MyCallAdapter extends CallAdapterInterface<MyResponseType> {
+///   @override
+///   MyResponseType? onResponse(dynamic data) {
+///     // Transform or adapt `data`
+///     return MyResponseType.fromJson(data);
+///   }
+///
+///   @override
+///   void onError(dynamic error) {
+///     // Custom error handling
+///     logger.log("Error occurred: $error");
+///   }
+/// }
+/// ```
+///
+/// 2. Set the adapter on an API method or the entire API interface:
+///
+/// - To apply the adapter to an individual method, use `@CallAdapter`:
+/// ```dart
+/// @CallAdapter(MyCallAdapter)
+/// Future<MyResponseType> fetchData();
+/// ```
+///
+/// - To apply it to all methods in an Api interface, pass the adapter to `@RestApi`:
+/// ```dart
+/// @RestApi(callAdapterInterface: MyCallAdapter)
+/// abstract class MyApiService {
+///   @GET('/data')
+///   Future<MyResponseType> fetchData();
+/// }
+/// ```
+class CallAdapter {
+  const CallAdapter(this.callAdapterInterface);
+  final Type callAdapterInterface;
+}

--- a/retrofit/lib/call_adapter.dart
+++ b/retrofit/lib/call_adapter.dart
@@ -1,9 +1,12 @@
-/// Note that T must be the same as the type of `Future` for the method this is applied to
-abstract class CallAdapterInterface<T> {
-  void onError(dynamic error) {}
+/// Where T is supposed to be the return type of your request,
+/// While E is the type you want to convert your `error` to
+abstract class CallAdapterInterface<T, E> {
+  Future<E> onError(dynamic error) {
+    return error;
+  }
 
-  T? onResponse(dynamic data) {
-    return null;
+  Future<T> onResponse(dynamic data) {
+    return data;
   }
 }
 
@@ -18,24 +21,25 @@ abstract class CallAdapterInterface<T> {
 ///
 /// 1. Create a custom adapter by extending [CallAdapterInterface]:
 /// ```dart
-/// class MyCallAdapter extends CallAdapterInterface<MyResponseType> {
+/// class MyCallAdapter extends CallAdapterInterface<MyResponseType, CustomException> {
 ///   @override
-///   MyResponseType? onResponse(dynamic data) {
+///   Future<MyResponseType> onResponse(dynamic data) async {
 ///     // Transform or adapt `data`
 ///     return MyResponseType.fromJson(data);
 ///   }
 ///
 ///   @override
-///   void onError(dynamic error) {
-///     // Custom error handling
+///   Future<CustomException> onError(dynamic error) async {
+///     // Custom error handling / error transformation
 ///     logger.log("Error occurred: $error");
+///     return CustomException(message: error.toString);
 ///   }
 /// }
 /// ```
 ///
 /// 2. Set the adapter on an API method or the entire API interface:
 ///
-/// - To apply the adapter to an individual method, use `@CallAdapter`:
+/// - To apply the adapter to an individual method, use `@CallAdapter` on the method:
 /// ```dart
 /// @CallAdapter(MyCallAdapter)
 /// Future<MyResponseType> fetchData();

--- a/retrofit/lib/http.dart
+++ b/retrofit/lib/http.dart
@@ -67,6 +67,7 @@ class RestApi {
   const RestApi({
     this.baseUrl,
     this.parser = Parser.JsonSerializable,
+    this.callAdapterInterface,
   });
 
   /// Set the API base URL.
@@ -93,6 +94,7 @@ class RestApi {
 
   /// if you don't specify the [parser]. It will be [Parser.JsonSerializable]
   final Parser parser;
+  final Type? callAdapterInterface;
 }
 
 @immutable

--- a/retrofit/lib/retrofit.dart
+++ b/retrofit/lib/retrofit.dart
@@ -1,3 +1,4 @@
 export 'dio.dart';
 export 'error_logger.dart';
 export 'http.dart';
+export 'call_adapter.dart';

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - dio
   - retrofit
-version: 4.4.0
+version: 4.4.2
 environment:
   sdk: '>=2.19.0 <4.0.0'
 


### PR DESCRIPTION
### Call Adapters

This feature enables custom handling of responses and errors, allowing you to intercept and adapt calls based on your needs. 
This can be done by creating a custom adapter that extends CallAdapterInterface, then overriding either onError or onResponse depending on your useCase, then passing it to the @CallAdapter annotation or @RestApi.

```dart
class MyCallAdapter extends CallAdapterInterface<User, CustomException> {
  @override
  Future<CustomException> onError(error) async => CustomException(message: error.toString());

  @override
  Future<User> onResponse(dynamic data) async => User.customParsing(data);
}

// Usage 1
// This approach applies the adapter to only the request method annotated with `@CallAdapter`
@RestApi()
abstract class RestClient {
  factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;

  @CallAdapter(MyCallAdapter)
  @GET('/')
  Future<User> getTasks();
}

// Usage 2
// This approach applies the adapter to all request methods in the api interface
// Note that you can then override particular methods in the api interface by annotating it with `@CallAdapter`
@RestApi(callAdapterInterface: MyCallAdapter)
abstract class RestClient {
  factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;

  @GET('/')
  Future<User> getTasks();

  @POST('/')
  Future<User> submitTask();

  @CallAdapter(MyCallAdapter)
  @DELETE('/')
  Future<void> deleteTask();
}
```