### PR TITLE
fix(generator): detect generated toJson on Freezed models (#914)

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2144,13 +2144,39 @@ if (T != dynamic &&
     if (dartType is! InterfaceType) {
       return false;
     }
-    // Use lookUpMethod to check the class hierarchy including mixins
-    // This is important for Freezed-generated classes where toJson is in a mixin
-    return dartType.element.lookUpMethod(
-          name: 'toJson',
-          library: dartType.element.library,
-        ) !=
-        null;
+    return _declaresToJson(dartType.element);
+  }
+
+  /// True when [element] has `toJson`, including mixin / abstract / generated
+  /// methods. A source `fromJson` factory is enough: json_serializable and
+  /// Freezed generate `toJson` in parts that build_runner may hide from us.
+  bool _declaresToJson(InterfaceElement element) {
+    if (element.lookUpMethod(name: 'toJson', library: element.library) !=
+        null) {
+      return true;
+    }
+    if (element.getMethod('toJson') != null) {
+      return true;
+    }
+    if (element is ClassElement) {
+      if (element.getNamedConstructor('fromJson') != null) {
+        return true;
+      }
+      for (final constructor in element.constructors) {
+        final redirected =
+            constructor.redirectedConstructor?.returnType.element;
+        if (redirected is InterfaceElement &&
+            (redirected.getMethod('toJson') != null ||
+                redirected.lookUpMethod(
+                      name: 'toJson',
+                      library: redirected.library,
+                    ) !=
+                    null)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /// Gets the expression for serializing an enum value in FormData as a string.
@@ -3802,10 +3828,7 @@ MultipartFile.fromFileSync(i.path,
     switch (clientAnnotation.parser) {
       case retrofit.Parser.JsonSerializable:
       case retrofit.Parser.DartJsonMapper:
-        // Use lookUpMethod to check the class hierarchy including mixins
-        // This is important for Freezed-generated classes where toJson is in a mixin
-        final toJson = ele.lookUpMethod(name: 'toJson', library: ele.library);
-        return toJson == null;
+        return !_declaresToJson(ele);
       case retrofit.Parser.MapSerializable:
       case retrofit.Parser.DartMappable:
       case retrofit.Parser.FlutterCompute:

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -3340,3 +3340,39 @@ abstract class TestResponseTypeStreamInvalidReturnTypeStreamInt {
   @DioResponseType(ResponseType.stream)
   Stream<int> downloadFile();
 }
+
+// Freezed + json_serializable declare fromJson in source. toJson lives in the
+// generated mixin / private impl, which retrofit_generator may not see yet.
+class FreezedJsonModel {
+  const FreezedJsonModel();
+
+  // ignore: avoid_unused_constructor_parameters
+  factory FreezedJsonModel.fromJson(Map<String, dynamic> json) =>
+      const FreezedJsonModel();
+}
+
+@ShouldGenerate('''
+    final _data = <String, dynamic>{};
+    _data.addAll(model.toJson());
+''', contains: true)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestFreezedJsonModelBody {
+  @POST('/models')
+  Future<void> create(@Body() FreezedJsonModel model);
+}
+
+abstract class AbstractToJsonModel {
+  const AbstractToJsonModel();
+
+  Map<String, dynamic> toJson();
+}
+
+@ShouldGenerate('''
+    final _data = <String, dynamic>{};
+    _data.addAll(model.toJson());
+''', contains: true)
+@RestApi(baseUrl: 'https://httpbin.org/')
+abstract class TestAbstractToJsonModelBody {
+  @POST('/models')
+  Future<void> create(@Body() AbstractToJsonModel model);
+}


### PR DESCRIPTION
`lookUpMethod` still misses `toJson` on Freezed / json_serializable models when the generated part is not visible to retrofit_generator yet. That is the same warning from #914, and the generated client then does `final _data = body` instead of `body.toJson()`.

I treat a source `fromJson` factory as evidence that `toJson` exists, and still count mixin / abstract / redirected methods when they are visible.

### Test
- `TestFreezedJsonModelBody`: class with `fromJson` and no `toJson` in the same file (the hidden-part case)
- `TestAbstractToJsonModelBody`: abstract `toJson` on the public class

`dart analyze` is clean. `dart test` in `generator/` is 206 passing.

Fixes #914
