### PR TITLE
fix(generator): null-safe contentType in newRequestOptions (Closes #917)

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1946,7 +1946,7 @@ if (options is Options) {
     extra: options.extra,
     headers: options.headers,
     responseType: options.responseType,
-    contentType: options.contentType.toString(),
+    contentType: options.contentType?.toString(),
     validateStatus: options.validateStatus,
     receiveDataWhenStatusError: options.receiveDataWhenStatusError,
     followRedirects: options.followRedirects,

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1694,7 +1694,7 @@ abstract class TestModelList {
         extra: options.extra,
         headers: options.headers,
         responseType: options.responseType,
-        contentType: options.contentType.toString(),
+        contentType: options.contentType?.toString(),
         validateStatus: options.validateStatus,
         receiveDataWhenStatusError: options.receiveDataWhenStatusError,
         followRedirects: options.followRedirects,


### PR DESCRIPTION
The generated `newRequestOptions` helper copies an `Options` into a fresh `RequestOptions` with:

```dart
contentType: options.contentType.toString(),
```

When `options.contentType` is `null`, `null.toString()` returns the string `"null"`, so the request goes out with a literal `Content-Type: null` header instead of no content type. This is the `newRequestOptions` path used when an interceptor/caller passes a bare `Options`, so it silently corrupts the content type for any request that didn't set one.

### Fix

Make the copy null-safe:

```dart
contentType: options.contentType?.toString(),
```

Now a `null` content type stays `null` (Dio then applies its own default), and a set content type is unchanged.

### Test

Updated the `CustomOptions` golden in `generator/test/src/generator_test_src.dart` to expect the null-safe generated output. `dart test` passes in full (202 tests); `dart analyze` is clean.

Closes #917.
