### PR TITLE
feat(http): add QUERY HTTP method support (RFC 10008)

### DIFF
--- a/retrofit/lib/http.dart
+++ b/retrofit/lib/http.dart
@@ -10,6 +10,7 @@ class HttpMethod {
   static const String DELETE = 'DELETE';
   static const String HEAD = 'HEAD';
   static const String OPTIONS = 'OPTIONS';
+  static const String QUERY = 'QUERY';
 }
 
 /// Define how to parse response json
@@ -192,6 +193,12 @@ class HEAD extends Method {
 @immutable
 class OPTIONS extends Method {
   const OPTIONS(String path) : super(HttpMethod.OPTIONS, path);
+}
+
+/// Make a `QUERY` request (RFC 10008)
+@immutable
+class QUERY extends Method {
+  const QUERY(String path) : super(HttpMethod.QUERY, path);
 }
 
 /// Adds headers specified in the [value] map.


### PR DESCRIPTION
Adds support for the QUERY HTTP method as defined in RFC 10008.

This adds a new `QUERY` constant to `HttpMethod` class and a new `QUERY` class that extends `Method` to allow making QUERY requests.

The QUERY method is safe, idempotent, and cacheable - it's designed for requesting data with a request body, which is useful for complex queries that exceed URL length limits.

Fixes #922