### PR TITLE
feat: added `@BodyExtra` generator

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,3 +1,49 @@
+## 9.3.0
+
+- Added `@BodyExtra` annotation: Add individual fields to request body without defining complete DTO classes
+  - Support for adding dynamic fields to existing request bodies
+  - `expand` parameter (default: false) to control object field flattening behavior
+
+  Example(Combine fields):
+
+  ```dart
+  @http.POST('/path/')
+  Future<String> updateValue(@BodyExtra('id') int id, @BodyExtra('value') String value);
+  ```
+
+  Request body result:
+  
+  ```json
+  {"id": 123, "value": "some value"}
+  ```
+
+  Example(Combine objects):
+
+  ```dart
+  // pseudocode
+  class User {
+    int userId;
+    String userName;
+  }
+
+  class Settings {
+    int a;
+    int b;
+  }
+
+  @http.POST('/path/')
+  Future<String> updateValue(
+    @BodyExtra('user', expand: true) User user, 
+    @BodyExtra('settings', expand: true) Settings settings,
+  );
+  ```
+
+  Request body result:
+  
+  ```json
+  {"userId": 123, "userName": "hhh", "a": 1, "b": 2}
+  ```
+
 ## 9.2.0
 
 - Update protobuf version to 4.0.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - retrofit
   - codegen
-version: 9.2.0
+version: 9.3.0
 environment:
   sdk: '>=3.3.0 <4.0.0'
 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   dio: ^5.0.0
   protobuf: ^4.0.0
   source_gen: '>=1.5.0 <3.0.0'
-  retrofit: ^4.4.2
+  retrofit: ^4.5.0
 
 dev_dependencies:
   lints: any

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -796,6 +796,15 @@ abstract class StreamReturnModifier {
   Stream<User> getUser();
 }
 
+class UserExtraInfo {
+  const UserExtraInfo();
+
+  factory UserExtraInfo.fromJson(Map<String, dynamic> json) =>
+      const UserExtraInfo();
+
+  Map<String, dynamic> toJson() => <String, dynamic>{};
+}
+
 class User implements AbstractUser {
   const User();
 
@@ -893,6 +902,101 @@ abstract class NullableGenericCastBasicType {
 abstract class TestObjectBody {
   @POST('/users')
   Future<String> createUser(@Body() User user);
+}
+
+@ShouldGenerate(
+  '''
+    final _data = <String, dynamic>{'user_id': userId};
+''',
+  contains: true,
+)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestObjectSingleBodyExtra {
+  @POST('/users')
+  Future<String> createUser(
+    @BodyExtra('user_id') String userId,
+  );
+}
+
+@ShouldGenerate(
+  '''
+    final _data = <String, dynamic>{'user_id': userId};
+''',
+  contains: true,
+)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestObjectSingleBodyExtra1 {
+  @POST('/users')
+  Future<String> createUser({
+    @BodyExtra('user_id') required String userId,
+  });
+}
+
+@ShouldGenerate(
+  '''
+    final _data = <String, dynamic>{'update_timestamp': timestamp};
+    _data.addAll(user.toJson());
+''',
+  contains: true,
+)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestObjectBodyExtra {
+  @POST('/users')
+  Future<String> createUser(
+    @Body() User user, {
+    @BodyExtra('update_timestamp') required int timestamp,
+  });
+}
+
+@ShouldGenerate(
+  '''
+    final _data = <String, dynamic>{
+      'user_name': userName,
+      'update_timestamp': timestamp,
+    };
+''',
+  contains: true,
+)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestObjectBodyExtraWithoutBody {
+  @POST('/users')
+  Future<String> createUser({
+    @BodyExtra('user_name') required String userName,
+    @BodyExtra('update_timestamp') required int timestamp,
+  });
+}
+
+@ShouldGenerate(
+  '''
+    final _data = <String, dynamic>{'update_timestamp': timestamp};
+    _data.addAll(user?.toJson() ?? <String, dynamic>{});
+''',
+  contains: true,
+)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestObjectBodyExtraOptional {
+  @POST('/users')
+  Future<String> createUser({
+    @BodyExtra('user', expand: true) User? user,
+    @BodyExtra('update_timestamp') int? timestamp,
+  });
+}
+
+@ShouldGenerate(
+  '''
+    final _data = <String, dynamic>{};
+    _data.addAll(user.toJson());
+    _data.addAll(extraInfo.toJson());
+''',
+  contains: true,
+)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestObjectBodyExtraMultiExpandObject {
+  @POST('/users')
+  Future<String> createUser({
+    @BodyExtra('user', expand: true) required User user,
+    @BodyExtra('extra_info', expand: true) required UserExtraInfo extraInfo,
+  });
 }
 
 @ShouldGenerate(

--- a/retrofit/CHANGELOG.md
+++ b/retrofit/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 4.5.0
+
+- Added `@BodyExtra` annotation to support adding individual fields to request body, enhancing flexibility and extensibility.
+
+  Example :
+
+  ```dart
+  @http.POST('/path/')
+  Future<String> updateValue(@BodyExtra('id') int id, @BodyExtra('value') String value);
+  ```
+
+  The request body will be：
+  
+  ```json
+  {"id": 123, "value": "some value"}
+  ```
+
 ## 4.4.2
 
 - Introduced CallAdapters, This feature allows adaptation of a Call with return type R into the type of T. 

--- a/retrofit/lib/http.dart
+++ b/retrofit/lib/http.dart
@@ -191,6 +191,37 @@ class Body {
   final bool nullToAbsent;
 }
 
+
+/// Use this annotation on a service method param when you want to add individual fields 
+/// to the request body without defining a complete DTO class. This is useful when you 
+/// need to include additional fields in the request body alongside existing data, or when 
+/// you only need to send a few specific fields without creating a full data transfer object.
+/// 
+/// Unlike @Body which requires a complete DTO class to represent the entire request body,
+/// @BodyExtra allows you to define individual fields that will be merged into the final 
+/// request body JSON. This provides more flexibility for scenarios where:
+/// - You need to add dynamic or conditional fields to an existing request
+/// - You want to avoid creating DTOs for simple field additions
+/// - You need to compose request bodies from multiple sources
+/// 
+/// Example:
+/// ```
+/// @POST("/post")
+/// Future<String> example(@Body UserDTO user, @BodyExtra("timestamp") int timestamp);
+/// ```
+/// Results in: {"name": "John", "email": "john@example.com", "timestamp": 1234567890}
+@immutable
+class BodyExtra {
+  const BodyExtra(this.value, {this.expand = false});
+
+  final String value;
+
+  /// Default is false. Controls how Object/Map values are handled:
+  /// - `true`: Object/Map fields are flattened to the request body root level
+  /// - `false`: The entire Object/Map is added as a nested field
+  final bool expand;
+}
+
 /// Use this annotation on a service method param when you want to indicate that no body should be
 /// generated for POST/PUT/DELETE requests.
 @immutable

--- a/retrofit/pubspec.yaml
+++ b/retrofit/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - dio
   - retrofit
-version: 4.4.2
+version: 4.5.0
 environment:
   sdk: '>=2.19.0 <4.0.0'
 


### PR DESCRIPTION
About https://github.com/trevorwang/retrofit.dart/discussions/752.

Added `@BodyExtra` annotation: Add individual fields to request body without defining complete DTO classes
  - Support for adding dynamic fields to existing request bodies
  - `expand` parameter (default: false) to control object field flattening behavior

  Example(Combine fields):

  ```dart
  @http.POST('/path/')
  Future<String> updateValue(@BodyExtra('id') int id, @BodyExtra('value') String value);
  ```

  Request body result:

  ```json
  {"id": 123, "value": "some value"}
  ```

  Example(Combine objects):

  ```dart
  // pseudocode
  class User {
    int userId;
    String userName;
  }
  class Settings {
    int a;
    int b;
  }
  @http.POST('/path/')
  Future<String> updateValue(
    @BodyExtra('user', expand: true) User user, 
    @BodyExtra('settings', expand: true) Settings settings,
  );
  ```

  Request body result:

  ```json
  {"userId": 123, "userName": "hhh", "a": 1, "b": 2}
  ```