### PR TITLE
fix(generator): guard PartMap helper variables for nullable file parts (Closes #889)

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2824,6 +2824,22 @@ if (T != dynamic &&
             final fileNameVar = '_${fieldName}_fileName';
             final contentTypeVar = '_${fieldName}_contentType';
 
+            final optionalFile =
+                m.formalParameters
+                    .firstWhereOrNull((pp) => pp.displayName == p.displayName)
+                    ?.isOptional ??
+                false;
+
+            // The helper variables below read the part parameter, so for a
+            // nullable part they must be declared inside the null check.
+            final needsNullCheck = p.type.isNullable || optionalFile;
+            if (needsNullCheck) {
+              final condition = refer(
+                p.displayName,
+              ).notEqualTo(literalNull).code;
+              blocks.addAll([const Code('if('), condition, const Code(') {')]);
+            }
+
             // Generate code to extract runtime fileName
             if (fileNameValue != null) {
               blocks.add(
@@ -2863,35 +2879,16 @@ if (T != dynamic &&
               },
             );
 
-            final optionalFile =
-                m.formalParameters
-                    .firstWhereOrNull((pp) => pp.displayName == p.displayName)
-                    ?.isOptional ??
-                false;
+            blocks.add(
+              refer(dataVar).property('files').property('add').call([
+                refer(
+                  'MapEntry',
+                ).newInstance([literal(fieldName), uploadFileInfo]),
+              ]).statement,
+            );
 
-            final returnCode = refer(dataVar)
-                .property('files')
-                .property('add')
-                .call([
-                  refer(
-                    'MapEntry',
-                  ).newInstance([literal(fieldName), uploadFileInfo]),
-                ])
-                .statement;
-
-            if (p.type.isNullable || optionalFile) {
-              final condition = refer(
-                p.displayName,
-              ).notEqualTo(literalNull).code;
-              blocks.addAll([
-                const Code('if('),
-                condition,
-                const Code(') {'),
-                returnCode,
-                const Code('}'),
-              ]);
-            } else {
-              blocks.add(returnCode);
+            if (needsNullCheck) {
+              blocks.add(const Code('}'));
             }
           } else {
             // No PartMap - use original static approach

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -3018,6 +3018,68 @@ abstract class PartMapWithFileAndStaticDefaultsTest {
 }
 
 @ShouldGenerate('''
+    if (file != null) {
+      final _file_fileName =
+          (partMetadata?['file_fileName'] as String?) ??
+          file.path.split(Platform.pathSeparator).last;
+      final DioMediaType? _file_contentType =
+          (partMetadata?['file_contentType'] as String?) != null
+          ? DioMediaType.parse(partMetadata!['file_contentType'] as String)
+          : null;
+      _data.files.add(
+        MapEntry(
+          'file',
+          MultipartFile.fromFileSync(
+            file.path,
+            filename: _file_fileName,
+            contentType: _file_contentType,
+          ),
+        ),
+      );
+    }
+''', contains: true)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class PartMapWithNullableFileTest {
+  @POST('/upload')
+  @MultiPart()
+  Future<String> uploadFile({
+    @Part(name: 'file') File? file,
+    @PartMap() Map<String, dynamic>? partMetadata,
+  });
+}
+
+@ShouldGenerate('''
+    if (file != null) {
+      final _file_fileName =
+          (partMeta?['file_fileName'] as String?) ?? 'default.txt';
+      final _file_contentType =
+          (partMeta?['file_contentType'] as String?) != null
+          ? DioMediaType.parse(partMeta!['file_contentType'] as String)
+          : DioMediaType.parse('text/plain');
+      _data.files.add(
+        MapEntry(
+          'file',
+          MultipartFile.fromFileSync(
+            file.path,
+            filename: _file_fileName,
+            contentType: _file_contentType,
+          ),
+        ),
+      );
+    }
+''', contains: true)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class PartMapWithNullableFileAndStaticDefaultsTest {
+  @POST('/upload')
+  @MultiPart()
+  Future<String> uploadFile({
+    @Part(name: 'file', fileName: 'default.txt', contentType: 'text/plain')
+    File? file,
+    @PartMap() Map<String, dynamic>? partMeta,
+  });
+}
+
+@ShouldGenerate('''
     final _data_fileName = meta?['data_fileName'] as String?;
     final DioMediaType? _data_contentType =
         (meta?['data_contentType'] as String?) != null


### PR DESCRIPTION
# PR title

fix: guard PartMap helper variables for nullable file parts

# PR body

Closes #889

## What breaks

With a nullable `@Part() File?` parameter and a `@PartMap()` in the same method, the generator emits code that does not compile:

```dart
final _compressedFilePath_fileName =
    (partMetadata?['compressedFilePath_fileName'] as String?) ??
    compressedFilePath.path.split(Platform.pathSeparator).last;
```

`compressedFilePath` is `File?`, and the helper variable dereferences `.path` before the `if (compressedFilePath != null)` check, so the generated file fails analysis with `unchecked_use_of_nullable_value`.

## Root cause

In the `isFileField` branch with a PartMap present, the `_x_fileName` / `_x_contentType` helper variables are added to the block list before the null check is emitted. Only the `_data.files.add(...)` call was wrapped in the guard.

## Fix

Emit the null check before the helper variable declarations, so for nullable (or optional) file parts the helpers and the `add` call both live inside `if (x != null) { ... }`. The parameter is promoted to non-null inside the guard, so `x.path` is valid. Non-nullable required parts generate the same code as before.

## Tests

Two golden tests added in `generator_test_src.dart`:

- `PartMapWithNullableFileTest`: nullable `File?` part with a PartMap, expects the helpers inside the guard.
- `PartMapWithNullableFileAndStaticDefaultsTest`: same, with static `fileName`/`contentType` defaults on the annotation.

Both fail on master and pass with this change. The full generator suite (204 tests) passes, and `dart analyze` / `dart format` are clean.
