### PR TITLE
fix(generator): generates invalid code for the same path parameter appears multiple times 

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,7 +1,21 @@
 
+## 9.1.8
+
+- Fixed issue which generated invalid code for the same path parameter appears multiple times.
+
+  Example:
+
+  ```dart
+  @GET('/image/{imageType}/{id}/{id}_XL.png')
+  Future<HttpResponse<dynamic>> getImage(
+    @Path('imageType') ImageType imageType,
+    @Path('id') String id,
+  );
+  ```
+
 ## 9.1.7
 
-- Introduced CallAdapters, This feature allows adaptation of a Call with return type R into the type of T. 
+- Introduced CallAdapters, This feature allows adaptation of a Call with return type R into the type of T.
   e.g. Future<User> to Future<Result<User>>
 
   Code Example:
@@ -19,7 +33,7 @@
       }
     }
   }
-  
+
   @RestApi()
   abstract class RestClient {
     factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
@@ -76,7 +90,7 @@
   @http.POST('/path/')
   Future<String> myMethod();
   ```
-  
+
 ## 9.1.2
 
 - Support passing Enums into `TypedExtras`.
@@ -122,6 +136,7 @@
 - Added `@Extras` to pass extra options to dio requests, response, transformer and interceptors.
 
   Example :
+
   ```dart
   @http.POST('/path/')
   Future<String> myMethod(@Extras() Map<String, dynamic> extras);

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -608,7 +608,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     var definePath = method.peek('path')?.stringValue;
     paths.forEach((k, v) {
       final value = v.peek('value')?.stringValue ?? k.displayName;
-      definePath = definePath?.replaceFirst(
+      definePath = definePath?.replaceAll(
         '{$value}',
         "\${${k.displayName}${k.type.element?.kind == ElementKind.ENUM ? _hasToJson(k.type) ? '.toJson()' : '.name' : ''}}",
       );

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -498,6 +498,19 @@ abstract class PathTest {
   );
 }
 
+@ShouldGenerate(
+  r'/image/${imageType.name}/${id}/${id}_XL.png',
+  contains: true,
+)
+@RestApi()
+abstract class MultiplePathTest {
+  @GET('/image/{imageType}/{id}/{id}_XL.png')
+  Future<HttpResponse<dynamic>> getImage(
+    @Path('imageType') ImageType imageType,
+    @Path('id') String id,
+  );
+}
+
 enum ImageType { icon, large }
 
 @ShouldGenerate(


### PR DESCRIPTION
This PR fixes an issue with path parameter replacement in `RetrofitGenerator`.
This modification allows for multiple occurrences of the same Path Parameter to be properly replaced in API Endpoint URL.

## Changes

- Changed `replaceFirst` to `replaceAll` in the path parameter replacement logic
- Added test cases to verify multiple path parameter replacements

## Example

https://x.com/YumNumm/status/1880651949508612347

![image](https://github.com/user-attachments/assets/1fe9f6b6-232b-47eb-98c2-4366d93b80d3)

---

Before: 
```dart
@Get('/users/{id}/posts/{id}')
Future<ResponseType> getUserPosts(@Path('id') String id);
// Only replaces first occurrence: `/users/123/posts/{id}`
```

After: 
```dart
@Get('/users/{id}/posts/{id}')
Future<ResponseType> getUserPosts(@Path('id') String id);
// Replaces all occurrences: `/users/123/posts/123`
```

## Related Issues
N/A
