### PR TITLE
fix(generator): use utf8.decoder.bind for Stream<String> to prevent FormatException

### DIFF
--- a/generator/lib/src/generator.dart
+++ b/generator/lib/src/generator.dart
@@ -1050,16 +1050,16 @@ $returnAsyncWrapper httpResponse;
       );
 
       if (_isStreamOfString(m.returnType)) {
-        // For Stream<String>, decode the bytes to strings using utf8.decode
+        // For Stream<String>, decode the bytes to strings using utf8.decoder.bind
         // Note: Requires 'import dart:convert;' in the main API file (not in .g file as it's a part)
         log.warning(
-          '\u001b[33mMethod ${m.displayName} returns Stream<String> and uses utf8.decode. '
+          '\u001b[33mMethod ${m.displayName} returns Stream<String> and uses utf8.decoder.bind. '
           'Ensure your API class file imports dart:convert: import \'dart:convert\';\u001b[0m',
         );
         blocks.add(
           Code('''
 final $_valueVar = $_resultVar.asStream().asyncExpand(
-  (response) => response.data!.stream.map(utf8.decode),
+  (response) => utf8.decoder.bind(response.data!.stream),
 );
 $returnAsyncWrapper* $_valueVar;
 '''),

--- a/generator/test/src/generator_test_src.dart
+++ b/generator/test/src/generator_test_src.dart
@@ -3318,14 +3318,14 @@ abstract class TestBareTypeParameterNullable {
   '''
     final _result = _dio.fetch<ResponseBody>(_options);
     final _value = _result.asStream().asyncExpand(
-      (response) => response.data!.stream.map(utf8.decode),
+      (response) => utf8.decoder.bind(response.data!.stream),
     );
     yield* _value;
 ''',
   contains: true,
   expectedLogItems: [
     'ResponseType  :  1',
-    '\x1B[33mMethod getServerEvents returns Stream<String> and uses utf8.decode. Ensure your API class file imports dart:convert: import \'dart:convert\';\x1B[0m',
+    '\x1B[33mMethod getServerEvents returns Stream<String> and uses utf8.decoder.bind. Ensure your API class file imports dart:convert: import \'dart:convert\';\x1B[0m',
   ],
 )
 @RestApi()


### PR DESCRIPTION
### Description

This PR fixes a bug where `Stream<String>` response types throw a `FormatException: Unfinished UTF-8 octet sequence` when decoding raw multi-byte text streams (e.g., streaming chunks containing emojis, Mandarin characters, or special math symbols).

### The Problem

Currently, the generator generates code that decodes stream chunks independently using `.map((chunk) => utf8.decode(chunk))`. 

In real-world networking (like HTTP chunked transfers or Server-Sent Events), data packets are split based on network buffer limits rather than character boundaries. If a 3-byte or 4-byte UTF-8 character happens to be cut across two network chunks:
1. `.map()` attempts to decode the first chunk independently.
2. The decoding fails because it encounters a truncated, incomplete byte sequence.
3. It throws an unrecoverable `FormatException`.

### The Solution

This change replaces `.map(utf8.decode)` with `utf8.decoder.bind(stream)`. 

The `StreamTransformer` approach acts as a proper state machine. If a multi-byte character is split at the end of a chunk, the transformer safely retains those trailing bytes in memory and joins them with the next incoming network chunk before emitting the decoded text string.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
