### PR TITLE
Fix issue of callAdapter using yield/return incorrectly

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 9.1.8
+
+- Fixed bug of callAdapter using yield/return incorrectly
+
 ## 9.1.7
 
 - Introduced CallAdapters, This feature allows adaptation of a Call with return type R into the type of T. 
@@ -26,7 +30,7 @@
 
     @UseCallAdapter(MyCallAdapter)
     @GET('/')
-    Future<User> getTasks();
+    Future<Either<ApiError, User>> getTasks();
   }
 ```
 

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -623,8 +623,16 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     ConstantReader httpMethod,
     InterfaceType? callAdapter,
   ) {
-    final returnAsyncWrapper =
+    String returnAsyncWrapper =
         m.returnType.isDartAsyncFuture ? 'return' : 'yield';
+    if (callAdapter != null) {
+      final callAdapterOriginalReturnType = callAdapter.superclass
+        ?.typeArguments.firstOrNull as InterfaceType?;
+      returnAsyncWrapper = _isReturnTypeFuture(
+              callAdapterOriginalReturnType?.getDisplayString() ?? '')
+          ? 'return'
+          : 'yield';
+    }
     final path = _generatePath(m, httpMethod);
     final blocks = <Code>[];
 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - retrofit
   - codegen
-version: 9.1.6
+version: 9.1.8
 environment:
   sdk: '>=3.3.0 <4.0.0'
 

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -65,11 +65,36 @@ class MockCallAdapter3<T> extends CallAdapter<Future<T>, Flow<T>> {
 }
 
 @ShouldGenerate(
-  '''
-  @override
-  Flow<User> getUser() {
-    return MockCallAdapter3<User>().adapt(() => _getUser());
-  }
+'''
+      Future<User> _getUser() async {
+        final _extra = <String, dynamic>{};
+        final queryParameters = <String, dynamic>{};
+        final _headers = <String, dynamic>{};
+        const Map<String, dynamic>? _data = null;
+        final _options = _setStreamType<User>(
+          Options(method: 'GET', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                'path',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+        );
+        final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+        late User _value;
+        try {
+          _value = User.fromJson(_result.data!);
+        } on Object catch (e, s) {
+          errorLogger?.logError(e, s, _options);
+          rethrow;
+        }
+        return _value;
+      }
+      @override
+      Flow<User> getUser() {
+        return MockCallAdapter3<User>().adapt(() => _getUser());
+      }
 ''',
   contains: true,
 )

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -66,35 +66,31 @@ class MockCallAdapter3<T> extends CallAdapter<Future<T>, Flow<T>> {
 
 @ShouldGenerate(
 '''
-      Future<User> _getUser() async {
-        final _extra = <String, dynamic>{};
-        final queryParameters = <String, dynamic>{};
-        final _headers = <String, dynamic>{};
-        const Map<String, dynamic>? _data = null;
-        final _options = _setStreamType<User>(
-          Options(method: 'GET', headers: _headers, extra: _extra)
-              .compose(
-                _dio.options,
-                'path',
-                queryParameters: queryParameters,
-                data: _data,
-              )
-              .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
-        );
-        final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-        late User _value;
-        try {
-          _value = User.fromJson(_result.data!);
-        } on Object catch (e, s) {
-          errorLogger?.logError(e, s, _options);
-          rethrow;
-        }
-        return _value;
-      }
-      @override
-      Flow<User> getUser() {
-        return MockCallAdapter3<User>().adapt(() => _getUser());
-      }
+  Future<User> _getUser() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<User>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'path',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late User _value;
+    try {
+      _value = User.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
 ''',
   contains: true,
 )


### PR DESCRIPTION
- The CallAdapter should use "R" in CallAdapter<R, T> when trying to figure out if to use a "return" or "yield", not the return type of the request Method. E.g. in the image below it should use the type in green circle, instead of the one in the red circle.
![reto](https://github.com/user-attachments/assets/516f1ded-ddf4-4384-9fe7-81becb0fdbf3)


- This PR also makes the test case more elaborate, to cover this case.