### PR TITLE
Use toString() for multipart enum values

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2143,19 +2143,19 @@ if (T != dynamic &&
   }
 
   /// Gets the expression for serializing an enum value in FormData as a string.
-  /// Uses toJson() if available, otherwise uses .name.
+  /// Uses toJson() if available, otherwise uses toString().
   String _getEnumValueExpression(DartType enumType, String variableName) {
     return _hasToJson(enumType)
         ? '$variableName.toJson()'
-        : '$variableName.name';
+        : '$variableName.toString()';
   }
 
   /// Gets the Reference for serializing an enum value in FormData.
-  /// Uses toJson() if available, otherwise uses .name.
+  /// Uses toJson() if available, otherwise uses toString().
   Expression _getEnumValueReference(DartType enumType, String variableName) {
     return _hasToJson(enumType)
         ? refer(variableName).property('toJson').call([])
-        : refer(variableName).property('name');
+        : refer(variableName).property('toString').call([]);
   }
 
   /// Generates the query parameters code block.

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1583,14 +1583,14 @@ enum TestEnumWithToJson {
     final _data = FormData.fromMap(map);
 ''', contains: true)
 @ShouldGenerate('''
-_data.fields.add(MapEntry('enumValue', enumValue.name));
+_data.fields.add(MapEntry('enumValue', enumValue.toString()));
 ''', contains: true)
 @ShouldGenerate('''
     _data.fields.add(MapEntry('enumValue', enumValue.toJson()));
 ''', contains: true)
 @ShouldGenerate('''
     enumValues.forEach((i) {
-      _data.fields.add(MapEntry('enumValues', i.name));
+      _data.fields.add(MapEntry('enumValues', i.toString()));
     });
 ''', contains: true)
 @ShouldGenerate('''


### PR DESCRIPTION
## Problem
- multipart `@Part()` enum values were serialized with `.name`
- the README says enum string serialization relies on `toString()`
- that makes multipart behavior inconsistent with the documented contract and prevents custom wire values implemented via `toString()`

## Solution
- keep `toJson()` as the first choice when it is available
- otherwise serialize multipart enum values with `toString()` instead of `.name`
- update generator expectations for both single enum parts and enum lists

## Testing
- `dart test -r compact` in `retrofit`
- `dart test -r compact` in `generator`
- `dart run build_runner build --delete-conflicting-outputs` then `dart test -r compact` in `example`
- `dart run build_runner build --delete-conflicting-outputs` then `dart test -r compact` in `example_relative_base_url`

Closes #867