### PR TITLE
Stop using deprecated TypeChecker.fromRuntime

### DIFF
--- a/generator/CHANGELOG.md
+++ b/generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.0.3
+
+- Require source_gen: 3.1.0, stop using deprecated `TypeChecker.fromRuntime` and use the new `TypeChecker.typeNamed` instead.
+
 ## 10.0.2
 
 - Format generated code with default DartFormatter

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -432,7 +432,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     retrofit.Method,
   ];
 
-  TypeChecker _typeChecker(Type type) => TypeChecker.fromRuntime(type);
+  TypeChecker _typeChecker(Type type) => TypeChecker.typeNamed(type);
 
   ConstantReader? _getMethodAnnotation(MethodElement2 method) {
     for (final type in _methodsAnnotations) {
@@ -742,7 +742,7 @@ class RetrofitGenerator extends GeneratorForAnnotation<retrofit.RestApi> {
     final annotation = _getAnnotation(m, retrofit.Body);
     final bodyName = annotation?.element;
     if (bodyName != null) {
-      if (const TypeChecker.fromRuntime(
+      if (const TypeChecker.typeNamed(
         GeneratedMessage,
       ).isAssignableFromType(bodyName.type)) {
         extraOptions[_contentType] = literal(
@@ -1896,7 +1896,7 @@ if (T != dynamic &&
       final nullToAbsent =
           annotation!.reader.peek('nullToAbsent')?.boolValue ?? false;
       final bodyTypeElement = bodyName.type.element3;
-      if (const TypeChecker.fromRuntime(
+      if (const TypeChecker.typeNamed(
         Map,
       ).isAssignableFromType(bodyName.type)) {
         blocks
@@ -2252,7 +2252,7 @@ if (T != dynamic &&
             ]).statement,
           );
           if (p.type.isNullable) {
-            blocks.add(Code('}'));
+            blocks.add(const Code('}'));
           }
         } else if (_displayString(p.type) == 'List<int>') {
           final optionalFile =

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -8,20 +8,20 @@ topics:
   - rest
   - retrofit
   - codegen
-version: 10.0.2
+version: 10.0.3
 environment:
   sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   analyzer: '>=7.7.1 <9.0.0'
-  build: ^3.0.0
+  build: ^3.0.2
   built_collection: ^5.1.1
   code_builder: ^4.10.1
   dart_style: ^3.1.1
   dio: ^5.8.0
   protobuf: ^4.1.1
-  retrofit: ^4.6.0
-  source_gen: ^3.0.0
+  retrofit: ^4.7.2
+  source_gen: '>=3.1.0 <5.0.0'
 
 dev_dependencies:
   lints: any

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -504,32 +504,26 @@ abstract class FilePartWithNullableMultipartListTest {
 @ShouldGenerate('''
     final _data = FormData();
     _data.files.add(MapEntry('image', image));
-''',
-  contains: true,
-)
+''', contains: true)
 @RestApi(baseUrl: 'https://httpbin.org/')
 abstract class SingleMultipartFilePartTest {
   @POST('/profile')
   Future<String> setProfile(@Part() MultipartFile image);
 }
 
-@ShouldGenerate(
-  '''
+@ShouldGenerate('''
     final _data = FormData();
     if (image != null) {
       _data.files.add(MapEntry('image', image));
     }
-''',
-  contains: true,
-)
+''', contains: true)
 @RestApi(baseUrl: 'https://httpbin.org/')
 abstract class SingleNullableMultipartFilePartTest {
   @POST('/profile')
   Future<String> setProfile(@Part() MultipartFile? image);
 }
 
-@ShouldGenerate(
-  '''
+@ShouldGenerate('''
     final _data = FormData();
     _data.files.add(
       MapEntry(


### PR DESCRIPTION
- Require source_gen: 3.1.0, stop using deprecated `TypeChecker.fromRuntime` and use the new `TypeChecker.typeNamed` instead.