### PR TITLE
fix(generator): serialize FlutterCompute @Body via toJson

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -2587,18 +2587,54 @@ if (T != dynamic &&
               ).assign(refer(bodyName.displayName)).statement,
             );
           } else if (_missingSerialize(
-            ele.enclosingElement.firstFragment,
-            bodyName.type,
-          )) {
-            log.warning(
-              '${_displayString(bodyName.type)} must provide a `serialize${_displayString(bodyName.type)}()` method which returns a Map.\n'
-              "It is programmer's responsibility to make sure the ${_displayString(bodyName.type)} is properly serialized",
-            );
-            blocks.add(
-              declareFinal(
-                dataVar,
-              ).assign(refer(bodyName.displayName)).statement,
-            );
+                ele.enclosingElement.firstFragment,
+                bodyName.type,
+              ) &&
+              _missingSerialize(m.library.firstFragment, bodyName.type)) {
+            if (_declaresToJson(ele)) {
+              final nullable =
+                  bodyName.type.nullabilitySuffix ==
+                  NullabilitySuffix.question;
+              final toJsonExpr = nullable
+                  ? '${bodyName.displayName}?.toJson() ?? <String, dynamic>{}'
+                  : '${bodyName.displayName}.toJson()';
+              if (bodyExtras.isEmpty && expandBodyExtras.isEmpty) {
+                blocks.add(
+                  declareFinal(dataVar).assign(refer(toJsonExpr)).statement,
+                );
+              } else {
+                blocks.add(
+                  declareFinal(dataVar)
+                      .assign(
+                        literalMap(
+                          bodyExtras,
+                          refer('String'),
+                          refer('dynamic'),
+                        ),
+                      )
+                      .statement,
+                );
+                for (final item in expandBodyExtras.entries) {
+                  _generateParameterElement(item.key, blocks, dataVar);
+                }
+                blocks.add(
+                  refer('$dataVar.addAll').call([refer(toJsonExpr)]).statement,
+                );
+              }
+              if (preventNullToAbsent == null && nullToAbsent) {
+                blocks.add(Code('$dataVar.removeWhere((k, v) => v == null);'));
+              }
+            } else {
+              log.warning(
+                '${_displayString(bodyName.type)} must provide a `serialize${_displayString(bodyName.type)}()` method which returns a Map.\n'
+                "It is programmer's responsibility to make sure the ${_displayString(bodyName.type)} is properly serialized",
+              );
+              blocks.add(
+                declareFinal(
+                  dataVar,
+                ).assign(refer(bodyName.displayName)).statement,
+              );
+            }
           } else {
             blocks.add(
               declareFinal(dataVar)

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -2283,6 +2283,21 @@ abstract class TestComputeObjectBody {
   Future<void> getResult(@Body() User user);
 }
 
+class SmsCodeRequest {
+  const SmsCodeRequest();
+
+  Map<String, dynamic> toJson() => <String, dynamic>{};
+}
+
+@ShouldGenerate('''
+    final _data = smsCodeRequest.toJson();
+''', contains: true)
+@RestApi(baseUrl: 'https://httpbin.org/', parser: Parser.FlutterCompute)
+abstract class TestComputeObjectBodyWithoutSerializeFn {
+  @POST('/user/sendCode')
+  Future<void> sendSmsCode(@Body() SmsCodeRequest smsCodeRequest);
+}
+
 @ShouldGenerate('''
     final _data = await compute(serializeUserList, users);
 ''', contains: true)


### PR DESCRIPTION
`Parser.FlutterCompute` only called `compute(serializeX, body)` when it could see `serializeX` next to the model (or now the API library). Otherwise it emitted `final _data = body` and a warning.

I have `toJson` on the request class in that case, same as the `serializeX` helpers people already write. Existing `User` + `serializeUser` output is unchanged.

Fixes #923
