### PR TITLE
Fix enum issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ class Task {
 }
 ```
 
+> For enums, we rely on the `toString()` method to convert it to a string. Override the `toString()` method to return the value you want.
+
+```dart
+enum Status {
+  pending,
+  completed;
+
+  @override
+  String toString() => name;
+}
+
+@GET('/tasks/{status}')
+Future<List<Task>> getTasksByStatus(@Path() Status status);
+```
+
 #### Typed extras
 If you want to add static extra to all requests.
 

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2422,8 +2422,12 @@ MultipartFile.fromFileSync(i.path,
                       ? refer(p.displayName)
                             .property('toJson')
                             .call([])
-                            .ifNullThen(refer(p.displayName))
-                      : refer(p.displayName)
+                            .ifNullThen(
+                              refer(
+                                p.displayName,
+                              ).property('toString').call([]),
+                            )
+                      : refer(p.displayName).property('toString').call([])
                 else
                   refer(p.displayName).property('toString').call([]),
               ]),

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1350,10 +1350,12 @@ enum TestEnumWithToJson {
     final _data = FormData.fromMap(map);
 ''', contains: true)
 @ShouldGenerate('''
-_data.fields.add(MapEntry('enumValue', enumValue));
+_data.fields.add(MapEntry('enumValue', enumValue.toString()));
 ''', contains: true)
 @ShouldGenerate('''
-    _data.fields.add(MapEntry('enumValue', enumValue.toJson() ?? enumValue));
+    _data.fields.add(
+      MapEntry('enumValue', enumValue.toJson() ?? enumValue.toString()),
+    );
 ''', contains: true)
 @ShouldGenerate('''
     final _data = FormData();


### PR DESCRIPTION
Solves #777 

After 9.5.0, the enum generation was changed to no longer call '.name', instead it relies on 'toString()'.

However, in '@Part' annotations, the resulting generated code was having a compile time mismatch due to FormData being a map of String to String. So I changed it to call '.toString()' directly to solve this issue.

However, there is still breaking changes for many people's code base because of 9.5.0 without their knowledge, for example #780. If the enums don't override the '.toString()' method, the resulting string in places such as '@Path' annotation with be 'MyEnum.a' rather than 'a'. I don't know whether there is a way to check if an enum class has overridden the toString or not. If there is, we can check that and use the toString or call '.name' like before.

For now, I noted in the documentation that the users should override '.toString()', for there was no explanation anywhere about this change, and I had to find out myself by checking the git history.