### PR TITLE
move enum value resolve from .name to .toString

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 9.5.0
+
+- Migrate enum value name resolve from `.name` to `.toString()`
+  `.name` is pretty limited to in terms of adjusting the value. Having resolve through `.toString()`
+  gives you high level of flexibility on changing the resulting request value. Another improvement
+  that this fix synchronizes the way of resolving values for individual enum values and for the list
+  of entities. Previously individual values where resolved through `.name` and list of enums via `.toString`
+  deeper inside `dio` client
+
 ## 9.3.0
 
 - Added `@BodyExtra` annotation: Add individual fields to request body without defining complete DTO classes

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -611,7 +611,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
       final value = v.peek('value')?.stringValue ?? k.displayName;
       definePath = definePath?.replaceAll(
         '{$value}',
-        "\${${k.displayName}${k.type.element?.kind == ElementKind.ENUM ? _hasToJson(k.type) ? '.toJson()' : '.name' : ''}}",
+        "\${${k.displayName}${k.type.element?.kind == ElementKind.ENUM ? _hasToJson(k.type) ? '.toJson()' : '' : ''}}",
       );
     });
     return literal(definePath);
@@ -1695,8 +1695,8 @@ if (T != dynamic &&
                   : refer(p.displayName).property('toIso8601String').call([]);
             } else if (_isEnum(p.type) && !_hasToJson(p.type)) {
               value = p.type.nullabilitySuffix == NullabilitySuffix.question
-                  ? refer(p.displayName).nullSafeProperty('name')
-                  : refer(p.displayName).property('name');
+                  ? refer(p.displayName)
+                  : refer(p.displayName);
             } else {
               value = p.type.nullabilitySuffix == NullabilitySuffix.question
                   ? refer(p.displayName).nullSafeProperty('toJson').call([])
@@ -2223,7 +2223,7 @@ if (T != dynamic &&
                       _typeChecker(BuiltList).isExactlyType(innerType)))) {
             String value = '';
             if (innerType != null && _isEnum(innerType)) {
-              value = 'i.name';
+              value = 'i';
             } else if (_isBasicType(innerType)) {
               value = 'i';
               if (innerType != null &&
@@ -2325,9 +2325,10 @@ if (T != dynamic &&
                   refer(p.displayName)
                 else if (_isEnum(p.type))
                   _hasToJson(p.type)
-                      ? refer(p.displayName).property('toJson').call(
-                          []).ifNullThen(refer(p.displayName).property('name'))
-                      : refer(p.displayName).property('name')
+                      ? refer(p.displayName)
+                          .property('toJson')
+                          .call([]).ifNullThen(refer(p.displayName))
+                      : refer(p.displayName)
                 else
                   refer(p.displayName).property('toString').call([]),
               ]),

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - rest
   - retrofit
   - codegen
-version: 9.3.0
+version: 9.5.0
 environment:
   sdk: '>=3.3.0 <4.0.0'
 

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -509,7 +509,7 @@ abstract class TwoContentTypeAnnotationOnSameMethodTest {
 }
 
 @ShouldGenerate(
-  r'/image/${imageType.name}/${id}_XL.png',
+  r'/image/${imageType}/${id}_XL.png',
   contains: true,
 )
 @RestApi()
@@ -522,7 +522,7 @@ abstract class PathTest {
 }
 
 @ShouldGenerate(
-  r'/image/${imageType.name}/${id}/${id}_XL.png',
+  r'/image/${imageType}/${id}/${id}_XL.png',
   contains: true,
 )
 @RestApi()
@@ -718,7 +718,7 @@ enum EnumParam {
 
 @ShouldGenerate(
   '''
-    final queryParameters = <String, dynamic>{r'test': status?.name};
+    final queryParameters = <String, dynamic>{r'test': status};
 ''',
   contains: true,
 )
@@ -1594,15 +1594,13 @@ enum TestEnumWithToJson {
 )
 @ShouldGenerate(
   '''
-_data.fields.add(MapEntry('enumValue', enumValue.name));
+_data.fields.add(MapEntry('enumValue', enumValue));
 ''',
   contains: true,
 )
 @ShouldGenerate(
   '''
-    _data.fields.add(
-      MapEntry('enumValue', enumValue.toJson() ?? enumValue.name),
-    );
+    _data.fields.add(MapEntry('enumValue', enumValue.toJson() ?? enumValue));
 ''',
   contains: true,
 )


### PR DESCRIPTION
Hi @trevorwang 

Seems like it would be a breaking change but better to do than not to.
Non breaking way is probably only through `build.yaml` options but currently i do not see that we are handling any of them



Currently we are using `.name` to resolve the name
This could be problematic cause it does not allow to flexibly to change the value.

refer to this issue https://github.com/trevorwang/retrofit.dart/issues/177

another edge case that we have now is that enum query params are handled differently

```
param: nonListEnum.name
param2: listOfEnumsJustGoesWtihoutAnyConversion // lately dio does .toString somwhere and list of enums are being sent as MyEnum.value
```

