### PR TITLE
Implemented Call Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,40 @@ dio.options.baseUrl = 'https://5d42a6e2bc64f90014a56ca0.mockapi.io/api/v1';
 final client = RestClient(dio);
 ```
 
+### Call Adapter
+
+This feature allows you to adapt the return type of a network call from one type to another.
+
+For example:
+Future<User> → Future<Result<User>>
+
+This feature provides flexibility in handling API responses, enabling better integration with custom response wrappers or error handling libraries.
+
+The CallAdapterInterface takes the original return type R and transforms it into a new type T. This is particularly useful when working with response wrappers like Either, Result, or ApiResponse.
+
+Below is an example using a custom CallAdapter with a Result wrapper:
+```dart
+  class MyCallAdapter<T> extends CallAdapterInterface<Future<T>, Future<Result<T>>> {
+    @override
+    Future<Result<T>> adapt(Future<T> Function() call) async {
+      try {
+        final response = await call();
+        return Result<T>.ok(response);
+      } catch (e) {
+        return Result.err(e.toString());
+      }
+    }
+  }
+
+  @RestApi(callAdapterInterface: MyCallAdapter)
+  abstract class RestClient {
+    factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
+
+    @GET('/')
+    Future<Result<User>> getUser();
+  }
+```
+
 ### Multiple endpoints support
 
 If you want to use multiple endpoints to your `RestClient`, you should pass your base url when you initiate `RestClient`. Any value defined in `RestApi` will be ignored.

--- a/README.md
+++ b/README.md
@@ -251,11 +251,11 @@ Future<User> → Future<Result<User>>
 
 This feature provides flexibility in handling API responses, enabling better integration with custom response wrappers or error handling libraries.
 
-The CallAdapterInterface takes the original return type R and transforms it into a new type T. This is particularly useful when working with response wrappers like Either, Result, or ApiResponse.
+The CallAdapter takes the original return type R and transforms it into a new type T. This is particularly useful when working with response wrappers like Either, Result, or ApiResponse.
 
 Below is an example using a custom CallAdapter with a Result wrapper:
 ```dart
-  class MyCallAdapter<T> extends CallAdapterInterface<Future<T>, Future<Result<T>>> {
+  class MyCallAdapter<T> extends CallAdapter<Future<T>, Future<Result<T>>> {
     @override
     Future<Result<T>> adapt(Future<T> Function() call) async {
       try {
@@ -267,7 +267,7 @@ Below is an example using a custom CallAdapter with a Result wrapper:
     }
   }
 
-  @RestApi(callAdapterInterface: MyCallAdapter)
+  @RestApi(callAdapter: MyCallAdapter)
   abstract class RestClient {
     factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
 

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 9.1.6
+
+- Introduced CallAdapters, This feature allows adaptation of a Call with return type R into the type of T. 
+  e.g. Future<User> to Future<Result<User>>
+
+  Code Example:
+
+```dart
+  class MyCallAdapter<T> extends CallAdapterInterface<Future<T>, Future<Either<ApiError, T>>> {
+    @override
+    Future<Either<ApiError, T>> adapt(Future<T> Function() call) async {
+      try {
+        final response = await call();
+        return Either.right(response);
+      }
+      catch (e) {
+        return Either.left(ApiError(e))
+      }
+    }
+  }
+  
+  @RestApi()
+  abstract class RestClient {
+    factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
+
+    @UseCallAdapter(MyCallAdapter)
+    @GET('/')
+    Future<User> getTasks();
+  }
+```
+
 ## 9.1.5
 
 - Add support for nested object of non-primitive types in `TypedExtras`.

--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -8,7 +8,7 @@
   Code Example:
 
 ```dart
-  class MyCallAdapter<T> extends CallAdapterInterface<Future<T>, Future<Either<ApiError, T>>> {
+  class MyCallAdapter<T> extends CallAdapter<Future<T>, Future<Either<ApiError, T>>> {
     @override
     Future<Either<ApiError, T>> adapt(Future<T> Function() call) async {
       try {

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1,6 +1,5 @@
 import 'dart:ffi';
 import 'dart:io';
-
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
@@ -72,6 +71,8 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
   /// Annotation details for [retrofit.RestApi]
   late retrofit.RestApi clientAnnotation;
 
+  ConstantReader? clientAnnotationConstantReader;
+
   @override
   String generateForAnnotatedElement(
     Element element,
@@ -97,6 +98,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       baseUrl: annotation?.peek(_baseUrlVar)?.stringValue ?? '',
       parser: parser ?? retrofit.Parser.JsonSerializable,
     );
+    clientAnnotationConstantReader = annotation;
     final baseUrl = clientAnnotation.baseUrl;
     final annotateClassConsts = element.constructors
         .where((c) => !c.isFactory && !c.isDefaultConstructor);
@@ -222,16 +224,169 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           c.body = Block.of(block);
         }
       });
+  
+  // Traverses a type to find a matching type argument
+  // e.g. given a type `List<List<User>>` and a key `User`, it will return the `DartType` "User"
+  DartType? findMatchingTypeArgument(DartType? type, String key) {
+    if (type?.getDisplayString() == key) {
+      return type;
+    }
 
-  Iterable<Method> _parseMethods(ClassElement element) => <MethodElement>[
-        ...element.methods,
-        ...element.mixins.expand((i) => i.methods),
-      ].where((m) {
-        final methodAnnotation = _getMethodAnnotation(m);
-        return methodAnnotation != null &&
-            m.isAbstract &&
-            (m.returnType.isDartAsyncFuture || m.returnType.isDartAsyncStream);
-      }).map((m) => _generateMethod(m)!);
+    if (type is InterfaceType) {
+      for (final arg in type.typeArguments) {
+        final match = findMatchingTypeArgument(arg, key);
+        if (match != null) {
+          return match;
+        }
+      }
+    }
+    return null;
+  }
+
+  // retrieve CallAdapterInterface from method annotation or class annotation
+  ConstantReader? getCallAdapterInterface(MethodElement m) {
+    final requestCallAdapterAnnotation = _typeChecker(retrofit.UseCallAdapter)
+        .firstAnnotationOf(m)
+        .toConstantReader();
+    final rootCallAdapter = clientAnnotationConstantReader;
+
+    final callAdapter = (requestCallAdapterAnnotation ?? rootCallAdapter)
+        ?.peek('callAdapterInterface');
+
+    final callAdapterTypeValue = callAdapter?.typeValue as InterfaceType?;
+    if (callAdapterTypeValue != null) {
+      final typeArg = callAdapterTypeValue.typeArguments.firstOrNull;
+      if (typeArg == null) {
+        throw InvalidGenerationSource(
+          'your CallAdapterInterface subclass must accept a generic type parameter \n'
+          'e.g. "class ResultAdapter<T> extends CallAdapterInterface..."',
+        );
+      }
+    }
+    return callAdapter;
+  }
+
+  /// get result type being adapted to e.g. Future<Result<T>>
+  /// where T is supposed to be the wrapped result type
+  InterfaceType? getAdaptedReturnType(ConstantReader? callAdapterInterface) {
+    final callAdapter = callAdapterInterface?.typeValue as InterfaceType?;
+    final adaptedType =
+        callAdapter?.superclass?.typeArguments.lastOrNull as InterfaceType?;
+    return adaptedType;
+  }
+
+  /// extract the wrapped result type of an adapted call...
+  /// Usage scenario:
+  /// given the return type of the api method is `Future<Result<UserResponse>>`,
+  /// and the second type parameter(T) on CallAdapterInterface<R, T> is `Future<Result<T>>`,
+  /// this method basically figures out the value of 'T' which will be "UserResponse"
+  /// in this case
+  String extractWrappedResultType(String template, String actual) {
+    final regexPattern = RegExp(
+      RegExp.escape(template).replaceAll('dynamic', r'([\w<>]+)'),
+    );
+    final match = regexPattern.firstMatch(actual);
+
+    if (match != null && match.groupCount > 0) {
+      return match.group(1) ?? '';
+    }
+    return '';
+  }
+
+  // parse methods in the Api class
+  Iterable<Method> _parseMethods(ClassElement element) {
+    List<Method> methods = [];
+    final methodMembers = <MethodElement>[
+      ...element.methods,
+      ...element.mixins.expand((i) => i.methods),
+    ];
+    for (final method in methodMembers) {
+      final callAdapter = getCallAdapterInterface(method);
+      final adaptedReturnType = getAdaptedReturnType(callAdapter);
+      final resultTypeInString = extractWrappedResultType(
+        adaptedReturnType != null ? _displayString(adaptedReturnType) : '',
+        _displayString(method.returnType),
+      );
+      final typeArg = findMatchingTypeArgument(method.returnType, resultTypeInString);
+      final instantiatedCallAdapter = typeArg != null ?
+          (callAdapter?.typeValue as InterfaceType?)?.element.instantiate(
+        typeArguments: [typeArg],
+        nullabilitySuffix: NullabilitySuffix.none,
+      ) : null;
+      if (method.isAbstract) {
+        methods.add(_generateApiCallMethod(method, instantiatedCallAdapter)!);
+      }
+      if (callAdapter != null) {
+        methods.add(_generateAdapterMethod(method, instantiatedCallAdapter, resultTypeInString));
+      }
+    }
+    return methods;
+  }
+
+  Method _generateAdapterMethod(
+    MethodElement m,
+    InterfaceType? callAdapter,
+    String resultType,
+  ) {
+    return Method((methodBuilder) {
+      methodBuilder.returns =
+          refer(_displayString(m.returnType, withNullability: true));
+      methodBuilder.requiredParameters.addAll(
+        _generateParameters(
+          m,
+          (it) => it.isRequiredPositional,
+        ),
+      );
+      methodBuilder.optionalParameters.addAll(
+        _generateParameters(
+          m,
+          (it) => it.isOptional || it.isRequiredNamed,
+          optional: true,
+        ),
+      );
+      methodBuilder.name = m.displayName;
+      methodBuilder.annotations.add(const CodeExpression(Code('override')));
+      final positionalArgs = <String>[];
+      final namedArgs = <String>[];
+      for (final parameter in m.parameters) {
+        if (parameter.isRequiredPositional || parameter.isOptionalPositional) {
+          positionalArgs.add(parameter.displayName);
+        }
+        if (parameter.isNamed) {
+          namedArgs.add('${parameter.displayName}: ${parameter.displayName}');
+        }
+      }
+      final args =
+          '${positionalArgs.map((e) => '$e,').join()} ${namedArgs.map((e) => '$e,').join()}';
+      methodBuilder.body = Code('''
+        return ${callAdapter?.element.name}<$resultType>().adapt(
+          () => _${m.displayName}($args),
+        );
+      ''');
+    });
+  }
+
+  Iterable<Parameter> _generateParameters(
+    MethodElement m,
+    bool Function(ParameterElement) filter, {
+    bool optional = false,
+  }) {
+    return m.parameters.where(filter).map(
+          (it) => Parameter(
+            (p) => p
+              ..name = it.name
+              ..named = it.isNamed
+              ..type = refer(it.type.getDisplayString())
+              ..required = optional &&
+                  it.isNamed &&
+                  it.type.nullabilitySuffix == NullabilitySuffix.none &&
+                  !it.hasDefaultValue
+              ..defaultTo = optional && it.defaultValueCode != null
+                  ? Code(it.defaultValueCode!)
+                  : null,
+          ),
+        );
+  }
 
   String _generateTypeParameterizedName(TypeParameterizedElement element) =>
       element.displayName +
@@ -369,61 +524,82 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return _getResponseInnerType(generic);
   }
 
-  Method? _generateMethod(MethodElement m) {
-    final httpMethod = _getMethodAnnotation(m);
-    if (httpMethod == null) {
-      return null;
+  void _configureMethodMetadata(
+    MethodBuilder mm,
+    MethodElement m,
+    String returnType,
+    bool hasCallAdapter,
+  ) {
+    mm
+      ..returns = refer(returnType)
+      ..name = hasCallAdapter ? '_${m.displayName}' : m.displayName
+      ..types.addAll(m.typeParameters.map((e) => refer(e.name)))
+      ..modifier = _isReturnTypeFuture(returnType)
+          ? MethodModifier.async
+          : MethodModifier.asyncStar;
+  }
+
+  void _addParameters(MethodBuilder mm, MethodElement m) {
+    mm.requiredParameters.addAll(
+      _generateParameters(m, (it) => it.isRequiredPositional),
+    );
+    mm.optionalParameters.addAll(
+      _generateParameters(m, (it) => it.isOptional || it.isRequiredNamed,
+          optional: true),
+    );
+  }
+
+  void _addAnnotations(
+    MethodBuilder mm,
+    DartType? returnType,
+    bool hasCallAdapter,
+  ) {
+    if (!hasCallAdapter) {
+      mm.annotations.add(const CodeExpression(Code('override')));
+    }
+    if (globalOptions.useResult ?? false) {
+      if (returnType is ParameterizedType &&
+          returnType.typeArguments.first is! VoidType) {
+        mm.annotations.add(const CodeExpression(Code('useResult')));
+      }
+    }
+  }
+
+  // generate the method that makes the http request
+  Method? _generateApiCallMethod(MethodElement m, InterfaceType? callAdapter) {
+    final hasCallAdapter = callAdapter != null;
+
+    if (hasCallAdapter) {
+      return _generatePrivateApiCallMethod(m, callAdapter);
     }
 
-    return Method((mm) {
-      mm
-        ..returns =
-            refer(_displayString(m.type.returnType, withNullability: true))
-        ..name = m.displayName
-        ..types.addAll(m.typeParameters.map((e) => refer(e.name)))
-        ..modifier = m.returnType.isDartAsyncFuture
-            ? MethodModifier.async
-            : MethodModifier.asyncStar
-        ..annotations.add(const CodeExpression(Code('override')));
+    final httpMethod = _getMethodAnnotation(m);
+    if (httpMethod == null) return null;
 
-      if (globalOptions.useResult ?? false) {
-        final returnType = m.returnType;
-        if (returnType is ParameterizedType &&
-            returnType.typeArguments.first is! VoidType) {
-          mm.annotations.add(const CodeExpression(Code('useResult')));
-        }
-      }
+    final returnType = m.returnType;
+    return Method((methodBuilder) {
+      _configureMethodMetadata(methodBuilder, m,
+          _displayString(returnType, withNullability: true), false);
+      _addParameters(methodBuilder, m);
+      _addAnnotations(methodBuilder, returnType, false);
+      methodBuilder.body =
+          _generateRequest(m, httpMethod, null);
+    });
+  }
 
-      /// required parameters
-      mm.requiredParameters.addAll(
-        m.parameters.where((it) => it.isRequiredPositional).map(
-              (it) => Parameter(
-                (p) => p
-                  ..name = it.name
-                  ..named = it.isNamed
-                  ..type = refer(it.type.getDisplayString()),
-              ),
-            ),
-      );
+  Method? _generatePrivateApiCallMethod(
+      MethodElement m, InterfaceType? callAdapterInterface) {
+    final callAdapterOriginalReturnType = callAdapterInterface?.superclass
+        ?.typeArguments.firstOrNull as InterfaceType?;
+    
+    final httpMethod = _getMethodAnnotation(m);
+    if (httpMethod == null) return null;
 
-      /// optional positional or named parameters
-      mm.optionalParameters.addAll(
-        m.parameters.where((i) => i.isOptional || i.isRequiredNamed).map(
-              (it) => Parameter(
-                (p) => p
-                  ..required = (it.isNamed &&
-                      it.type.nullabilitySuffix == NullabilitySuffix.none &&
-                      !it.hasDefaultValue)
-                  ..name = it.name
-                  ..named = it.isNamed
-                  ..type = refer(it.type.getDisplayString())
-                  ..defaultTo = it.defaultValueCode == null
-                      ? null
-                      : Code(it.defaultValueCode!),
-              ),
-            ),
-      );
-      mm.body = _generateRequest(m, httpMethod);
+    return Method((methodBuilder) {
+      _configureMethodMetadata(methodBuilder, m, _displayString(callAdapterOriginalReturnType), true);
+      _addParameters(methodBuilder, m);
+      _addAnnotations(methodBuilder, m.returnType, true);
+      methodBuilder.body = _generateRequest(m, httpMethod, callAdapterInterface);
     });
   }
 
@@ -440,7 +616,13 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     return literal(definePath);
   }
 
-  Code _generateRequest(MethodElement m, ConstantReader httpMethod) {
+  bool _isReturnTypeFuture(String type) => type.startsWith('Future<');
+
+  Code _generateRequest(
+    MethodElement m,
+    ConstantReader httpMethod,
+    InterfaceType? callAdapterInterface,
+  ) {
     final returnAsyncWrapper =
         m.returnType.isDartAsyncFuture ? 'return' : 'yield';
     final path = _generatePath(m, httpMethod);
@@ -549,8 +731,6 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
           refer(receiveProgress.element.displayName);
     }
 
-    final wrappedReturnType = _getResponseType(m.returnType);
-
     blocks.add(
       declareFinal(_optionsVar)
           .assign(_parseOptions(m, namedArguments, blocks, extraOptions))
@@ -559,20 +739,20 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
 
     final options = refer(_optionsVar).expression;
 
-    if (wrappedReturnType == null || 'void' == wrappedReturnType.toString()) {
-      blocks.add(
-        refer('await $_dioVar.fetch')
-            .call([options], {}, [refer('void')]).statement,
-      );
-      return Block.of(blocks);
-    }
+    final wrappedReturnType = _getResponseType(
+      callAdapterInterface != null
+          ? callAdapterInterface.superclass!.typeArguments.first
+          : m.returnType,
+    );
+    final isWrappedWithHttpResponseWrapper = wrappedReturnType != null
+        ? _typeChecker(retrofit.HttpResponse).isExactlyType(wrappedReturnType)
+        : false;
 
-    final isWrapped =
-        _typeChecker(retrofit.HttpResponse).isExactlyType(wrappedReturnType);
-    final returnType =
-        isWrapped ? _getResponseType(wrappedReturnType) : wrappedReturnType;
+    final returnType = isWrappedWithHttpResponseWrapper
+        ? _getResponseType(wrappedReturnType)
+        : wrappedReturnType;
     if (returnType == null || 'void' == returnType.toString()) {
-      if (isWrapped) {
+      if (isWrappedWithHttpResponseWrapper) {
         blocks
           ..add(
             refer('final $_resultVar = await $_dioVar.fetch')
@@ -1004,7 +1184,7 @@ You should create a new class to encapsulate the response.
           );
         }
       }
-      if (isWrapped) {
+      if (isWrappedWithHttpResponseWrapper) {
         blocks.add(
           Code('''
       final httpResponse = HttpResponse($_valueVar, $_resultVar);
@@ -2652,6 +2832,11 @@ extension DartTypeExt on DartType {
 extension DartObjectX on DartObject? {
   bool get isEnum {
     return this?.type?.element?.kind.name == 'ENUM';
+  }
+
+  ConstantReader? toConstantReader() {
+    if (this == null) return null;
+    return ConstantReader(this);
   }
 }
 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - retrofit
   - codegen
-version: 9.1.5
+version: 9.1.6
 environment:
   sdk: '>=3.3.0 <4.0.0'
 
@@ -20,10 +20,12 @@ dependencies:
   dart_style: ^2.3.0
   dio: ^5.0.0
   protobuf: ^3.1.0
-  retrofit: ^4.4.0
+  retrofit:
+    path: ../retrofit
   source_gen: ^1.5.0
 
 dev_dependencies:
   lints: ^4.0.0
   source_gen_test: ^1.0.6
   test: ^1.25.0
+  

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -20,12 +20,15 @@ dependencies:
   dart_style: ^2.3.0
   dio: ^5.0.0
   protobuf: ^3.1.0
-  retrofit:
-    path: ../retrofit
+  retrofit: ^4.4.2
   source_gen: ^1.5.0
 
 dev_dependencies:
   lints: ^4.0.0
   source_gen_test: ^1.0.6
   test: ^1.25.0
+
+dependency_overrides:
+  retrofit:
+    path: ../retrofit
   

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -5,7 +5,7 @@ import 'package:source_gen_test/annotations.dart';
 import 'query.pb.dart';
 
 class Resource<T> {}
-class MockCallAdapter1<T> extends CallAdapterInterface<Future<T>, Future<Resource<T>>> {
+class MockCallAdapter1<T> extends CallAdapter<Future<T>, Future<Resource<T>>> {
   @override
   Future<Resource<T>> adapt(Future<T> Function() call) async {
     return Resource();
@@ -30,7 +30,7 @@ abstract class TestCallAdapter1 {
 }
 
 class Either<L, R> {}
-class MockCallAdapter2<T> extends CallAdapterInterface<Future<T>, Future<Either<T, String>>> {
+class MockCallAdapter2<T> extends CallAdapter<Future<T>, Future<Either<T, String>>> {
   @override
   Future<Either<T, String>> adapt(Future<T> Function() call) async {
     return Either();
@@ -55,7 +55,7 @@ abstract class TestCallAdapter2 {
 }
 
 class Flow<T> {}
-class MockCallAdapter3<T> extends CallAdapterInterface<Future<T>, Flow<T>> {
+class MockCallAdapter3<T> extends CallAdapter<Future<T>, Flow<T>> {
   @override
   Flow<T> adapt(Future<T> Function() call) {
     return Flow();

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1,12 +1,83 @@
 import 'dart:io';
-
 import 'package:dio/dio.dart' hide Headers;
 import 'package:retrofit/retrofit.dart';
 import 'package:source_gen_test/annotations.dart';
-
 import 'query.pb.dart';
 
-enum FileType { mp4, mp3 }
+class Resource<T> {}
+class MockCallAdapter1<T> extends CallAdapterInterface<Future<T>, Future<Resource<T>>> {
+  @override
+  Future<Resource<T>> adapt(Future<T> Function() call) async {
+    return Resource();
+  }
+}
+@ShouldGenerate(
+'''
+  @override
+  Future<Resource<GenericUser<User>>> getUser() {
+    return MockCallAdapter1<GenericUser<User>>().adapt(
+      () => _getUser(),
+    );
+  }
+''',
+  contains: true,
+)
+@RestApi()
+abstract class TestCallAdapter1 {
+  @UseCallAdapter(MockCallAdapter1)
+  @GET('path')
+  Future<Resource<GenericUser<User>>> getUser();
+}
+
+class Either<L, R> {}
+class MockCallAdapter2<T> extends CallAdapterInterface<Future<T>, Future<Either<T, String>>> {
+  @override
+  Future<Either<T, String>> adapt(Future<T> Function() call) async {
+    return Either();
+  }
+}
+@ShouldGenerate(
+'''
+  @override
+  Future<Either<User, String>> getUser() {
+    return MockCallAdapter2<User>().adapt(
+      () => _getUser(),
+    );
+  }
+''',
+  contains: true,
+)
+@RestApi()
+abstract class TestCallAdapter2 {
+  @UseCallAdapter(MockCallAdapter2)
+  @GET('path')
+  Future<Either<User, String>> getUser();
+}
+
+class Flow<T> {}
+class MockCallAdapter3<T> extends CallAdapterInterface<Future<T>, Flow<T>> {
+  @override
+  Flow<T> adapt(Future<T> Function() call) {
+    return Flow();
+  }
+}
+@ShouldGenerate(
+'''
+  @override
+  Flow<User> getUser() {
+    return MockCallAdapter3<User>().adapt(
+      () => _getUser(),
+    );
+  }
+''',
+  contains: true,
+)
+@RestApi()
+abstract class TestCallAdapter3 {
+  @UseCallAdapter(MockCallAdapter3)
+  @GET('path')
+  Flow<User> getUser();
+}
 
 class Config {
   final String date;
@@ -21,7 +92,7 @@ class Config {
     required this.subConfig,
   });
 }
-
+enum FileType { mp4, mp3 }
 class DummyTypedExtras extends TypedExtras {
   final String id;
   final Config config;

--- a/retrofit/CHANGELOG.md
+++ b/retrofit/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 4.4.2
+
+- Introduced CallAdapters, This feature allows adaptation of a Call with return type R into the type of T. 
+  e.g. Future<User> to Future<Result<User>>
+
+  Code Example:
+```dart
+  class MyCallAdapter<T> extends CallAdapterInterface<Future<T>, Future<Either<ApiError, T>>> {
+    @override
+    Future<Either<ApiError, T>> adapt(Future<T> Function() call) async {
+      try {
+        final response = await call();
+        return Either.right(response);
+      }
+      catch (e) {
+        return Either.left(ApiError(e))
+      }
+    }
+  }
+  
+  @RestApi()
+  abstract class RestClient {
+    factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
+
+    @UseCallAdapter(MyCallAdapter)
+    @GET('/')
+    Future<User> getTasks();
+  }
+```
+
 ## 4.4.0
 
 - Added `@TypedExtras` to pass extra options to dio requests using custom annotations.

--- a/retrofit/CHANGELOG.md
+++ b/retrofit/CHANGELOG.md
@@ -7,7 +7,7 @@
 
   Code Example:
 ```dart
-  class MyCallAdapter<T> extends CallAdapterInterface<Future<T>, Future<Either<ApiError, T>>> {
+  class MyCallAdapter<T> extends CallAdapter<Future<T>, Future<Either<ApiError, T>>> {
     @override
     Future<Either<ApiError, T>> adapt(Future<T> Function() call) async {
       try {

--- a/retrofit/lib/call_adapter.dart
+++ b/retrofit/lib/call_adapter.dart
@@ -1,0 +1,53 @@
+/// Adapts a Call with return type R into the type of T.
+/// e.g. Future<User> to Future<Result<User>>
+abstract class CallAdapterInterface<R, T> {
+  T adapt(R Function() call);
+}
+
+
+/// By annotating a method with `@UseCallAdapter`, you can specify a custom adapter
+/// class where you can adapt a call to another response wrapper
+///
+/// ### Usage
+///
+/// 1. Create the call adapter by extending [CallAdapterInterface]:
+/// pass in type parameters for the original call return type and adapted call return type.
+/// Note: your adapter subclass must accept a single type parameter(T), where T is
+/// the type of the unwrapped response from the original call. e.g. 
+/// "UserResponse" in "Future<UserResponse>"
+/// 
+/// ```dart
+/// class ResultCallAdapter<T> extends CallAdapterInterface<Future<T>, Future<Result<T>>> {
+///   @override
+///   Future<Result<T>> adapt(Future<T> Function() call) async {
+///     try {
+///       final response = await call();
+///       return Success<T>(response);
+///     } catch (e) {
+///       return Error(e);
+///     }
+///   } 
+/// }
+
+/// ```
+///
+/// 2. Set the adapter on an API method or the entire API interface:
+///
+/// - To apply the adapter to an individual method, use `@UseCallAdapter` on the method:
+/// ```dart
+/// @UseCallAdapter(ResultCallAdapter)
+/// Future<Result<UserResponse>> fetchData();
+/// ```
+///
+/// - To apply it to all methods in an Api interface, pass the adapter to `@RestApi`:
+/// ```dart
+/// @RestApi(callAdapterInterface: ResultCallAdapter)
+/// abstract class MyApiService {
+///   @GET('/data')
+///   Future<Result<UserResponse>> fetchData();
+/// }
+/// ```
+class UseCallAdapter {
+  const UseCallAdapter(this.callAdapterInterface);
+  final Type callAdapterInterface;
+}

--- a/retrofit/lib/call_adapter.dart
+++ b/retrofit/lib/call_adapter.dart
@@ -1,6 +1,6 @@
 /// Adapts a Call with return type R into the type of T.
 /// e.g. Future<User> to Future<Result<User>>
-abstract class CallAdapterInterface<R, T> {
+abstract class CallAdapter<R, T> {
   T adapt(R Function() call);
 }
 
@@ -10,14 +10,14 @@ abstract class CallAdapterInterface<R, T> {
 ///
 /// ### Usage
 ///
-/// 1. Create the call adapter by extending [CallAdapterInterface]:
+/// 1. Create the call adapter by extending [CallAdapter]:
 /// pass in type parameters for the original call return type and adapted call return type.
 /// Note: your adapter subclass must accept a single type parameter(T), where T is
 /// the type of the unwrapped response from the original call. e.g. 
 /// "UserResponse" in "Future<UserResponse>"
 /// 
 /// ```dart
-/// class ResultCallAdapter<T> extends CallAdapterInterface<Future<T>, Future<Result<T>>> {
+/// class ResultCallAdapter<T> extends CallAdapter<Future<T>, Future<Result<T>>> {
 ///   @override
 ///   Future<Result<T>> adapt(Future<T> Function() call) async {
 ///     try {
@@ -41,13 +41,13 @@ abstract class CallAdapterInterface<R, T> {
 ///
 /// - To apply it to all methods in an Api interface, pass the adapter to `@RestApi`:
 /// ```dart
-/// @RestApi(callAdapterInterface: ResultCallAdapter)
+/// @RestApi(callAdapter: ResultCallAdapter)
 /// abstract class MyApiService {
 ///   @GET('/data')
 ///   Future<Result<UserResponse>> fetchData();
 /// }
 /// ```
 class UseCallAdapter {
-  const UseCallAdapter(this.callAdapterInterface);
-  final Type callAdapterInterface;
+  const UseCallAdapter(this.callAdapter);
+  final Type callAdapter;
 }

--- a/retrofit/lib/http.dart
+++ b/retrofit/lib/http.dart
@@ -67,6 +67,7 @@ class RestApi {
   const RestApi({
     this.baseUrl,
     this.parser = Parser.JsonSerializable,
+    this.callAdapterInterface,
   });
 
   /// Set the API base URL.
@@ -93,6 +94,7 @@ class RestApi {
 
   /// if you don't specify the [parser]. It will be [Parser.JsonSerializable]
   final Parser parser;
+  final Type? callAdapterInterface;
 }
 
 @immutable

--- a/retrofit/lib/http.dart
+++ b/retrofit/lib/http.dart
@@ -67,7 +67,7 @@ class RestApi {
   const RestApi({
     this.baseUrl,
     this.parser = Parser.JsonSerializable,
-    this.callAdapterInterface,
+    this.callAdapter,
   });
 
   /// Set the API base URL.
@@ -94,7 +94,7 @@ class RestApi {
 
   /// if you don't specify the [parser]. It will be [Parser.JsonSerializable]
   final Parser parser;
-  final Type? callAdapterInterface;
+  final Type? callAdapter;
 }
 
 @immutable

--- a/retrofit/lib/retrofit.dart
+++ b/retrofit/lib/retrofit.dart
@@ -1,3 +1,4 @@
 export 'dio.dart';
 export 'error_logger.dart';
 export 'http.dart';
+export 'call_adapter.dart';

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - dio
   - retrofit
-version: 4.4.0
+version: 4.4.2
 environment:
   sdk: '>=2.19.0 <4.0.0'
 


### PR DESCRIPTION
Introduced CallAdapters, a feature that allows you to adapt the return type of a network call from one type to another.
For example:
`Future<User>` → `Future<Result<User>>`.

A CallAdapter takes the original return type R and transforms it into a new type T. This is particularly useful when working with response wrappers like Either, Result, or ApiResponse.

Sample Code:
```dart
class MyCallAdapter<T> extends CallAdapter<Future<T>, Future<Result<T>>> {
  @override
  Future<Result<T>> adapt(Future<T> Function() call) async {
    try {
      final response = await call();
      return Result<T>.ok(response);
    } catch (e) {
      return Result.err(e.toString());
    }
  }
}

@RestApi(callAdapter: MyCallAdapter)
abstract class RestClient {
  factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;

  @GET('/')
  Future<Result<User>> getUser();
}
```

Generated Code Snippet:

```dart
  @override
  Future<Result<User>> getUser() {
    return MyCallAdapter<User>().adapt(
      () => _getUser(),
    );
  }
```
where the private method "_getUser()" is the method that makes the Api request