### PR TITLE
updat: support generic with void

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1343,10 +1343,14 @@ You should create a new class to encapsulate the response.
       if (_displayString(dartType) == 'dynamic' || _isBasicType(dartType)) {
         return '(json)=>json as ${_displayString(dartType, withNullability: dartType.isNullable)},';
       } else {
-        if (dartType.isNullable) {
-          return '(json)=> json == null ? null : ${_displayString(dartType)}.fromJson(json as Map<String, dynamic>),';
+        if (_displayString(dartType) == 'void') {
+          return '(json)=> (){}(),';
         } else {
-          return '(json)=>${_displayString(dartType)}.fromJson(json as Map<String, dynamic>),';
+          if (dartType.isNullable) {
+            return '(json)=> json == null ? null : ${_displayString(dartType)}.fromJson(json as Map<String, dynamic>),';
+          } else {
+            return '(json)=>${_displayString(dartType)}.fromJson(json as Map<String, dynamic>),';
+          }
         }
       }
     }


### PR DESCRIPTION
support  generic class with void. example ApiResponse<void>

@JsonSerializable(genericArgumentFactories: true)
class ApiResponse<T> {
  final int code;
  final String? msg;
  @JsonKey(name: 'data')
  final T data;
}

  @POST("/app/user/sendRegisterCode")
  Future<ApiResponse<void>> sendRegisterCode(@Body() Map<String, dynamic> body);