### PR TITLE
fix: keep the request future in the stream pipeline for ResponseType.stream

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1045,7 +1045,7 @@ $returnAsyncWrapper httpResponse;
       // we extract the stream from it
       blocks.add(
         declareFinal(_resultVar)
-            .assign(refer('await $_dioVar.fetch<ResponseBody>').call([options]))
+            .assign(refer('$_dioVar.fetch<ResponseBody>').call([options]))
             .statement,
       );
 
@@ -1058,7 +1058,9 @@ $returnAsyncWrapper httpResponse;
         );
         blocks.add(
           Code('''
-final $_valueVar = $_resultVar.data!.stream.map(utf8.decode);
+final $_valueVar = $_resultVar.asStream().asyncExpand(
+  (response) => response.data!.stream.map(utf8.decode),
+);
 $returnAsyncWrapper* $_valueVar;
 '''),
         );
@@ -1066,7 +1068,9 @@ $returnAsyncWrapper* $_valueVar;
         // For Stream<Uint8List>, return the raw stream
         blocks.add(
           Code('''
-final $_valueVar = $_resultVar.data!.stream;
+final $_valueVar = $_resultVar.asStream().asyncExpand(
+  (response) => response.data!.stream,
+);
 $returnAsyncWrapper* $_valueVar;
 '''),
         );

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1112,8 +1112,10 @@ abstract class TestQueryParamExtensionTypeWithToJsonNullable {
           )
           .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
     );
-    final _result = await _dio.fetch<ResponseBody>(_options);
-    final _value = _result.data!.stream;
+    final _result = _dio.fetch<ResponseBody>(_options);
+    final _value = _result.asStream().asyncExpand(
+      (response) => response.data!.stream,
+    );
     yield* _value;
   }
 ''',
@@ -3234,8 +3236,10 @@ abstract class TestBareTypeParameterNullable {
 
 @ShouldGenerate(
   '''
-    final _result = await _dio.fetch<ResponseBody>(_options);
-    final _value = _result.data!.stream.map(utf8.decode);
+    final _result = _dio.fetch<ResponseBody>(_options);
+    final _value = _result.asStream().asyncExpand(
+      (response) => response.data!.stream.map(utf8.decode),
+    );
     yield* _value;
 ''',
   contains: true,


### PR DESCRIPTION
Closes #907.

### The problem

Generated methods for `@DioResponseType(ResponseType.stream)` awaited the
request future inside an `async*` body:

```dart
final _result = await _dio.fetch<ResponseBody>(_options);
final _value = _result.data!.stream;
yield* _value;
```

If the stream subscription is cancelled while execution is suspended at that
`await`, a later error from the pending future is no longer delivered through
the stream listener lifecycle and can surface as an unhandled zone error. In
practice that shows up as noisy false positives in global error collectors, even
when the consumer is handling stream errors correctly.

### The fix

Emit the fetch without `await` and expand it through the stream pipeline, so the
future stays inside the stream:

```dart
final _result = _dio.fetch<ResponseBody>(_options);
final _value = _result.asStream().asyncExpand(
  (response) => response.data!.stream,
);
yield* _value;
```

`Stream<String>` gets the same shape with `.map(utf8.decode)` inside the expand.
This is the change proposed in the issue.

### Tests

Updated the two `ResponseType.stream` codegen expectations, for
`Stream<Uint8List>` and for `Stream<String>`, to the new generated output.
Generator suite green (202 tests), `dart analyze` clean, formatted.
