### PR TITLE
[generator] add nullable of File type @Part

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1867,6 +1867,9 @@ ${bodyName.displayName} == null
         final contentType = r.peek('contentType')?.stringValue;
 
         if (isFileField) {
+          if (p.type.isNullable) {
+            blocks.add(Code('if (${p.displayName} != null){'));
+          }
           final fileNameValue = r.peek('fileName')?.stringValue;
           final fileName = fileNameValue != null
               ? literalString(fileNameValue)
@@ -1906,6 +1909,9 @@ ${bodyName.displayName} == null
             );
           } else {
             blocks.add(returnCode);
+          }
+          if (p.type.isNullable) {
+            blocks.add(Code('}'));
           }
         } else if (_displayString(p.type) == 'List<int>') {
           final optionalFile = m.parameters


### PR DESCRIPTION
Fixes [#717](https://github.com/trevorwang/retrofit.dart/issues/717)
This can add a generate code to check the if condition of the nullable File type when we write like that `@Part(name: "photo") File? photo`. 
After we run the build runner, it will generate the code to check this File type to the optional field.
```
if (photo != null) { // generate this line
   _data.files.add(MapEntry(
      'photo',
      MultipartFile.fromFileSync(
         photo.path,
         filename: photo.path.split(Platform.pathSeparator).last,
      ),
   ));
}  // generate this line