### PR TITLE
Fix: add warning for missing dart:convert import when using ResponseType.stream

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1051,6 +1051,11 @@ $returnAsyncWrapper httpResponse;
 
       if (_isStreamOfString(m.returnType)) {
         // For Stream<String>, decode the bytes to strings using utf8.decode
+        // Note: Requires 'import dart:convert;' in the main API file (not in .g file as it's a part)
+        log.warning(
+          '\u001b[33mMethod ${m.displayName} returns Stream<String> and uses utf8.decode. '
+          'Ensure your API class file imports dart:convert: import \'dart:convert\';\u001b[0m',
+        );
         blocks.add(
           Code('''
 final $_valueVar = $_resultVar.data!.stream.map(utf8.decode);

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -3214,7 +3214,10 @@ abstract class TestBareTypeParameterNullable {
     yield* _value;
 ''',
   contains: true,
-  expectedLogItems: ['ResponseType  :  1'],
+  expectedLogItems: [
+    'ResponseType  :  1',
+    '\x1B[33mMethod getServerEvents returns Stream<String> and uses utf8.decode. Ensure your API class file imports dart:convert: import \'dart:convert\';\x1B[0m',
+  ],
 )
 @RestApi()
 abstract class TestResponseTypeStreamString {


### PR DESCRIPTION
Closes #904 
When using @DioResponseType(ResponseType.stream), the generated code may include utf8.decode without importing dart:convert. This leads to a compile-time error:

Undefined name 'utf8'

The error is not self-explanatory and can make it difficult for developers to identify the root cause.

Changes
Added a warning message during code generation when ResponseType.stream is used.
The warning informs users that dart:convert may need to be imported manually.
Why
Improves developer experience by making the issue easier to understand.
Helps developers quickly resolve the error without unnecessary debugging.
Notes
No breaking changes.
This PR does not modify generated imports; it only provides guidance via a warning.
A potential future improvement could be automatically adding the required import in generated files.

### Screenshot

Below is the warning displayed during code generation:
<img width="1039" height="159" alt="Screenshot 2026-04-04 at 2 07 51 AM" src="https://github.com/user-attachments/assets/3d392cdb-ad34-452c-ba56-b4aabc87af77" />
