### PR TITLE
feat(http): add QUERY HTTP method support (RFC 10008)

### DIFF
--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -1471,6 +1471,24 @@ abstract class TestOptionsMethod {
 }
 
 @ShouldGenerate('''
+      Options(method: 'QUERY', headers: _headers, extra: _extra)
+''', contains: true)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestQueryMethod {
+  @QUERY('/')
+  Future<String> testQueryMethod();
+}
+
+@ShouldGenerate('''
+      Options(method: 'QUERY', headers: _headers, extra: _extra)
+''', contains: true)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestQueryMethodWithBody {
+  @QUERY('/search')
+  Future<String> testQueryMethodWithBody(@Body() Map<String, dynamic> query);
+}
+
+@ShouldGenerate('''
     final httpResponse = HttpResponse(null, _result);
 ''', contains: true)
 @RestApi()

--- a/retrofit/lib/http.dart
+++ b/retrofit/lib/http.dart
@@ -10,6 +10,7 @@ class HttpMethod {
   static const String DELETE = 'DELETE';
   static const String HEAD = 'HEAD';
   static const String OPTIONS = 'OPTIONS';
+  static const String QUERY = 'QUERY';
 }
 
 /// Define how to parse response json
@@ -192,6 +193,12 @@ class HEAD extends Method {
 @immutable
 class OPTIONS extends Method {
   const OPTIONS(String path) : super(HttpMethod.OPTIONS, path);
+}
+
+/// Make a `QUERY` request (RFC 10008)
+@immutable
+class QUERY extends Method {
+  const QUERY(String path) : super(HttpMethod.QUERY, path);
 }
 
 /// Adds headers specified in the [value] map.

--- a/retrofit/test/http_test.dart
+++ b/retrofit/test/http_test.dart
@@ -11,6 +11,7 @@ void main() {
       expect(HttpMethod.DELETE, 'DELETE');
       expect(HttpMethod.HEAD, 'HEAD');
       expect(HttpMethod.OPTIONS, 'OPTIONS');
+      expect(HttpMethod.QUERY, 'QUERY');
     });
   });
 
@@ -43,7 +44,7 @@ void main() {
   });
 
   group('Method annotations', () {
-    test('GET/POST/PATCH/PUT/DELETE/HEAD/OPTIONS', () {
+    test('GET/POST/PATCH/PUT/DELETE/HEAD/OPTIONS/QUERY', () {
       expect(const GET('/foo').method, 'GET');
       expect(const POST('/foo').method, 'POST');
       expect(const PATCH('/foo').method, 'PATCH');
@@ -51,6 +52,7 @@ void main() {
       expect(const DELETE('/foo').method, 'DELETE');
       expect(const HEAD('/foo').method, 'HEAD');
       expect(const OPTIONS('/foo').method, 'OPTIONS');
+      expect(const QUERY('/foo').method, 'QUERY');
     });
     test('Method path', () {
       expect(const GET('/bar').path, '/bar');


### PR DESCRIPTION
Adds support for the QUERY HTTP method as defined in RFC 10008.

This adds a new `QUERY` constant to `HttpMethod` class and a new `QUERY` class that extends `Method` to allow making QUERY requests.

The QUERY method is safe, idempotent, and cacheable - it's designed for requesting data with a request body, which is useful for complex queries that exceed URL length limits.

Includes tests for the generator and HTTP method.

Fixes #922