### PR TITLE
correct DartMappable code generation for generic return types

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1182,7 +1182,7 @@ $returnAsyncWrapper* $_valueVar;
                 );
               case retrofit.Parser.DartMappable:
                 mapperCode = refer(
-                  '(dynamic i) => ${_displayString(innerReturnType)}Mapper.fromMap(i as $castType)',
+                  '(dynamic i) => ${_dartMappableMapper(innerReturnType)}.fromMap(i as $castType)',
                 );
               case retrofit.Parser.FlutterCompute:
                 throw Exception('Unreachable code');
@@ -1270,7 +1270,7 @@ $returnAsyncWrapper* $_valueVar;
 (k, dynamic v) =>
     MapEntry(
       k, (v as List)
-        .map((i) => ${_displayString(type)}Mapper.fromMap(i as Map<String, dynamic>))
+        .map((i) => ${_dartMappableMapper(type)}.fromMap(i as Map<String, dynamic>))
         .toList()
     )
 ''');
@@ -1345,7 +1345,7 @@ You should create a new class to encapsulate the response.
                 );
               case retrofit.Parser.DartMappable:
                 mapperCode = refer(
-                  '(k, dynamic v) => MapEntry(k, ${_displayString(secondType)}Mapper.fromMap(v as Map<String, dynamic>))',
+                  '(k, dynamic v) => MapEntry(k, ${_dartMappableMapper(secondType)}.fromMap(v as Map<String, dynamic>))',
                 );
               case retrofit.Parser.FlutterCompute:
                 log.warning('''
@@ -1554,7 +1554,7 @@ You should create a new class to encapsulate the response.
               );
             case retrofit.Parser.DartMappable:
               mapperCode = refer(
-                '${_displayString(returnType)}Mapper.fromMap($_resultVar.data!)',
+                '${_dartMappableMapper(returnType)}.fromMap($_resultVar.data!)',
               );
             case retrofit.Parser.FlutterCompute:
               mapperCode = refer(
@@ -3985,6 +3985,16 @@ String _displayString(DartType? e, {bool withNullability = false}) {
       return e!.getDisplayString();
     }
   }
+}
+
+/// Returns the DartMappable mapper class name for a type, correctly placing
+/// "Mapper" between the base class name and its type arguments.
+/// e.g. `ApiResponse<LoginDataModel>` → `ApiResponseMapper<LoginDataModel>`
+String _dartMappableMapper(DartType? type) {
+  final s = _displayString(type);
+  final idx = s.indexOf('<');
+  if (idx == -1) return '${s}Mapper';
+  return '${s.substring(0, idx)}Mapper${s.substring(idx)}';
 }
 
 extension _DartTypeX on DartType {

--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1182,7 +1182,7 @@ $returnAsyncWrapper* $_valueVar;
                 );
               case retrofit.Parser.DartMappable:
                 mapperCode = refer(
-                  '(dynamic i) => ${_dartMappableMapper(innerReturnType)}.fromMap(i as $castType)',
+                  '(dynamic i) => ${_dartMappableMapperClass(innerReturnType)}.fromMap${_dartMappableTypeArgs(innerReturnType)}(i as $castType)',
                 );
               case retrofit.Parser.FlutterCompute:
                 throw Exception('Unreachable code');
@@ -1270,7 +1270,7 @@ $returnAsyncWrapper* $_valueVar;
 (k, dynamic v) =>
     MapEntry(
       k, (v as List)
-        .map((i) => ${_dartMappableMapper(type)}.fromMap(i as Map<String, dynamic>))
+        .map((i) => ${_dartMappableMapperClass(type)}.fromMap${_dartMappableTypeArgs(type)}(i as Map<String, dynamic>))
         .toList()
     )
 ''');
@@ -1345,7 +1345,7 @@ You should create a new class to encapsulate the response.
                 );
               case retrofit.Parser.DartMappable:
                 mapperCode = refer(
-                  '(k, dynamic v) => MapEntry(k, ${_dartMappableMapper(secondType)}.fromMap(v as Map<String, dynamic>))',
+                  '(k, dynamic v) => MapEntry(k, ${_dartMappableMapperClass(secondType)}.fromMap${_dartMappableTypeArgs(secondType)}(v as Map<String, dynamic>))',
                 );
               case retrofit.Parser.FlutterCompute:
                 log.warning('''
@@ -1554,7 +1554,7 @@ You should create a new class to encapsulate the response.
               );
             case retrofit.Parser.DartMappable:
               mapperCode = refer(
-                '${_dartMappableMapper(returnType)}.fromMap($_resultVar.data!)',
+                '${_dartMappableMapperClass(returnType)}.fromMap${_dartMappableTypeArgs(returnType)}($_resultVar.data!)',
               );
             case retrofit.Parser.FlutterCompute:
               mapperCode = refer(
@@ -3987,14 +3987,22 @@ String _displayString(DartType? e, {bool withNullability = false}) {
   }
 }
 
-/// Returns the DartMappable mapper class name for a type, correctly placing
-/// "Mapper" between the base class name and its type arguments.
-/// e.g. `ApiResponse<LoginDataModel>` → `ApiResponseMapper<LoginDataModel>`
-String _dartMappableMapper(DartType? type) {
+/// Returns the base mapper class name (without type arguments).
+/// e.g. `ApiResponse<LoginDataModel>` → `ApiResponseMapper`
+/// e.g. `UserModel` → `UserModelMapper`
+String _dartMappableMapperClass(DartType? type) {
   final s = _displayString(type);
   final idx = s.indexOf('<');
-  if (idx == -1) return '${s}Mapper';
-  return '${s.substring(0, idx)}Mapper${s.substring(idx)}';
+  return idx == -1 ? '${s}Mapper' : '${s.substring(0, idx)}Mapper';
+}
+
+/// Returns the type arguments string for use on a method call, or empty string.
+/// e.g. `ApiResponse<LoginDataModel>` → `<LoginDataModel>`
+/// e.g. `UserModel` → ``
+String _dartMappableTypeArgs(DartType? type) {
+  final s = _displayString(type);
+  final idx = s.indexOf('<');
+  return idx == -1 ? '' : s.substring(idx);
 }
 
 extension _DartTypeX on DartType {


### PR DESCRIPTION
## Fix: DartMappable parser generating invalid code for generic types
                                                                                                                            
### Problem                                                                                                                   

When using Parser.DartMappable with generic return types (e.g. ApiResponse<LoginDataModel>), the generator was producing
syntactically invalid Dart code:

// Generated (WRONG)
``` dart
ApiResponse<LoginDataModel>Mapper.fromMap(...)
```

The Mapper suffix was appended after the full display string including type arguments, which is not valid Dart syntax.

### Solution

Added two helper functions in generator/lib/src/generator.dart:

- _dartMappableMapperClass(type) — extracts the base class name and appends Mapper, e.g. ApiResponse<LoginDataModel> →
ApiResponseMapper
- _dartMappableTypeArgs(type) — extracts the type arguments for use at the call site, e.g. ApiResponse<LoginDataModel> →
<LoginDataModel>

The generated code is now correct:

// Generated (CORRECT)
``` dart
ApiResponseMapper.fromMap<LoginDataModel>(...)
```

Affected cases

### All four code generation paths that use Parser.DartMappable were updated:
- Single object response
- List response
- Map response (value type)
- Map of lists response

## Related Issue
Related to #893 